### PR TITLE
Fix typo json returns `company_number` not `companyNumber`

### DIFF
--- a/web/templates/web/domains/importer/search-companies.html
+++ b/web/templates/web/domains/importer/search-companies.html
@@ -49,11 +49,11 @@
 
           for (row of data['items']) {
               status = row['company_status'];
-              companyNumber = row['companyNumber'];
+              companyNumber = row['company_number'];
               companyInfo[companyNumber] = row;
 
               if (status === 'active') {
-                  companyNumber = '<a href="#" class="select-company">' + row['companyNumber'] + '</a>';
+                  companyNumber = '<a href="#" class="select-company">' + companyNumber + '</a>';
               }
 
               html = [


### PR DESCRIPTION
When querying companies house company number is returned as
`company_number`.

The bug is avoiding company number to be displayed when associating an
organisation with a company.