### PR TITLE
Remove mixins from web.forms.forms

### DIFF
--- a/web/domains/case/_import/forms.py
+++ b/web/domains/case/_import/forms.py
@@ -1,13 +1,12 @@
 from django.db.models import Q
-from django.forms import ModelChoiceField
+from django.forms import ModelChoiceField, ModelForm
 from web.domains.importer.models import Importer
 from web.domains.office.models import Office
-from web.forms import ModelEditForm
 
 from .models import ImportApplication, ImportApplicationType
 
 
-class NewImportApplicationForm(ModelEditForm):
+class NewImportApplicationForm(ModelForm):
 
     application_type = ModelChoiceField(
         queryset=ImportApplicationType.objects.filter(is_active=True),

--- a/web/domains/case/access/approval/forms.py
+++ b/web/domains/case/access/approval/forms.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from web.forms import ModelEditForm
+from django.forms import ModelForm
 
 from .models import ApprovalRequest
 
 
-class ApprovalRequestResponseForm(ModelEditForm):
+class ApprovalRequestResponseForm(ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["response"].required = True

--- a/web/domains/case/access/forms.py
+++ b/web/domains/case/access/forms.py
@@ -1,8 +1,7 @@
 import structlog as logging
 from django.core.exceptions import ValidationError
+from django.forms import ModelForm
 from django.forms.widgets import Select, Textarea
-
-from web.forms import ModelEditForm
 
 from .approval.models import ApprovalRequest
 from .models import AccessRequest
@@ -29,7 +28,7 @@ def is_agent_request(request_type):
     return request_type in [AccessRequest.IMPORTER_AGENT, AccessRequest.EXPORTER_AGENT]
 
 
-class ExporterAccessRequestForm(ModelEditForm):
+class ExporterAccessRequestForm(ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["request_type"].widget = Select(choices=AccessRequest.EXPORTER_REQUEST_TYPES)
@@ -90,14 +89,14 @@ class ImporterAccessRequestForm(ExporterAccessRequestForm):
         widgets["request_reason"] = Textarea({"rows": 5})
 
 
-class CloseAccessRequestForm(ModelEditForm):
+class CloseAccessRequestForm(ModelForm):
     class Meta:
         model = AccessRequest
 
         fields = ["response", "response_reason"]
 
 
-class ApprovalRequestForm(ModelEditForm):
+class ApprovalRequestForm(ModelForm):
     def __init__(self, team, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields[

--- a/web/domains/case/fir/forms.py
+++ b/web/domains/case/fir/forms.py
@@ -1,15 +1,15 @@
 import structlog as logging
 from django.core.validators import validate_email
+from django.forms import ModelForm
 from django.forms.widgets import Textarea
 from django.utils import timezone
 
 from web.domains.case.fir.models import FurtherInformationRequest
-from web.forms import ModelEditForm
 
 logger = logging.getLogger(__name__)
 
 
-class FurtherInformationRequestForm(ModelEditForm):
+class FurtherInformationRequestForm(ModelForm):
     """Request form for FIRs.
        Takes an optional user keyword arg to set fir requested by"""
 
@@ -63,7 +63,7 @@ class FurtherInformationRequestForm(ModelEditForm):
         }
 
 
-class FurtherInformationRequestResponseForm(ModelEditForm):
+class FurtherInformationRequestResponseForm(ModelForm):
     def __init__(self, response_by, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.response_by = response_by

--- a/web/domains/commodity/forms.py
+++ b/web/domains/commodity/forms.py
@@ -1,8 +1,8 @@
-from django.forms import CharField, ChoiceField
+from django.forms import CharField, ChoiceField, ModelForm
 from django.forms.widgets import CheckboxInput, Textarea
 from django_filters import BooleanFilter, CharFilter, ChoiceFilter, DateFilter, ModelChoiceFilter
 from django_filters.fields import ModelChoiceField
-from web.forms import ModelEditForm, ModelSearchFilter
+from web.forms import ModelSearchFilter
 from web.forms.widgets import DateInput
 
 from .models import Commodity, CommodityGroup, CommodityType, Unit
@@ -34,7 +34,7 @@ class CommodityFilter(ModelSearchFilter):
         fields = []
 
 
-class CommodityForm(ModelEditForm):
+class CommodityForm(ModelForm):
     commodity_code = CharField(label="Commodity Code")
 
     class Meta:
@@ -100,7 +100,7 @@ class CommodityGroupFilter(ModelSearchFilter):
         fields = []
 
 
-class CommodityGroupForm(ModelEditForm):
+class CommodityGroupForm(ModelForm):
     group_type = ChoiceField(
         choices=CommodityGroup.TYPES,
         help_text="Auto groups will include all commodities beginning with the \

--- a/web/domains/commodity/forms.py
+++ b/web/domains/commodity/forms.py
@@ -1,14 +1,20 @@
 from django.forms import CharField, ChoiceField, ModelForm
 from django.forms.widgets import CheckboxInput, Textarea
-from django_filters import BooleanFilter, CharFilter, ChoiceFilter, DateFilter, ModelChoiceFilter
+from django_filters import (
+    BooleanFilter,
+    CharFilter,
+    ChoiceFilter,
+    DateFilter,
+    FilterSet,
+    ModelChoiceFilter,
+)
 from django_filters.fields import ModelChoiceField
-from web.forms import ModelSearchFilter
 from web.forms.widgets import DateInput
 
 from .models import Commodity, CommodityGroup, CommodityType, Unit
 
 
-class CommodityFilter(ModelSearchFilter):
+class CommodityFilter(FilterSet):
     commodity_code = CharFilter(
         field_name="commodity_code", lookup_expr="icontains", label="Commodity Code"
     )
@@ -69,7 +75,7 @@ class CommodityEditForm(CommodityForm):
         self.fields["commodity_code"].disabled = True
 
 
-class CommodityGroupFilter(ModelSearchFilter):
+class CommodityGroupFilter(FilterSet):
     group_type = ChoiceFilter(
         field_name="group_type", choices=CommodityGroup.TYPES, label="Group Type"
     )

--- a/web/domains/constabulary/forms.py
+++ b/web/domains/constabulary/forms.py
@@ -1,12 +1,11 @@
 from django.forms import ModelForm
 from django.forms.widgets import Select, CheckboxInput
-from django_filters import CharFilter, ChoiceFilter, BooleanFilter
-from web.forms import ModelSearchFilter
+from django_filters import CharFilter, ChoiceFilter, BooleanFilter, FilterSet
 
 from .models import Constabulary
 
 
-class ConstabulariesFilter(ModelSearchFilter):
+class ConstabulariesFilter(FilterSet):
     name = CharFilter(field_name="name", lookup_expr="icontains", label="Constabulary Name")
 
     region = ChoiceFilter(

--- a/web/domains/constabulary/forms.py
+++ b/web/domains/constabulary/forms.py
@@ -1,6 +1,7 @@
+from django.forms import ModelForm
 from django.forms.widgets import Select, CheckboxInput
 from django_filters import CharFilter, ChoiceFilter, BooleanFilter
-from web.forms import ModelEditForm, ModelSearchFilter
+from web.forms import ModelSearchFilter
 
 from .models import Constabulary
 
@@ -30,7 +31,7 @@ class ConstabulariesFilter(ModelSearchFilter):
         fields = []
 
 
-class ConstabularyForm(ModelEditForm):
+class ConstabularyForm(ModelForm):
     class Meta:
         model = Constabulary
         fields = ["name", "region", "email"]

--- a/web/domains/country/forms.py
+++ b/web/domains/country/forms.py
@@ -1,6 +1,7 @@
+from django.forms import ModelForm
 from django.forms.widgets import Select, Textarea
 from django_filters import CharFilter
-from web.forms import ModelEditForm, ModelSearchFilter
+from web.forms import ModelSearchFilter
 
 from .models import Country, CountryGroup, CountryTranslation, CountryTranslationSet
 
@@ -17,7 +18,7 @@ class CountryNameFilter(ModelSearchFilter):
         fields = []
 
 
-class CountryCreateForm(ModelEditForm):
+class CountryCreateForm(ModelForm):
     class Meta:
         model = Country
         fields = ["name", "type", "commission_code", "hmrc_code"]
@@ -36,7 +37,7 @@ class CountryEditForm(CountryCreateForm):
         fields = ["name", "type", "commission_code", "hmrc_code"]
 
 
-class CountryGroupEditForm(ModelEditForm):
+class CountryGroupEditForm(ModelForm):
     class Meta:
         model = CountryGroup
         fields = ["name", "comments"]
@@ -44,14 +45,14 @@ class CountryGroupEditForm(ModelEditForm):
         widgets = {"comments": Textarea({"rows": 5, "cols": 20})}
 
 
-class CountryTranslationSetEditForm(ModelEditForm):
+class CountryTranslationSetEditForm(ModelForm):
     class Meta:
         model = CountryTranslationSet
         fields = ["name"]
         labels = {"name": "Translation Set Name"}
 
 
-class CountryTranslationEditForm(ModelEditForm):
+class CountryTranslationEditForm(ModelForm):
     class Meta:
         model = CountryTranslation
         fields = ["translation"]

--- a/web/domains/country/forms.py
+++ b/web/domains/country/forms.py
@@ -1,12 +1,11 @@
 from django.forms import ModelForm
 from django.forms.widgets import Select, Textarea
-from django_filters import CharFilter
-from web.forms import ModelSearchFilter
+from django_filters import CharFilter, FilterSet
 
 from .models import Country, CountryGroup, CountryTranslation, CountryTranslationSet
 
 
-class CountryNameFilter(ModelSearchFilter):
+class CountryNameFilter(FilterSet):
     country_name = CharFilter(field_name="name", lookup_expr="icontains", label="Country Name")
 
     @property

--- a/web/domains/exporter/forms.py
+++ b/web/domains/exporter/forms.py
@@ -1,11 +1,11 @@
 from django.forms import ModelForm
-from django_filters import CharFilter
-from web.forms import ModelDisplayForm, ModelSearchFilter
+from django_filters import CharFilter, FilterSet
+from web.forms import ModelDisplayForm
 
 from .models import Exporter
 
 
-class ExporterFilter(ModelSearchFilter):
+class ExporterFilter(FilterSet):
     exporter_name = CharFilter(field_name="name", lookup_expr="icontains", label="Exporter Name")
 
     agent_name = CharFilter(field_name="agents__name", lookup_expr="icontains", label="Agent Name")

--- a/web/domains/exporter/forms.py
+++ b/web/domains/exporter/forms.py
@@ -1,6 +1,6 @@
 from django.forms import ModelForm
 from django_filters import CharFilter, FilterSet
-from web.forms import ModelDisplayForm
+from web.forms.mixins import ReadonlyFormMixin
 
 from .models import Exporter
 
@@ -22,5 +22,5 @@ class ExporterEditForm(ModelForm):
         labels = {"name": "Organisation Name"}
 
 
-class ExporterDisplayForm(ModelDisplayForm):
+class ExporterDisplayForm(ReadonlyFormMixin, ModelForm):
     pass

--- a/web/domains/exporter/forms.py
+++ b/web/domains/exporter/forms.py
@@ -1,5 +1,6 @@
+from django.forms import ModelForm
 from django_filters import CharFilter
-from web.forms import ModelDisplayForm, ModelEditForm, ModelSearchFilter
+from web.forms import ModelDisplayForm, ModelSearchFilter
 
 from .models import Exporter
 
@@ -14,7 +15,7 @@ class ExporterFilter(ModelSearchFilter):
         fields = []
 
 
-class ExporterEditForm(ModelEditForm):
+class ExporterEditForm(ModelForm):
     class Meta:
         model = Exporter
         fields = ["name", "registered_number", "comments"]

--- a/web/domains/firearms/forms.py
+++ b/web/domains/firearms/forms.py
@@ -2,7 +2,7 @@ from django.db.models import Count
 from django.forms import BaseInlineFormSet, inlineformset_factory, ModelForm
 from django.forms.widgets import CheckboxInput, HiddenInput
 from django_filters import BooleanFilter, CharFilter, FilterSet
-from web.forms import ModelDisplayForm
+from web.forms.mixins import ReadonlyFormMixin
 
 from .models import ObsoleteCalibre, ObsoleteCalibreGroup
 
@@ -50,7 +50,7 @@ class ObsoleteCalibreGroupEditForm(ModelForm):
         labels = {"name": "Group Name"}
 
 
-class ObsoleteCalibreGroupDisplayForm(ModelDisplayForm):
+class ObsoleteCalibreGroupDisplayForm(ReadonlyFormMixin, ModelForm):
     class Meta(ObsoleteCalibreGroupEditForm.Meta):
         pass
 

--- a/web/domains/firearms/forms.py
+++ b/web/domains/firearms/forms.py
@@ -1,8 +1,8 @@
 from django.db.models import Count
-from django.forms import BaseInlineFormSet, inlineformset_factory
+from django.forms import BaseInlineFormSet, inlineformset_factory, ModelForm
 from django.forms.widgets import CheckboxInput, HiddenInput
 from django_filters import BooleanFilter, CharFilter
-from web.forms import ModelEditForm, ModelSearchFilter, ModelDisplayForm
+from web.forms import ModelSearchFilter, ModelDisplayForm
 
 from .models import ObsoleteCalibre, ObsoleteCalibreGroup
 
@@ -43,7 +43,7 @@ class ObsoleteCalibreGroupFilter(ModelSearchFilter):
         fields = []
 
 
-class ObsoleteCalibreGroupEditForm(ModelEditForm):
+class ObsoleteCalibreGroupEditForm(ModelForm):
     class Meta:
         model = ObsoleteCalibreGroup
         fields = ["name"]
@@ -55,7 +55,7 @@ class ObsoleteCalibreGroupDisplayForm(ModelDisplayForm):
         pass
 
 
-class ObsoleteCalibreForm(ModelEditForm):
+class ObsoleteCalibreForm(ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/web/domains/firearms/forms.py
+++ b/web/domains/firearms/forms.py
@@ -1,13 +1,13 @@
 from django.db.models import Count
 from django.forms import BaseInlineFormSet, inlineformset_factory, ModelForm
 from django.forms.widgets import CheckboxInput, HiddenInput
-from django_filters import BooleanFilter, CharFilter
-from web.forms import ModelSearchFilter, ModelDisplayForm
+from django_filters import BooleanFilter, CharFilter, FilterSet
+from web.forms import ModelDisplayForm
 
 from .models import ObsoleteCalibre, ObsoleteCalibreGroup
 
 
-class ObsoleteCalibreGroupFilter(ModelSearchFilter):
+class ObsoleteCalibreGroupFilter(FilterSet):
     group_name = CharFilter(
         field_name="name", lookup_expr="icontains", label="Obsolete Calibre Group Name"
     )

--- a/web/domains/importer/forms.py
+++ b/web/domains/importer/forms.py
@@ -1,13 +1,12 @@
 from django.forms import ChoiceField, CharField, ModelForm
-from django_filters import CharFilter, ChoiceFilter
-from web.forms import ModelSearchFilter
+from django_filters import CharFilter, ChoiceFilter, FilterSet
 from web.forms.mixins import ReadonlyFormMixin
 from django.db.models import Q
 
 from .models import Importer
 
 
-class ImporterFilter(ModelSearchFilter):
+class ImporterFilter(FilterSet):
     importer_entity_type = ChoiceFilter(
         field_name="type", choices=Importer.TYPES, label="Importer Entity Type"
     )

--- a/web/domains/importer/forms.py
+++ b/web/domains/importer/forms.py
@@ -1,6 +1,6 @@
-from django.forms.fields import ChoiceField, CharField
+from django.forms import ChoiceField, CharField, ModelForm
 from django_filters import CharFilter, ChoiceFilter
-from web.forms import ModelEditForm, ModelSearchFilter
+from web.forms import ModelSearchFilter
 from web.forms.mixins import ReadonlyFormMixin
 from django.db.models import Q
 
@@ -59,7 +59,7 @@ class ImporterFilter(ModelSearchFilter):
         fields = []
 
 
-class ImporterOrganisationEditForm(ModelEditForm):
+class ImporterOrganisationEditForm(ModelForm):
     type = ChoiceField(choices=Importer.TYPES)
 
     def __init__(self, *args, **kwargs):
@@ -76,7 +76,7 @@ class ImporterOrganisationDisplayForm(ReadonlyFormMixin, ImporterOrganisationEdi
     pass
 
 
-class ImporterIndividualEditForm(ModelEditForm):
+class ImporterIndividualEditForm(ModelForm):
     type = ChoiceField(choices=Importer.TYPES)
 
     def __init__(self, *args, **kwargs):
@@ -88,7 +88,7 @@ class ImporterIndividualEditForm(ModelEditForm):
         fields = ["type", "user", "comments"]
 
 
-class ImporterIndividualDisplayForm(ReadonlyFormMixin, ModelEditForm):
+class ImporterIndividualDisplayForm(ReadonlyFormMixin, ModelForm):
     type = ChoiceField(choices=Importer.TYPES)
 
     # ImporterIndividualDetailView fills these out

--- a/web/domains/legislation/forms.py
+++ b/web/domains/legislation/forms.py
@@ -1,5 +1,6 @@
+from django.forms import ModelForm
 from django_filters import CharFilter, ChoiceFilter
-from web.forms import ModelEditForm, ModelSearchFilter
+from web.forms import ModelSearchFilter
 
 from .models import ProductLegislation
 
@@ -40,7 +41,7 @@ class ProductLegislationFilter(ModelSearchFilter):
         fields = []
 
 
-class ProductLegislationForm(ModelEditForm):
+class ProductLegislationForm(ModelForm):
     class Meta:
         model = ProductLegislation
         fields = ["name", "is_biocidal", "is_biocidal_claim", "is_eu_cosmetics_regulation"]

--- a/web/domains/legislation/forms.py
+++ b/web/domains/legislation/forms.py
@@ -1,11 +1,10 @@
 from django.forms import ModelForm
-from django_filters import CharFilter, ChoiceFilter
-from web.forms import ModelSearchFilter
+from django_filters import CharFilter, ChoiceFilter, FilterSet
 
 from .models import ProductLegislation
 
 
-class ProductLegislationFilter(ModelSearchFilter):
+class ProductLegislationFilter(FilterSet):
     name = CharFilter(field_name="name", lookup_expr="icontains", label="Legislation Name")
 
     is_biocidal = ChoiceFilter(

--- a/web/domains/mailshot/forms.py
+++ b/web/domains/mailshot/forms.py
@@ -5,8 +5,7 @@ import structlog as logging
 from django.forms import CharField, ModelForm, MultipleChoiceField
 from django.forms.widgets import CheckboxSelectMultiple, Textarea
 
-from django_filters import CharFilter, ChoiceFilter
-from web.forms import ModelSearchFilter
+from django_filters import CharFilter, ChoiceFilter, FilterSet
 
 from web.forms.mixins import ReadonlyFormMixin
 
@@ -15,7 +14,7 @@ from .models import Mailshot
 logger = logging.get_logger(__name__)
 
 
-class MailshotFilter(ModelSearchFilter):
+class MailshotFilter(FilterSet):
 
     id = CharFilter(field_name="id", lookup_expr="icontains", label="Reference")
 
@@ -32,7 +31,7 @@ class MailshotFilter(ModelSearchFilter):
         fields = []
 
 
-class ReceivedMailshotsFilter(ModelSearchFilter):
+class ReceivedMailshotsFilter(FilterSet):
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop("user")
         super().__init__(*args, **kwargs)

--- a/web/domains/mailshot/forms.py
+++ b/web/domains/mailshot/forms.py
@@ -2,11 +2,11 @@
 # -*- coding: utf-8 -*-
 
 import structlog as logging
-from django.forms import CharField, MultipleChoiceField
+from django.forms import CharField, ModelForm, MultipleChoiceField
 from django.forms.widgets import CheckboxSelectMultiple, Textarea
 
 from django_filters import CharFilter, ChoiceFilter
-from web.forms import ModelEditForm, ModelSearchFilter
+from web.forms import ModelSearchFilter
 
 from web.forms.mixins import ReadonlyFormMixin
 
@@ -66,7 +66,7 @@ class ReceivedMailshotsFilter(ModelSearchFilter):
         fields = []
 
 
-class MailshotForm(ModelEditForm):
+class MailshotForm(ModelForm):
 
     RECIPIENT_CHOICES = (
         ("importers", "Importers and Agents"),
@@ -126,7 +126,7 @@ class MailshotReadonlyForm(ReadonlyFormMixin, MailshotForm):
     pass
 
 
-class MailshotRetractForm(ModelEditForm):
+class MailshotRetractForm(ModelForm):
     class Meta:
         model = Mailshot
         fields = ["is_retraction_email", "retract_email_subject", "retract_email_body"]

--- a/web/domains/office/forms.py
+++ b/web/domains/office/forms.py
@@ -1,4 +1,3 @@
-from web.forms import ModelEditForm
 from django import forms
 from web.domains.office.models import Office
 
@@ -14,7 +13,7 @@ class OfficeFormSet(forms.BaseFormSet):
                 form.add_error("address", "Cannot be empty")
 
 
-class OfficeEditForm(ModelEditForm):
+class OfficeEditForm(forms.ModelForm):
     address = forms.CharField(
         widget=forms.Textarea({"rows": 3, "required": "required"}), required=True, strip=True
     )

--- a/web/domains/team/forms.py
+++ b/web/domains/team/forms.py
@@ -1,12 +1,11 @@
 from django.forms import CharField, ModelForm
 from django.forms.widgets import Textarea
-from django_filters import CharFilter
-from web.forms import ModelSearchFilter
+from django_filters import CharFilter, FilterSet
 
 from .models import Team
 
 
-class TeamsFilter(ModelSearchFilter):
+class TeamsFilter(FilterSet):
     name = CharFilter(field_name="name", lookup_expr="icontains", label="Name")
 
     class Meta:

--- a/web/domains/team/forms.py
+++ b/web/domains/team/forms.py
@@ -1,7 +1,7 @@
-from django.forms.fields import CharField
+from django.forms import CharField, ModelForm
 from django.forms.widgets import Textarea
 from django_filters import CharFilter
-from web.forms import ModelEditForm, ModelSearchFilter
+from web.forms import ModelSearchFilter
 
 from .models import Team
 
@@ -14,7 +14,7 @@ class TeamsFilter(ModelSearchFilter):
         fields = []
 
 
-class TeamEditForm(ModelEditForm):
+class TeamEditForm(ModelForm):
     name = CharField()
 
     class Meta:

--- a/web/domains/template/forms.py
+++ b/web/domains/template/forms.py
@@ -1,6 +1,5 @@
 from django import forms
-from django_filters import CharFilter, ChoiceFilter
-from web.forms import ModelSearchFilter
+from django_filters import CharFilter, ChoiceFilter, FilterSet
 
 from .models import Template
 
@@ -59,7 +58,7 @@ class EndorsementCreateTemplateForm(GenericTemplate):
         self.fields["template_name"].label = "Endorsement Name"
 
 
-class TemplatesFilter(ModelSearchFilter):
+class TemplatesFilter(FilterSet):
     # Fields of the model that can be filtered
     template_name = CharFilter(lookup_expr="icontains", label="Template Name")
     application_domain = ChoiceFilter(

--- a/web/domains/template/forms.py
+++ b/web/domains/template/forms.py
@@ -1,11 +1,11 @@
 from django import forms
 from django_filters import CharFilter, ChoiceFilter
-from web.forms import ModelSearchFilter, ModelEditForm
+from web.forms import ModelSearchFilter
 
 from .models import Template
 
 
-class GenericTemplate(ModelEditForm):
+class GenericTemplate(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/web/domains/user/forms.py
+++ b/web/domains/user/forms.py
@@ -8,8 +8,8 @@ from django.forms.widgets import (
     Textarea,
 )
 from django.utils.translation import gettext_lazy as _
-from django_filters import BooleanFilter, CharFilter, MultipleChoiceFilter
-from web.forms import ModelSearchFilter, validators
+from django_filters import BooleanFilter, CharFilter, FilterSet, MultipleChoiceFilter
+from web.forms import validators
 from web.forms.fields import PhoneNumberField
 from web.forms.widgets import DateInput
 
@@ -173,7 +173,7 @@ class PersonalEmailForm(ModelForm):
         }
 
 
-class PeopleFilter(ModelSearchFilter):
+class PeopleFilter(FilterSet):
     email_address = CharFilter(
         field_name="personal_emails__email", lookup_expr="icontains", label="Email"
     )
@@ -190,7 +190,7 @@ class PeopleFilter(ModelSearchFilter):
         fields = []
 
 
-class UserListFilter(ModelSearchFilter):
+class UserListFilter(FilterSet):
     email_address = CharFilter(field_name="email", lookup_expr="icontains", label="Email Address")
     username = CharFilter(field_name="username", lookup_expr="icontains", label="Login Name")
     forename = CharFilter(field_name="first_name", lookup_expr="icontains", label="Forename")

--- a/web/domains/user/forms.py
+++ b/web/domains/user/forms.py
@@ -1,4 +1,4 @@
-from django.forms.fields import CharField
+from django.forms import CharField, ModelForm
 from django.forms.widgets import (
     CheckboxInput,
     CheckboxSelectMultiple,
@@ -9,14 +9,14 @@ from django.forms.widgets import (
 )
 from django.utils.translation import gettext_lazy as _
 from django_filters import BooleanFilter, CharFilter, MultipleChoiceFilter
-from web.forms import ModelEditForm, ModelSearchFilter, validators
+from web.forms import ModelSearchFilter, validators
 from web.forms.fields import PhoneNumberField
 from web.forms.widgets import DateInput
 
 from .models import AlternativeEmail, Email, PersonalEmail, PhoneNumber, User
 
 
-class UserDetailsUpdateForm(ModelEditForm):
+class UserDetailsUpdateForm(ModelForm):
     security_answer_repeat = CharField(
         required=True, label="Re-enter Security Answer", widget=PasswordInput(render_value=True)
     )
@@ -93,7 +93,7 @@ class UserDetailsUpdateForm(ModelEditForm):
         }
 
 
-class PhoneNumberForm(ModelEditForm):
+class PhoneNumberForm(ModelForm):
     telephone_number = CharField(validators=PhoneNumberField().validators)
 
     def __init__(self, *args, **kwargs):
@@ -111,7 +111,7 @@ class PhoneNumberForm(ModelEditForm):
         widgets = {"type": Select(choices=PhoneNumber.TYPES)}
 
 
-class AlternativeEmailsForm(ModelEditForm):
+class AlternativeEmailsForm(ModelForm):
     notifications = CharField(required=False, widget=Select(choices=((True, "Yes"), (False, "No"))))
 
     def __init__(self, *args, **kwargs):
@@ -133,7 +133,7 @@ class AlternativeEmailsForm(ModelEditForm):
         }
 
 
-class PersonalEmailForm(ModelEditForm):
+class PersonalEmailForm(ModelForm):
     PRIMARY = "PRIMARY"
     notifications = CharField(
         required=False, widget=Select(choices=((PRIMARY, "Primary"), (True, "Yes"), (False, "No")))

--- a/web/forms/forms.py
+++ b/web/forms/forms.py
@@ -1,7 +1,0 @@
-from django.forms import ModelForm
-
-from .mixins import ReadonlyFormMixin
-
-
-class ModelDisplayForm(ReadonlyFormMixin, ModelForm):
-    pass

--- a/web/forms/forms.py
+++ b/web/forms/forms.py
@@ -1,11 +1,6 @@
 from django.forms import ModelForm
-from django_filters import FilterSet
 
 from .mixins import ReadonlyFormMixin
-
-
-class ModelSearchFilter(FilterSet):
-    pass
 
 
 class ModelDisplayForm(ReadonlyFormMixin, ModelForm):

--- a/web/forms/forms.py
+++ b/web/forms/forms.py
@@ -8,9 +8,5 @@ class ModelSearchFilter(FilterSet):
     pass
 
 
-class ModelEditForm(ModelForm):
-    pass
-
-
 class ModelDisplayForm(ReadonlyFormMixin, ModelForm):
     pass


### PR DESCRIPTION
Allow to use django.forms.ModelForm when declaring forms
and django_filters.FilterSet when creating search filters