### PR TITLE
ICMSLST-636 Use single-file uploads for importer/firearms.

### DIFF
--- a/web/domains/importer/urls.py
+++ b/web/domains/importer/urls.py
@@ -19,36 +19,27 @@ urlpatterns = [
         views.delete_contact,
         name="importer-contact-delete",
     ),
-    # firearms authorities
+    # firearms authority
     path(
-        "<int:pk>/firearms-authorities/create/",
-        firearms_views.create_firearms_authorities,
-        name="importer-firearms-authorities-create",
+        "<int:pk>/firearms/create/", firearms_views.create_firearms, name="importer-firearms-create"
+    ),
+    path("firearms/<int:pk>/edit/", firearms_views.edit_firearms, name="importer-firearms-edit"),
+    path("firearms/<int:pk>/view/", firearms_views.view_firearms, name="importer-firearms-view"),
+    path(
+        "firearms/<int:pk>/archive/",
+        firearms_views.archive_firearms,
+        name="importer-firearms-archive",
     ),
     path(
-        "<int:importer_pk>/firearms-authorities/<int:firearms_authority_pk>/edit/",
-        firearms_views.edit_firearms_authorities,
-        name="importer-firearms-authorities-edit",
+        "firearms/<int:pk>/unarchive/",
+        firearms_views.unarchive_firearms,
+        name="importer-firearms-unarchive",
     ),
+    # firearms authority - documents
     path(
-        "<int:importer_pk>/firearms-authorities/<int:firearms_authority_pk>/",
-        firearms_views.detail_firearms_authorities,
-        name="importer-firearms-authorities-detail",
-    ),
-    path(
-        "<int:importer_pk>/firearms-authorities/<int:firearms_authority_pk>/archive/",
-        firearms_views.archive_firearms_authorities,
-        name="importer-firearms-authorities-archive",
-    ),
-    path(
-        "<int:importer_pk>/firearms-authorities/<int:firearms_authority_pk>/unarchive/",
-        firearms_views.unarchive_firearms_authorities,
-        name="importer-firearms-authorities-unarchive",
-    ),
-    path(
-        "<int:importer_pk>/firearms-authorities/<int:firearms_authority_pk>/files/<int:file_pk>/",
-        firearms_views.archive_file_firearms_authorities,
-        name="importer-firearms-authorities-file-archive",
+        "firearms/<int:firearms_pk>/delete-document/<int:document_pk>/",
+        firearms_views.delete_document_firearms,
+        name="importer-firearms-delete-document",
     ),
     # section 5 authority
     path("<int:pk>/section5/create/", views.create_section5, name="importer-section5-create"),

--- a/web/domains/importer/urls.py
+++ b/web/domains/importer/urls.py
@@ -37,6 +37,16 @@ urlpatterns = [
     ),
     # firearms authority - documents
     path(
+        "firearms/<int:pk>/add-document/",
+        firearms_views.add_document_firearms,
+        name="importer-firearms-add-document",
+    ),
+    path(
+        "firearms/<int:firearms_pk>/view-document/<int:document_pk>/",
+        firearms_views.view_document_firearms,
+        name="importer-firearms-view-document",
+    ),
+    path(
         "firearms/<int:firearms_pk>/delete-document/<int:document_pk>/",
         firearms_views.delete_document_firearms,
         name="importer-firearms-delete-document",

--- a/web/templates/partial/firearms-authorities.html
+++ b/web/templates/partial/firearms-authorities.html
@@ -32,7 +32,7 @@
     <ul class="menu-out flow-across">
       <li>
         <a
-          href="{{ icms_url('importer-firearms-authorities-create', kwargs={'pk': object.pk}) }}"
+          href="{{ icms_url('importer-firearms-create', kwargs={'pk': object.pk}) }}"
           class="button small-button icon-plus">
           Create Firearms Authority</a>
       </li>

--- a/web/templates/partial/firearms-authorities/list.html
+++ b/web/templates/partial/firearms-authorities/list.html
@@ -18,9 +18,7 @@
     <tr>
       <td>
         <a
-          href="{{ icms_url(
-                     'importer-firearms-authorities-detail',
-                     args=[object.pk, firearms_authority.pk]) }}">
+          href="{{ icms_url('importer-firearms-view', args=[firearms_authority.pk]) }}">
           {{ firearms_authority.reference }}
         </a>
       </td>
@@ -33,20 +31,20 @@
       {% if not read_only %}
         <td>
           <a
