### PR TITLE
Feature/code improvements

### DIFF
--- a/web/domains/case/access/views.py
+++ b/web/domains/case/access/views.py
@@ -132,7 +132,18 @@ class AccessRequestFirView(PostActionMixin):
         Params:
             process_id - Access Request id
         """
-        self.set_fir_status(request.POST['id'], FurtherInformationRequest.CLOSED)
+        self.set_fir_status(request.POST['id'], FurtherInformationRequest.DRAFT)
+        return redirect('access_request_fir_list', process_id=process_id)
+
+    def send(self, request, process_id):
+        """
+        Marks the FIR as open
+        @todo: send the actual email
+
+        Params:
+            process_id - Access Request id
+        """
+        self.set_fir_status(request.POST['id'], FurtherInformationRequest.OPEN)
         return redirect('access_request_fir_list', process_id=process_id)
 
     def delete(self, request, process_id):
@@ -233,7 +244,7 @@ class AccessRequestFirView(PostActionMixin):
             form - the form the user has submitted (or None, if present the form is returned instead of creating a new one)
         """
         process = AccessRequestProcess.objects.get(pk=process_id)
-        items = process.access_request.further_information_requests.all().order_by('pk').reverse()
+        items = process.access_request.further_information_requests.exclude(status=FurtherInformationRequest.DELETED).order_by('pk').reverse()
 
         return {
             'fir_list': [self.create_display_or_edit_form(fir, selected_fir, form) for fir in items],

--- a/web/domains/case/access/views.py
+++ b/web/domains/case/access/views.py
@@ -72,7 +72,9 @@ class ILBReviewRequest(SimpleFlowMixin, FormView):
 
 class AccessRequestFirView(PostActionMixin):
     """
-    Access Request Further Information Request - list
+    Access Request Further Information Request
+
+    This view class handles all actions that can be performed on a FIR
     """
     template_name = 'web/access-request/access-request-fir-list.html'
     FIR_TEMPLATE_CODE = 'IAR_RFI_EMAIL'

--- a/web/domains/case/access/views.py
+++ b/web/domains/case/access/views.py
@@ -70,17 +70,33 @@ class ILBReviewRequest(SimpleFlowMixin, FormView):
         )
 
 
-class AccessRequestFirListView(TemplateView, PostActionMixin):
+class AccessRequestFirView(PostActionMixin):
     """
     Access Request Further Information Request - list
     """
     template_name = 'web/access-request/access-request-fir-list.html'
     FIR_TEMPLATE_CODE = 'IAR_RFI_EMAIL'
 
+    def get(self, request, process_id):
+        """
+        Lists all FIRs associated to the acces request
+
+        Params:
+            process_id - Access Request id
+        """
+        return render(
+            request,
+            self.template_name,
+            self.get_context_data(process_id)
+        )
+
     def edit(self, request, process_id, *args, **kwargs):
         """
         Edits the FIR selected by the user.
         The selected FIR comes from the id property in the request body
+
+        Params:
+            process_id - Access Request id
         """
 
         data = request.POST if request.POST else None
@@ -110,6 +126,9 @@ class AccessRequestFirListView(TemplateView, PostActionMixin):
     def withdraw(self, request, process_id):
         """
         Marks the FIR as withdrawn
+
+        Params:
+            process_id - Access Request id
         """
         self.set_fir_status(request.POST['id'], FurtherInformationRequest.CLOSED)
         return redirect('access_request_fir_list', process_id=process_id)
@@ -117,7 +136,9 @@ class AccessRequestFirListView(TemplateView, PostActionMixin):
     def delete(self, request, process_id):
         """
         Marks the FIR as deleted and sets it as inactive
-        @todo: check with PO if we display inactive FIRs
+
+        Params:
+            process_id - Access Request id
         """
         model = self.set_fir_status(request.POST['id'], FurtherInformationRequest.DELETED)
         model.is_active = False
