### PR TITLE
replace FOXjs.actions with action button

### DIFF
--- a/web/static/web/js/action-buttons.js
+++ b/web/static/web/js/action-buttons.js
@@ -2,15 +2,14 @@ $(document).ready(function() {
     $('[role=action-button]').off().on('click', function(evt){
 
         evt.preventDefault();
-        var url    = $(this).attr('href');
-        var action = $(this).attr('data-action');
-        var csrf   = $(this).attr('data-csrf');
-        var method = $(this).attr('data-method') || 'POST';
+        var $el = $(this)
+        var url    = $el.attr('href');
+        var action = $el.attr('data-action');
+        var csrf   = $el.attr('data-csrf');
+        var method = $el.attr('data-method') || 'POST';
 
-        var confirmMessage =  $(this).attr('data-confirm');
-
-        var doAction = function(){
-            console.log('running action button callback')
+        var standAloneAction = function(){
+            console.log('running standAloneAction callback')
             $frm = $('<form></form>');
             $frm.attr('method', method);
 
@@ -28,11 +27,22 @@ $(document).ready(function() {
             $frm.submit();
         };
 
-        if (confirmMessage) {
-            return Dialogue().show(confirmMessage, doAction);
+        var inFormAction = function() {
+            console.log('running inFormAction callback')
+
+            $frm = $el.closest('frm');
+            $frm.append('<input type="hidden" name="action" value="'+ action +'" />')
+            $frm.submit();
         }
 
-        doAction();
+        var callback = $el.is('[data-in-form]') ? inFormAction : standAloneAction;
+
+        var confirmMessage =  $el.attr('data-confirm');
+        if (confirmMessage) {
+            return Dialogue().show(confirmMessage, callback);
+        }
+
+        callback();
     });
 });
 

--- a/web/templates/partial/agents.html
+++ b/web/templates/partial/agents.html
@@ -14,8 +14,7 @@
 
   <div class="list-actions">
     <ul class="menu-out flow-across">
-      <li> <button type="button" onclick="javascript:FOXjs.action({&quot;ref&quot;:&quot;action-create-agent&quot;,&quot;ctxt&quot;:&quot;s1Kzx6c_plrnqVW43&quot;}, this);" class="small-button icon-user-plus button">
-          Create Agent </button></li>
+      <li> <button type="button" role="action-button" data-csrf="{{ csrf_token }}" data-action="action-create-agent" class="small-button icon-user-plus button"> Create Agent </button></li>
     </ul>
   </div>
 

--- a/web/templates/partial/firearms-authorities.html
+++ b/web/templates/partial/firearms-authorities.html
@@ -21,7 +21,7 @@ There aren't any
 
             <div class="list-actions">
               <ul class="menu-out flow-across">
-  <li>  <button type="button" onclick="javascript:FOXjs.action({&quot;ref&quot;:&quot;action-IMP_LIB_AUTHORITY-add-authority&quot;,&quot;ctxt&quot;:&quot;s1Kzx6J_plrnqVW43&quot;}, this);" class="small-button icon-plus button">
+  <li>  <button type="button" role="action-button" data-in-form data-action="action-IMP_LIB_AUTHORITY-add-authority" class="small-button icon-plus button">
     Add Firearms Authority  </button></li>
 </ul>
             </div>

--- a/web/templates/partial/offices.html
+++ b/web/templates/partial/offices.html
@@ -35,11 +35,11 @@
        <td ><input   type="text" value="" size="16" maxlength="16" aria-required="false" aria-describedby="hint147-content" /></td>
        <td >
          <ul class="menu-out grouped flow-across">
-           <li> <button type="button" onclick="javascript:FOXjs.action({&quot;ref&quot;:&quot;action-IMP_SHARED_LIB_OFFICES-search-address-by-postcode&quot;,&quot;ctxt&quot;:&quot;s1Kzx6o_plrnqVW43&quot;}, this);" class="link-button icon-search button no-prompt-action" aria-describedby="hint148-content" aria-label="Find Address">
+           <li> <button type="button" role="action-button" data-in-form data-action="action-IMP_SHARED_LIB_OFFICES-search-address-by-postcode" class="link-button icon-search button no-prompt-action" aria-describedby="hint148-content" aria-label="Find Address">
              </button>
              <div id="hint148-content" role="tooltip" class="hint-content">Find Address</div>
            </li>
-           <li> <button type="button" onclick="javascript:FOXjs.action({&quot;confirm&quot;:&quot;Are you sure you want to archive this office?&quot;,&quot;ref&quot;:&quot;action-IMP_SHARED_LIB_OFFICES-archive-office&quot;,&quot;ctxt&quot;:&quot;s1Kzx6o_plrnqVW43&quot;}, this);" class="link-button icon-bin button no-prompt-action" aria-describedby="hint149-content" aria-label="Archive">
+           <li> <button type="button" role="action-button" data-in-form data-confirm="Are you sure you want to archive this office?" data-action="action-IMP_SHARED_LIB_OFFICES-archive-office" class="link-button icon-bin button no-prompt-action" aria-describedby="hint149-content" aria-label="Archive">
              </button>
              <div id="hint149-content" role="tooltip" class="hint-content">Archive</div>
            </li>
@@ -53,15 +53,15 @@
        <td ><input   type="text" value="" size="16" maxlength="16" aria-required="false" aria-describedby="hint150-content" /></td>
        <td >
          <ul class="menu-out grouped flow-across">
-           <li> <button type="button" onclick="javascript:FOXjs.action({&quot;ref&quot;:&quot;action-IMP_SHARED_LIB_OFFICES-reset-search-address&quot;,&quot;ctxt&quot;:&quot;s1Kzx6v_plrnqVW43&quot;}, this);" class="link-button icon-binoculars button no-prompt-action" aria-describedby="hint151-content" aria-label="Start Search Again">
+           <li> <button type="button" role="action-button" data-in-form data-action="action-IMP_SHARED_LIB_OFFICES-reset-search-address" class="link-button icon-binoculars button no-prompt-action" aria-describedby="hint151-content" aria-label="Start Search Again">
              </button>
              <div id="hint151-content" role="tooltip" class="hint-content">Start Search Again</div>
            </li>
-           <li> <button type="button" onclick="javascript:FOXjs.action({&quot;ref&quot;:&quot;action-IMP_SHARED_LIB_OFFICES-manually-enter-address&quot;,&quot;ctxt&quot;:&quot;s1Kzx6v_plrnqVW43&quot;}, this);" class="link-button icon-pencil button no-prompt-action" aria-describedby="hint152-content" aria-label="Manually Enter Address">
+           <li> <button type="button" role="action-button" data-in-form data-action="action-IMP_SHARED_LIB_OFFICES-manually-enter-address" class="link-button icon-pencil button no-prompt-action" aria-describedby="hint152-content" aria-label="Manually Enter Address">
              </button>
              <div id="hint152-content" role="tooltip" class="hint-content">Manually Enter Address</div>
            </li>
-           <li> <button type="button" onclick="javascript:FOXjs.action({&quot;confirm&quot;:&quot;Are you sure you want to archive this office?&quot;,&quot;ref&quot;:&quot;action-IMP_SHARED_LIB_OFFICES-archive-office&quot;,&quot;ctxt&quot;:&quot;s1Kzx6v_plrnqVW43&quot;}, this);" class="link-button icon-bin button no-prompt-action" aria-describedby="hint153-content" aria-label="Archive">
+           <li> <button type="button" role="action-button" data-in-form data-action="action-IMP_SHARED_LIB_OFFICES-archive-office" data-confirm="Are you sure you want to archive this office?" class="link-button icon-bin button no-prompt-action" aria-describedby="hint153-content" aria-label="Archive">
              </button>
              <div id="hint153-content" role="tooltip" class="hint-content">Archive</div>
            </li>
@@ -72,7 +72,7 @@
 
    <div class="list-actions">
      <ul class="menu-out flow-across">
-       <li> <button type="button" onclick="javascript:FOXjs.action({&quot;ref&quot;:&quot;action-IMP_SHARED_LIB_OFFICES-add-office&quot;,&quot;ctxt&quot;:&quot;s1Kzx6n_plrnqVW43&quot;}, this);" class="small-button icon-office button">
+       <li> <button type="button" role="action-button" data-in-form data-action="action-IMP_SHARED_LIB_OFFICES-add-office" class="small-button icon-office button">
            Add Office </button></li>
      </ul>
    </div>

--- a/web/templates/partial/section5-authorities.html
+++ b/web/templates/partial/section5-authorities.html
@@ -15,7 +15,7 @@
   <div class="list-actions">
     <ul class="menu-out flow-across">
       <li>
-        <button type="button" onclick="javascript:FOXjs.action({&quot;ref&quot;:&quot;action-IMP_LIB_AUTHORITY-add-authority&quot;,&quot;ctxt&quot;:&quot;s1Kzx6M_plrnqVW43&quot;}, this);" class="small-button icon-plus button">
+        <button type="button"role="action-button" data-in-form data-action="action-IMP_LIB_AUTHORITY-add-authority" class="small-button icon-plus button">
           Add Section 5 Authority </button>
       </li>
     </ul>

--- a/web/templates/web/contacts/list.html
+++ b/web/templates/web/contacts/list.html
@@ -68,7 +68,7 @@
             <td>
                 <div class="container setoutForm" >
                     <div class="row">
-                        <div class="twelve columns" > <button type="button" onclick="javascript:FOXjs.action({&quot;ref&quot;:&quot;action-list-add-qual-comment&quot;,&quot;ctxt&quot;:&quot;s16dZTf_plrnqVW43&quot;}, this);" class="icon-bubble link-button inline-link-button button">
+                        <div class="twelve columns" > <button type="button" role="action-button" data-in-form data-action="action-list-add-qual-comment" class="icon-bubble link-button inline-link-button button">
                                 Add qualifying comment </button></div>
                     </div>
                 </div>

--- a/web/templates/web/portal/outbound-emails.html
+++ b/web/templates/web/portal/outbound-emails.html
@@ -12,7 +12,7 @@
 
     <li class="current-tab">
 
-        <a href="javascript:FOXjs.action({&quot;ref&quot;:&quot;action-DASH001X-navigate-to-tab&quot;,&quot;ctxt&quot;:&quot;sO4Ad_plrnqWp1W&quot;}, this);">Outbound Emails</a>
+        <a role="action-button" data-action="action-DASH001X-navigate-to-tab">Outbound Emails</a>
 
     </li>
 
@@ -43,13 +43,13 @@
 
 <div class="list-actions">
     <ul class="menu-out small-menu-out flow-across">
-        <li> <button type="button" onclick="javascript:FOXjs.action({&quot;ref&quot;:&quot;action-select-all&quot;,&quot;ctxt&quot;:&quot;sO568_plrnqWp1W&quot;}, this);" class="icon-checkbox-checked button">
+        <li> <button type="button" role="action-button" data-action="action-select-all" class="icon-checkbox-checked button">
                 Select All </button></li>
-        <li> <button type="button" onclick="javascript:FOXjs.action({&quot;ref&quot;:&quot;action-select-none&quot;,&quot;ctxt&quot;:&quot;sO568_plrnqWp1W&quot;}, this);" class="icon-checkbox-unchecked button">
+        <li> <button type="button" role="action-button" data-action="action-select-none" class="icon-checkbox-unchecked button">
                 Select None </button></li>
-        <li> <button type="button" onclick="javascript:FOXjs.action({&quot;ref&quot;:&quot;action-resend&quot;,&quot;ctxt&quot;:&quot;sO568_plrnqWp1W&quot;}, this);" class="icon-mail2 button">
+        <li> <button type="button" role="action-button" data-action="action-resend" class="icon-mail2 button">
                 Resend Selected </button></li>
-        <li> <button type="button" onclick="javascript:FOXjs.action({&quot;ref&quot;:&quot;action-update-resend&quot;,&quot;ctxt&quot;:&quot;sO568_plrnqWp1W&quot;}, this);" class="icon-pencil button">
+        <li> <button type="button" role="action-button" data-action="action-update-resend" class="icon-pencil button">
                 Update Recipient and Resend Selected </button></li>
     </ul>
 </div>


### PR DESCRIPTION
* replaced FOXjs.actions with action button on several template files
* action buttons support the notion of `standalone buttons` (eg: to use as actions in list views) and `in form action buttons` (to use in conjunction with exiting forms, eg: a delete button that needs to pass existing data)