-            href="{{ icms_url('importer-firearms-authorities-edit', args=[object.pk, firearms_authority.pk]) }}"
+            href="{{ icms_url('importer-firearms-edit', args=[firearms_authority.pk]) }}"
             class="button small-button icon-pencil">
             Edit
           </a>
           {% if firearms_authority.is_active %}
             <form method="post"
-                  action="{{ icms_url('importer-firearms-authorities-archive', args=[object.pk, firearms_authority.pk]) }}"
+                  action="{{ icms_url('importer-firearms-archive', args=[firearms_authority.pk]) }}"
                   class="form-inline">
               {{ csrf_input }}
               <button type="submit" class="button small-button icon-bin">Archive</button>
             </form>
           {% else %}
             <form method="post"
-                  action="{{ icms_url('importer-firearms-authorities-unarchive', args=[object.pk, firearms_authority.pk]) }}"
+                  action="{{ icms_url('importer-firearms-unarchive', args=[firearms_authority.pk]) }}"
                   class="form-inline">
               {{ csrf_input }}
               <button type="submit" class="button small-button icon-bin">Restore</button>

--- a/web/templates/web/domains/case/import/firearms/manage-constabulary-emails.html
+++ b/web/templates/web/domains/case/import/firearms/manage-constabulary-emails.html
@@ -87,7 +87,7 @@
                   </td>
                   <td>
                     <a
-                      href="{{ icms_url('importer-firearms-authorities-edit', args=[process.importer.pk, certificate.firearms_authority.pk]) }}">
+                      href="{{ icms_url('importer-firearms-edit', args=[certificate.firearms_authority.pk]) }}">
                       View Details
                     </a>
                   </td>

--- a/web/templates/web/domains/importer/add-document-firearms.html
+++ b/web/templates/web/domains/importer/add-document-firearms.html
@@ -1,0 +1,37 @@
+{% extends "layout/sidebar.html" %}
+{% import "forms/forms.html" as forms %}
+{% import "forms/fields.html" as fields %}
+
+{% block css %}
+  {{ form.media.css }}
+  {{ super() }}
+{% endblock %}
+
+{% block sidebar %}
+    {% include "partial/importer/sidebar.html" %}
+{% endblock %}
+
+{% block context_header %}
+  Edit Firearms Authority ({{ firearms.reference }}) for Importer '{{ importer.display_name }}'
+{% endblock %}
+
+{% block content_actions %}
+  <div class="content-actions">
+    <ul class="menu-out flow-across">
+      <li>
+        <a href="{{ icms_url('importer-firearms-edit', kwargs={'pk': firearms.pk}) }}" class="prev-link">
+            Firearms Authority ({{ firearms.reference }})
+        </a>
+      </li>
+    </ul>
+  </div>
+{% endblock %}
+
+{% block main_content %}
+  <h4>Add document</h4>
+  {% call forms.form(action='', method='post', csrf_input=csrf_input, enctype='multipart/form-data') -%}
+    {{ fields.field(form.document) }}
+    <input type="submit" name="action" class="primary-button button" value="Add" />
+  {% endcall %}
+
+{% endblock %}

--- a/web/templates/web/domains/importer/detail-firearms-authority.html
+++ b/web/templates/web/domains/importer/detail-firearms-authority.html
@@ -93,7 +93,7 @@
           </tr>
         </thead>
         <tbody>
-        {% for document in firearms_authority.files.all() %}
+        {% for document in firearms_authority.files.active() %}
           <tr>
             <td>
               {{ document.filename }}<br />

--- a/web/templates/web/domains/importer/detail-firearms-authority.html
+++ b/web/templates/web/domains/importer/detail-firearms-authority.html
@@ -84,7 +84,7 @@
       Documents
     </dt>
     <dd>
-    {% if firearms_authority.files.exists() %}
+    {% if firearms_authority.files.active() %}
       <table class="setoutList">
         <thead>
           <tr>
@@ -96,7 +96,10 @@
         {% for document in firearms_authority.files.active() %}
           <tr>
             <td>
-              {{ document.filename }}<br />
+              <a href="{{ icms_url('importer-firearms-view-document', kwargs={'firearms_pk': firearms_authority.pk, 'document_pk': document.pk}) }}">
+                {{ document.filename }}
+              </a>
+              <br />
               <span class="extra-info">{{ document.file_size }}</span>
             </td>
             <td>