@@ -128,6 +149,9 @@ class AccessRequestFirListView(TemplateView, PostActionMixin):
     def save(self, request, process_id, *args, **kwargs):
         """
         Saves the FIR being editted by the user
+
+        Params:
+            process_id - Access Request id
         """
         model = FurtherInformationRequest.objects.get(pk=request.POST['id'])
         form = FurtherInformationRequestForm(data=request.POST, instance=model)
@@ -146,6 +170,9 @@ class AccessRequestFirListView(TemplateView, PostActionMixin):
         """
         Creates a new FIR and associates it with the current access request then display the FIR form
         so the user can edit data
+
+        Params:
+            process_id - Access Request id
         """
         access_request = AccessRequest.objects.get(pk=process_id)
         try:
@@ -179,9 +206,9 @@ class AccessRequestFirListView(TemplateView, PostActionMixin):
         If `fir.id` is is the same as `selected_fir` then a "editable" version of the form is returned
 
         Params:
-        fir - FurtherInformationRequest model
-        selected_fir - id of the FIR the user is editing (or None)
-        form - the form the user has submitted (or None, if present the form is returned instead of creating a new one)
+            fir - FurtherInformationRequest model
+            selected_fir - id of the FIR the user is editing (or None)
+            form - the form the user has submitted (or None, if present the form is returned instead of creating a new one)
         """
         if selected_fir and fir.id == selected_fir:
             return form if form else FurtherInformationRequestForm(instance=fir)
@@ -195,14 +222,20 @@ class AccessRequestFirListView(TemplateView, PostActionMixin):
         )
 
     def get_context_data(self, process_id, selected_fir=None, form=None, *args, **kwargs):
+        """
+        Helper function to generate context data to be sent to views
+
+        Params:
+            process_id - Access Request id
+            selected_fir - id of the FIR the user is editing (or None)
+            form - the form the user has submitted (or None, if present the form is returned instead of creating a new one)
+        """
         process = AccessRequestProcess.objects.get(pk=process_id)
-        context = super().get_context_data(*args, **kwargs)
-
         items = process.access_request.further_information_requests.all().order_by('pk').reverse()
-        logger.debug('getting context data')
-        context['fir_list'] = [self.create_display_or_edit_form(fir, selected_fir, form) for fir in items]
-        context['activation'] = {
-            'process': process,
-        }
 
-        return context
+        return {
+            'fir_list': [self.create_display_or_edit_form(fir, selected_fir, form) for fir in items],
+            'activation': {  # keeping the same format as viewflow, so sidebar works seamlessly
+                'process': process,
+            }
+        }

--- a/web/domains/case/access/views.py
+++ b/web/domains/case/access/views.py
@@ -81,7 +81,7 @@ class AccessRequestFirView(PostActionMixin):
 
     def get(self, request, process_id):
         """
-        Lists all FIRs associated to the acces request
+        Lists all FIRs associated to the access request
 
         Params:
             process_id - Access Request id

--- a/web/domains/case/forms.py
+++ b/web/domains/case/forms.py
@@ -53,7 +53,7 @@ class FurtherInformationRequestForm(ModelEditForm):
                 'css': '',
                 'action': 'Delete',
                 'label': 'Delete',
-                'confirm_message': 'You sure?',
+                'confirm_message': 'Are you sure you want to delete this Further Information Request?',
             },
             'edit': {
                 'css': 'icon-pencil',
@@ -64,7 +64,7 @@ class FurtherInformationRequestForm(ModelEditForm):
                 'css': '',
                 'action': 'withdraw',
                 'label': 'Withdraw Request',
-                'confirm_message': 'You sure?',
+                'confirm_message': 'Are you sure you want to withdraw this Further Information Request?',
             },
         }
 

--- a/web/domains/case/forms.py
+++ b/web/domains/case/forms.py
@@ -5,8 +5,17 @@ from web.domains.case.models import FurtherInformationRequest
 
 class FurtherInformationRequestForm(ModelEditForm):
 
