### PR TITLE
ICMSLST-86 Add edit screen for "CFS Schedule translation".

### DIFF
--- a/web/domains/template/views.py
+++ b/web/domains/template/views.py
@@ -210,5 +210,35 @@ def create_cfs_schedule_translation(request):
 @login_required
 @permission_required("web.reference_data_access", raise_exception=True)
 def edit_cfs_schedule_translation(request, pk):
-    # TODO: impl
-    raise NotImplementedError("blaa")
+    template = get_object_or_404(Template, pk=pk)
+
+    assert template.template_type == Template.CFS_SCHEDULE_TRANSLATION
+
+    english_template = get_object_or_404(Template, template_type=Template.CFS_SCHEDULE)
+    english_paras = english_template.paragraphs.all()
+
+    assert len(english_paras) > 0
+
+    if request.POST:
+        form = CFSScheduleTranslationForm(request.POST, instance=template)
+
+        if form.is_valid():
+            template = form.save()
+
+            return redirect(
+                reverse("template-cfs-schedule-translation-edit", kwargs={"pk": template.pk})
+            )
+    else:
+        form = CFSScheduleTranslationForm(instance=template)
+
+    translations = {para.name: para.content for para in template.paragraphs.all()}
+
+    context = {
+        "object": template,
+        "form": form,
+        "page_title": "Edit CFS Schedule translation",
+        "english_paras": english_paras,
+        "translations": translations,
+    }
+
+    return render(request, "web/domains/template/edit-cfs-schedule-translation.html", context)

--- a/web/templates/web/domains/template/edit-cfs-schedule-translation.html
+++ b/web/templates/web/domains/template/edit-cfs-schedule-translation.html
@@ -3,5 +3,33 @@
 {% block main_content %}
   {{ super() }}
 
-  <p>TODO: list translations here, have an "Edit" buttong linking to template-cfs-schedule-translation-paragraphs-edit</p>
+  <h3>Translations</h3>
+
+  <a href="{{ url('template-cfs-schedule-translation-paragraphs-edit', kwargs={'pk': object.pk }) }}"
+     class="button small-button icon-pencil">
+     Edit
+  </a>
+
+  <table>
+    <tr>
+        <td style="width: 30%"><label>English</label></td>
+        <td style="vertical-align: top; width: 70%"><label>Translation</label></td>
+    </tr>
+    {% for para in english_paras %}
+      <tr>
+        <td>
+          <p>{{ para.content }}</p>
+        </td>
+        <td>
+          {{ translations.get(para.name, '') }}
+        </td>
+      </tr>
+      <tr>
+        <td colspan="2">
+            <hr>
+        </td>
+      </tr>
+    {% endfor %}
+</table>
+
 {% endblock %}


### PR DESCRIPTION
Note that this is not for the translations themselves, just for the
template-level data (name, countries, etc). It does show the translations
and contains a link to edit them (upcoming ticket).

Looks like this: 
![image](https://user-images.githubusercontent.com/23551/104622861-b01b0080-5689-11eb-8d84-049b079e8f44.png)
