### PR TITLE
ICMSLST-671 Make WithdrawApplication re-usable between import/export.

### DIFF
--- a/web/domains/case/_import/forms.py
+++ b/web/domains/case/_import/forms.py
@@ -78,38 +78,6 @@ class CreateWoodQuotaApplicationForm(CreateImportApplicationForm):
         return cleaned_data
 
 
-class WithdrawForm(forms.ModelForm):
-    class Meta:
-        model = models.WithdrawImportApplication
-        fields = ("reason",)
-
-
-class WithdrawResponseForm(forms.ModelForm):
-    STATUSES = (
-        models.WithdrawImportApplication.ACCEPTED,
-        models.WithdrawImportApplication.REJECTED,
-    )
-    status = forms.ChoiceField(label="Withdraw Decision", choices=STATUSES)
-    response = forms.CharField(
-        required=False, label="Withdraw Reject Reason", widget=forms.Textarea
-    )
-
-    class Meta:
-        model = models.WithdrawImportApplication
-        fields = (
-            "status",
-            "response",
-        )
-
-    def clean(self):
-        cleaned_data = super().clean()
-        if (
-            cleaned_data.get("status") == models.WithdrawImportApplication.STATUS_REJECTED
-            and cleaned_data.get("response") == ""
-        ):
-            self.add_error("response", "This field is required when Withdrawal is refused")
-
-
 class ResponsePreparationForm(forms.ModelForm):
     class Meta:
         model = models.ImportApplication

--- a/web/domains/case/_import/models.py
+++ b/web/domains/case/_import/models.py
@@ -298,41 +298,6 @@ class ImportContact(models.Model):
     updated_datetime = models.DateTimeField(auto_now=True)
 
 
