### PR TITLE
Use latest python (3.7.x) for cloudfoundry

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.6
+python-3.7.x


### PR DESCRIPTION
See https://docs.cloudfoundry.org/buildpacks/python/index.html#runtime

To request the latest Python version in a patch line, replace the patch version
with x: 3.6.x. To request the latest version in a minor line, replace the minor
version: 3.x.