### PR TITLE
Icmslst 486 add endorsements licence dates

### DIFF
--- a/web/domains/case/_import/derogations/views.py
+++ b/web/domains/case/_import/derogations/views.py
@@ -129,7 +129,7 @@ def delete_supporting_document(
 
 @login_required
 @permission_required("web.importer_access", raise_exception=True)
-def submit_derogations(request, pk: int) -> HttpResponse:
+def submit_derogations(request: HttpRequest, pk: int) -> HttpResponse:
     with transaction.atomic():
         application = get_object_or_404(DerogationsApplication.objects.select_for_update(), pk=pk)
         task = application.get_task(ImportApplication.IN_PROGRESS, "prepare")
@@ -155,6 +155,20 @@ def submit_derogations(request, pk: int) -> HttpResponse:
                 application.status = ImportApplication.SUBMITTED
                 application.submit_datetime = timezone.now()
                 application.save()
+
+                # TODO: replace with Endorsement Usage Template (ICMSLST-638)
+                first_endorsement = Template.objects.get(
+                    is_active=True,
+                    template_type=Template.ENDORSEMENT,
+                    template_name="Endorsement 1 (must be updated each year)",
+                )
+                application.endorsements.create(content=first_endorsement.template_content)
+                second_endorsement = Template.objects.get(
+                    is_active=True,
+                    template_type=Template.ENDORSEMENT,
+                    template_name="Endorsement 15",
+                )
+                application.endorsements.create(content=second_endorsement.template_content)
 
                 task.is_active = False
                 task.finished = timezone.now()

--- a/web/domains/case/_import/firearms/views.py
+++ b/web/domains/case/_import/firearms/views.py
@@ -437,6 +437,7 @@ def submit_oil(request: HttpRequest, pk: int) -> HttpResponse:
                 )
                 application.save()
 
+                # TODO: replace with Endorsement Usage Template (ICMSLST-638)
                 endorsement = Template.objects.get(
                     is_active=True,
                     template_type=Template.ENDORSEMENT,

--- a/web/domains/case/_import/firearms/views.py
+++ b/web/domains/case/_import/firearms/views.py
@@ -4,7 +4,8 @@ from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.forms.models import model_to_dict
 from django.http import HttpRequest, HttpResponse
-from django.shortcuts import get_object_or_404, redirect, render, reverse
+from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
 from django.utils import timezone
 from django.views.decorators.http import require_GET, require_POST
 from s3chunkuploader.file_handler import s3_client

--- a/web/domains/case/_import/sanctions/views.py
+++ b/web/domains/case/_import/sanctions/views.py
@@ -5,7 +5,8 @@ from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.forms.models import model_to_dict
 from django.http import HttpRequest, HttpResponse
-from django.shortcuts import get_object_or_404, redirect, render, reverse
+from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
 from django.utils import timezone
 from django.views.decorators.http import require_GET, require_POST
 from s3chunkuploader.file_handler import s3_client


### PR DESCRIPTION
- Add default endorsements to Derogations;
- Set licence_start_date when case is taken by ILB Admin.

And add tickets to use endorsement usages instead of endorsements.
Endorsement usages are managed by ILB Admins. They allow to link an
application type with endorsements. Which in turn are used to generate
the licence.