-class WithdrawImportApplication(models.Model):
-    STATUS_OPEN = "open"
-    STATUS_REJECTED = "rejected"
-    STATUS_ACCEPTED = "accepted"
-
-    OPEN = (STATUS_OPEN, "OPEN")
-    REJECTED = (STATUS_REJECTED, "REJECTED")
-    ACCEPTED = (STATUS_ACCEPTED, "ACCEPTED")
-    STATUSES = (OPEN, REJECTED, ACCEPTED)
-
-    import_application = models.ForeignKey(
-        ImportApplication, on_delete=models.PROTECT, related_name="withdrawals"
-    )
-    is_active = models.BooleanField(default=True)
-    status = models.CharField(max_length=10, choices=STATUSES, default=STATUS_OPEN)
-    reason = models.TextField()
-    request_by = models.ForeignKey(
-        User,
-        on_delete=models.PROTECT,
-        related_name="+",
-    )
-
-    response = models.TextField()
-    response_by = models.ForeignKey(
-        User,
-        on_delete=models.PROTECT,
-        blank=True,
-        null=True,
-        related_name="+",
-    )
-
-    created_datetime = models.DateTimeField(auto_now_add=True)
-    updated_datetime = models.DateTimeField(auto_now=True)
-
-
 class EndorsementImportApplication(models.Model):
     import_application = models.ForeignKey(
         ImportApplication, on_delete=models.PROTECT, related_name="endorsements"

--- a/web/domains/case/forms.py
+++ b/web/domains/case/forms.py
@@ -1,6 +1,11 @@
 from django import forms
 
-from web.domains.case.models import CASE_NOTE_STATUSES, CaseNote, UpdateRequest
+from web.domains.case.models import (
+    CASE_NOTE_STATUSES,
+    CaseNote,
+    UpdateRequest,
+    WithdrawApplication,
+)
 from web.domains.file.utils import ICMSFileField
 
 
@@ -29,3 +34,33 @@ class UpdateRequestForm(forms.ModelForm):
     class Meta:
         model = UpdateRequest
         fields = ("request_subject", "email_cc_address_list", "request_detail")
+
+
+class WithdrawForm(forms.ModelForm):
+    class Meta:
+        model = WithdrawApplication
+        fields = ("reason",)
+
+
+class WithdrawResponseForm(forms.ModelForm):
+    STATUSES = (WithdrawApplication.ACCEPTED, WithdrawApplication.REJECTED)
+
+    status = forms.ChoiceField(label="Withdraw Decision", choices=STATUSES)
+    response = forms.CharField(
+        required=False, label="Withdraw Reject Reason", widget=forms.Textarea
+    )
+
+    class Meta:
+        model = WithdrawApplication
+        fields = (
+            "status",
+            "response",
+        )
+
+    def clean(self):
+        cleaned_data = super().clean()
+        if (
+            cleaned_data.get("status") == WithdrawApplication.STATUS_REJECTED
+            and cleaned_data.get("response") == ""
+        ):
+            self.add_error("response", "This field is required when Withdrawal is refused")

--- a/web/migrations/0020_withdrawimportapplication.py
+++ b/web/migrations/0020_withdrawimportapplication.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.CreateModel(
-            name="WithdrawImportApplication",
+            name="WithdrawApplication",
             fields=[
                 (
                     "id",
@@ -38,8 +38,18 @@ class Migration(migrations.Migration):
                 ("created_datetime", models.DateTimeField(auto_now_add=True)),
                 ("updated_datetime", models.DateTimeField(auto_now=True)),
                 (
+                    "export_application",
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="withdrawals",
+                        to="web.exportapplication",
+                    ),
+                ),
+                (
                     "import_application",
                     models.ForeignKey(
+                        null=True,
                         on_delete=django.db.models.deletion.PROTECT,
                         related_name="withdrawals",
                         to="web.importapplication",
@@ -62,5 +72,27 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
+        ),
+        migrations.AddConstraint(
+            model_name="withdrawapplication",
+            constraint=models.CheckConstraint(
+                check=models.Q(
+                    ("import_application__isnull", False),
+                    ("export_application__isnull", False),
+                    _connector="OR",
+                ),
+                name="application_one_null",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="withdrawapplication",
+            constraint=models.CheckConstraint(
+                check=models.Q(
+                    ("import_application__isnull", True),
+                    ("export_application__isnull", True),
+                    _connector="OR",
+                ),
+                name="application_one_not_null",
+            ),
         ),
     ]

--- a/web/templates/web/domains/workbasket/partials/import-case.html
+++ b/web/templates/web/domains/workbasket/partials/import-case.html
@@ -22,6 +22,9 @@
     {% for task in process.tasks.all() %}
       {% if request.user.has_perm("web.reference_data_access") %}
         {% include 'web/domains/workbasket/partials/workbasket-item.html' %}
+
+        {# TODO: this is not the right thing, but we need to be able to test the system #}
+        {% include 'web/domains/workbasket/partials/workbasket-item-user.html' %}
       {% else %}
         {% include 'web/domains/workbasket/partials/workbasket-item-user.html' %}
       {% endif %}


### PR DESCRIPTION
The postgres-level DB constraints created:

```
Check constraints:
    "application_one_not_null" CHECK (import_application_id IS NULL OR export_application_id IS NULL)
    "application_one_null" CHECK (import_application_id IS NOT NULL OR export_application_id IS NOT NULL)
```

Test to check they work as expected:

```
# both null, refused
>>> WithdrawApplication.objects.create(request_by=me)
django.db.utils.IntegrityError: new row for relation "web_withdrawapplication" violates check constraint "application_one_null"


# both set, refused
>>> WithdrawApplication.objects.create(request_by=me, import_application=imp, export_application=exp)
django.db.utils.IntegrityError: new row for relation "web_withdrawapplication" violates check constraint "application_one_not_null"

# import set, accepted
>>> WithdrawApplication.objects.create(request_by=me, import_application=imp)<WithdrawApplication: WithdrawApplication object (4)>

# export set, accepted
>>> WithdrawApplication.objects.create(request_by=me, export_application=exp)
<WithdrawApplication: WithdrawApplication object (5)>
```