### PR TITLE
ICMSLST-405 Speed up tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ test: ## run tests
 	ICMS_DEBUG=False \
 	TEST_TARGET='web/tests' \
 	DJANGO_SETTINGS_MODULE=config.settings.test \
-	docker-compose run --rm web python -m pytest -p no:sugar --cov=web --cov=config --cov-report xml:test-reports/cov.xml $(TEST_TARGET)
+	docker-compose run --rm web python -m pytest -p no:sugar --cov=web --cov=config --cov-report xml:test-reports/cov.xml --dist=loadfile --tx=4*popen $(TEST_TARGET)
 
 accessibility: ## Generate accessibility reports
 	unset UID && \

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -9,6 +9,11 @@ env = environ.Env()
 
 SECRET_KEY = env.str("ICMS_SECRET_KEY", default="test")
 
+# speed up tests; see https://docs.djangoproject.com/en/3.0/topics/testing/overview/#password-hashing
+PASSWORD_HASHERS = [
+    "django.contrib.auth.hashers.MD5PasswordHasher",
+]
+
 # Email
 AWS_SES_ACCESS_KEY_ID = env.str("AWS_SES_ACCESS_KEY_ID", "test")
 AWS_SES_SECRET_ACCESS_KEY = env.str("AWS_SES_SECRET_ACCESS_KEY", "test")


### PR DESCRIPTION
Details:

* Use faster password hashing algo for tests.
* Run unittests in parallel (fixed at 4 for now).

Timings:

unittests:

Before: 2m10s
With faster password hashing: 0m50s
With faster password hashing and 4x parallel: 0m27s

BDD tests:

Before: 3m6s
With faster password hashing: 2m56s