-    actions_top = ['save']  # buttons to show on the top row of the form
-    actions_bottom = ['send', 'delete']  # buttons to show at the end of the form
+    def get_top_buttons(self):
+        """
+        buttons to show on the form's top row
+        """
+        return ['save']
+
+    def get_bottom_buttons(self):
+        """
+        buttons to show on the form's bottom row
+        """
+        return ['send', 'delete']
 
     class Meta:
         model = FurtherInformationRequest
@@ -64,8 +73,23 @@ class FurtherInformationRequestDisplayForm(FurtherInformationRequestForm, ModelD
     )
     requested_by = forms.CharField()
 
-    actions_top = ['edit']
-    actions_bottom = ['withdraw']
+    def get_top_buttons(self):
+        """
+        buttons to show on the form's top row
+        """
+        if self.instance.status == FurtherInformationRequest.DRAFT:
+            return ['edit']
+
+        return []
+
+    def get_bottom_buttons(self):
+        """
+        buttons to show on the form's bottom row
+        """
+        if self.instance.status == FurtherInformationRequest.OPEN:
+            return ['withdraw']
+
+        return []
 
     class Meta(FurtherInformationRequestForm.Meta):
         config = {

--- a/web/domains/case/forms.py
+++ b/web/domains/case/forms.py
@@ -47,11 +47,13 @@ class FurtherInformationRequestForm(ModelEditForm):
                 'css': 'primary-button',
                 'action': 'send',
                 'label': 'Send Request',
+                'confirm_message': 'You sure?',
             },
             'delete': {
                 'css': '',
                 'action': 'Delete',
                 'label': 'Delete',
+                'confirm_message': 'You sure?',
             },
             'edit': {
                 'css': 'icon-pencil',
@@ -62,6 +64,7 @@ class FurtherInformationRequestForm(ModelEditForm):
                 'css': '',
                 'action': 'withdraw',
                 'label': 'Withdraw Request',
+                'confirm_message': 'You sure?',
             },
         }
 

--- a/web/templates/web/access-request/access-request-fir-list.html
+++ b/web/templates/web/access-request/access-request-fir-list.html
@@ -29,7 +29,7 @@
         <ul class="menu-out flow-across">
             <li>
                 {% with action="new", css="icon-plus", label="New FIR", class="small-button" %}
-                    <form method="POST">{{ csrf_input }} {% include 'web/access-request/partials/fir-action-button.html' %}</form>
+                    <form method="POST">{{ csrf_input }} {% include 'web/access-request/partials/fields/fir-action-button.html' %}</form>
                 {% endwith %}
             </li>
         </ul>

--- a/web/templates/web/access-request/partials/fields/fir-action-button.html
+++ b/web/templates/web/access-request/partials/fields/fir-action-button.html
@@ -1,0 +1,1 @@
+<button name="action" value="{{ action }}"  {% if confirm_message %} data-confirm="{{ confirm_message}}" {%endif%} type="submit" class="{{ class }} {{ css }} button">{{ label }}</button>

--- a/web/templates/web/access-request/partials/fields/form-buttons-row.html
+++ b/web/templates/web/access-request/partials/fields/form-buttons-row.html
@@ -2,8 +2,8 @@
     <div class="{{ padding|default('three') }} columns"></div>
     <div class="six columns">
         {% for action in buttons_list %}
-            {% with css=config[action].css, label=config[action].label, class=class %}
-                {% include 'web/access-request/partials/fir-action-button.html' %}
+            {% with css=config[action].css, label=config[action].label, class=class, confirm_message=config[action].confirm_message %}
+                {% include 'web/access-request/partials/fields/fir-action-button.html' %}
             {% endwith %}
         {% endfor %}
     </div>

--- a/web/templates/web/access-request/partials/fir-action-button.html
+++ b/web/templates/web/access-request/partials/fir-action-button.html
@@ -1,1 +1,0 @@
-<button name="action" value="{{ action }}" type="submit"class="{{ class }} {{ css }} button"> {{ label }}</button>

--- a/web/templates/web/access-request/partials/fir-item.html
+++ b/web/templates/web/access-request/partials/fir-item.html
@@ -14,7 +14,7 @@
         {{ fields.hidden('id', fir.instance.id) }}
         {{ fields.hidden('status', fir.status.value() ) }}
 