--- a/web/templates/web/domains/importer/detail-section5-authority.html
+++ b/web/templates/web/domains/importer/detail-section5-authority.html
@@ -84,7 +84,7 @@
       Documents
     </dt>
     <dd>
-    {% if section5.files.exists() %}
+    {% if section5.files.active() %}
       <table class="setoutList">
         <thead>
           <tr>

--- a/web/templates/web/domains/importer/edit-firearms-authority.html
+++ b/web/templates/web/domains/importer/edit-firearms-authority.html
@@ -8,7 +8,7 @@
 {% block submit_button %}Save{% endblock %}
 
 {% block firearms_files %}
-  {% if firearms_authority.files.exists() %}
+  {% if firearms_authority.files.active() %}
     <div class="container">
       <div class="row">
         <div class="three columns">
@@ -29,7 +29,10 @@
             {% for document in firearms_authority.files.active() %}
               <tr>
                 <td>
-                  {{ document.filename }}<br />
+                  <a href="{{ icms_url('importer-firearms-view-document', kwargs={'firearms_pk': firearms_authority.pk, 'document_pk': document.pk}) }}">
+                    {{ document.filename }}
+                  </a>
+                  <br />
                   <span class="extra-info">{{ document.file_size|filesizeformat }}</span>
                 </td>
                 <td>
@@ -44,7 +47,7 @@
                             'firearms_pk': firearms_authority.pk,
                             'document_pk': document.pk}) }}>
                     {{ csrf_input }}
-                    <button type="submit" class="button link-button-no-padding">Delete</button>
+                    <button type="submit" class="link-button icon-bin button">Delete</button>
                   </form>
                 </td>
               </tr>
@@ -55,5 +58,19 @@
         <div class="three columns"></div>
       </div>
     </div>
+  {% else %}
+    <div class="info-box info-box-info">
+        There are no documents attached
+    </div>
   {% endif %}
+
+  <div class="container">
+    <div class="row">
+      <a class="button small-button" href="{{ icms_url('importer-firearms-add-document', kwargs={'pk': firearms_authority.pk}) }}">
+        Add document
+      </a>
+    </div>
+  </div>
+
+
 {% endblock %}

--- a/web/templates/web/domains/importer/edit-firearms-authority.html
+++ b/web/templates/web/domains/importer/edit-firearms-authority.html
@@ -39,11 +39,10 @@
                 <td>
                   <form method="post"
                         action={{ icms_url(
-                          'importer-firearms-authorities-file-archive',
+                          'importer-firearms-delete-document',
                           kwargs={
-                            'importer_pk': object.pk,
-                            'firearms_authority_pk': firearms_authority.pk,
-                            'file_pk': document.pk}) }}>
+                            'firearms_pk': firearms_authority.pk,
+                            'document_pk': document.pk}) }}>
                     {{ csrf_input }}
                     <button type="submit" class="button link-button-no-padding">Delete</button>
                   </form>

--- a/web/tests/domains/firearms/test_views.py
+++ b/web/tests/domains/firearms/test_views.py
@@ -61,7 +61,7 @@ def test_create_firearms_authority():
 
     client = Client()
     client.login(username=ilb_admin.username, password="test")
-    response = client.get(f"/importer/{importer.pk}/firearms-authorities/create/")
+    response = client.get(f"/importer/{importer.pk}/firearms/create/")
     assert response.status_code == 200
 
     constabulary = ConstabularyFactory.create(is_active=True)
@@ -82,12 +82,9 @@ def test_create_firearms_authority():
         "actquantity_set-1-firearmsact": firearms_act_two.pk,
         "actquantity_set-1-quantity": "1",
     }
-    response = client.post(f"/importer/{importer.pk}/firearms-authorities/create/", data=data)
+    response = client.post(f"/importer/{importer.pk}/firearms/create/", data=data)
     assert response.status_code == 302
 
-    firearms_authority = FirearmsAuthority.objects.get()
-    assert office_one == firearms_authority.linked_offices.first()
-    assert (
-        response["Location"]
-        == f"/importer/{importer.pk}/firearms-authorities/{firearms_authority.pk}/edit/"
-    )
+    firearms = FirearmsAuthority.objects.get()
+    assert office_one == firearms.linked_offices.first()
+    assert response["Location"] == f"/importer/firearms/{firearms.pk}/edit/"


### PR DESCRIPTION
Also add viewing uploaded documents.

Also clean up importer/firearms authority code.
    
In more detail:

* Remove unnecessary importer_pk from various URLs.
* Shorten URLs / view names / function names by removing "[-_]_authorities".
