### PR TITLE
Reduce query number on importer

### DIFF
--- a/web/domains/importer/forms.py
+++ b/web/domains/importer/forms.py
@@ -26,7 +26,7 @@ class ImporterFilter(ModelSearchFilter):
     # Filter base queryset to only get importers that are not agents.
     @property
     def qs(self):
-        return super().qs.select_related("user").filter(main_importer__isnull=True)
+        return super().qs.filter(main_importer__isnull=True)
 
     def filter_importer_name(self, queryset, name, value):
         if not value:

--- a/web/domains/importer/views.py
+++ b/web/domains/importer/views.py
@@ -38,6 +38,7 @@ class ImporterListView(ModelFilterView):
     template_name = "web/domains/importer/list.html"
     filterset_class = ImporterFilter
     model = Importer
+    queryset = Importer.objects.prefetch_related("offices").select_related("main_importer")
     page_title = "Maintain Importers"
 
     def has_permission(self):


### PR DESCRIPTION
Prefetch `offices` as they are displayed in every row of the `importer-list` view. Prefetching offices avoid to issue a query every time an office should be displayed (see https://docs.djangoproject.com/en/2.2/ref/models/querysets/#django.db.models.query.QuerySet.prefetch_related). The prefetch reduces the queries from 53 (1 office for each row) to 4.

Fix `select_related` which was targeting the wrong model. It was `user` and it target `main_importer`.