-        {% with config=form_actions_config, buttons_list=fir.actions_top, padding="", class="small-button" %}
+        {% with config=form_actions_config, buttons_list=fir.get_top_buttons(), padding="", class="small-button" %}
             {% include "web/access-request/partials/fields/form-buttons-row.html" %}
         {% endwith %}
 
@@ -46,7 +46,7 @@
             </div>
         </div>
 
-        {% with config=form_actions_config, buttons_list=fir.actions_bottom %}
+        {% with config=form_actions_config, buttons_list=fir.get_bottom_buttons() %}
             {% include "web/access-request/partials/fields/form-buttons-row.html" %}
         {% endwith %}
 

--- a/web/templates/web/case-fir-sidebar.html
+++ b/web/templates/web/case-fir-sidebar.html
@@ -13,5 +13,6 @@
             <a href="{{ url('access_request_fir_list', args=(process_id,)) }}"
                class="{% if route == 'access_request_fir_list' %}current-page{% endif %}">
                 Further Information Requests ({{ "%s/%s" % (open_ifr, total_ifr) }})
+            </a>
     </ul>
 {% endwith %}

--- a/web/templates/web/case-fir-sidebar.html
+++ b/web/templates/web/case-fir-sidebar.html
@@ -8,7 +8,7 @@
             </a>
         </li>
         <li>
-            {% set total_ifr = activation.process.access_request.further_information_requests.all()|length %}
+            {% set total_ifr = activation.process.access_request.further_information_requests.exclude(status="CLOSED")|length %}
             {% set open_ifr = activation.process.access_request.further_information_requests.filter(status="OPEN")|length %}
             <a href="{{ url('access_request_fir_list', args=(process_id,)) }}"
                class="{% if route == 'access_request_fir_list' %}current-page{% endif %}">

--- a/web/templates/web/case-fir-sidebar.html
+++ b/web/templates/web/case-fir-sidebar.html
@@ -8,7 +8,7 @@
             </a>
         </li>
         <li>
-            {% set total_ifr = activation.process.access_request.further_information_requests.exclude(status="CLOSED")|length %}
+            {% set total_ifr = activation.process.access_request.further_information_requests.exclude(status="DELETED")|length %}
             {% set open_ifr = activation.process.access_request.further_information_requests.filter(status="OPEN")|length %}
             <a href="{{ url('access_request_fir_list', args=(process_id,)) }}"
                class="{% if route == 'access_request_fir_list' %}current-page{% endif %}">

--- a/web/urls.py
+++ b/web/urls.py
@@ -29,7 +29,7 @@ from web.domains.user.views import user_details
 from web.domains.workbasket.views import workbasket, take_ownership
 from . import converters
 from .auth import views as auth_views
-from .domains.case.access.views import AccessRequestCreatedView, AccessRequestFirListView
+from .domains.case.access.views import AccessRequestCreatedView, AccessRequestFirView
 from .flows import AccessRequestFlow
 from .views import home
 
@@ -191,7 +191,7 @@ urlpatterns = [
     # Access Request
     path(
          'access/<process_id>/fir',
-         AccessRequestFirListView.as_view(), name="access_request_fir_list"
+         AccessRequestFirView.as_view(), name="access_request_fir_list"
     ),
     path('access/', include(access_request_urls)),
     path(


### PR DESCRIPTION
* Renamed `AccessRequestFirListView` to `AccessRequestFirView` as we are doing more than just listing FIRs
*  `AccessRequestFirView` not extending `TemplateView` for consistency so that all view actions use similar logic to display data
*  `FurtherInformationRequestForm` and `FurtherInformationRequestDisplayForm` top and bottom buttons done via a function instead of config so we can include bussiness logic when deciding which buttons to show
* More accurate docblocks
* confirmation dialogue on `withdraw`
* confirmation dialogue on `delete`
* `withdrawn` FIR goes back to `draft`
* `send` marks FIR as `open`