### PR TITLE
ICMSLST-669 Clean up import/licence code.

### DIFF
--- a/web/domains/case/_import/urls.py
+++ b/web/domains/case/_import/urls.py
@@ -55,15 +55,16 @@ urlpatterns = [
         "case/<int:application_pk>/",
         include(
             [
-                # endorsements and cover letters are import-specific, no reason to move them up to case-level
+                # endorsements, cover letters, and licences are import-specific,
+                # no reason to move them up to case-level
                 path("endorsements/", include(endorsements_urls)),
                 path("cover-letter/edit/", views.edit_cover_letter, name="edit-cover-letter"),
                 path(
                     "cover-letter/preview/", views.preview_cover_letter, name="preview-cover-letter"
                 ),
-                #
-                path("licence/", views.edit_licence, name="edit-licence"),
+                path("licence/edit", views.edit_licence, name="edit-licence"),
                 path("licence/preview/", views.preview_licence, name="preview-licence"),
+                #
                 path("authorisation/", views.authorisation, name="authorisation"),
                 path("start-authorisation/", views.start_authorisation, name="start-authorisation"),
                 path(

--- a/web/domains/case/_import/views.py
+++ b/web/domains/case/_import/views.py
@@ -12,7 +12,7 @@ from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
 from django.urls import reverse
-from django.views.decorators.http import require_POST
+from django.views.decorators.http import require_GET, require_POST
 from django.views.generic import TemplateView
 
 from web.flow.models import Task
@@ -217,9 +217,9 @@ def edit_cover_letter(request: HttpRequest, *, application_pk: int) -> HttpRespo
 
 @login_required
 @permission_required("web.reference_data_access", raise_exception=True)
-def edit_licence(request, application_pk):
+def edit_licence(request: HttpRequest, *, application_pk: int) -> HttpResponse:
     with transaction.atomic():
-        application = get_object_or_404(
+        application: ImportApplication = get_object_or_404(
             ImportApplication.objects.select_for_update(), pk=application_pk
         )
         task = application.get_task(
@@ -383,6 +383,7 @@ def delete_endorsement(
 
 @login_required
 @permission_required("web.reference_data_access", raise_exception=True)
+@require_GET
 def preview_cover_letter(request: HttpRequest, *, application_pk: int) -> HttpResponse:
     with transaction.atomic():
         application: ImportApplication = get_object_or_404(
@@ -417,9 +418,10 @@ def preview_cover_letter(request: HttpRequest, *, application_pk: int) -> HttpRe
 
 @login_required
 @permission_required("web.reference_data_access", raise_exception=True)
-def preview_licence(request, application_pk):
+@require_GET
+def preview_licence(request: HttpRequest, *, application_pk: int) -> HttpResponse:
     with transaction.atomic():
-        application = get_object_or_404(
+        application: ImportApplication = get_object_or_404(
             ImportApplication.objects.select_for_update(), pk=application_pk
         )
         task = application.get_task(
@@ -433,6 +435,9 @@ def preview_licence(request, application_pk):
             "issue_date": application.licence_issue_date.strftime("%d %B %Y"),
         }
 
+        # TODO: preview-licence.html contents are hard-coded and seem to be for
+        # a specific type of firearms application. needs to be generalized for
+        # other application types.
         html_string = render_to_string(
             request=request,
             template_name="web/domains/case/import/manage/preview-licence.html",

--- a/web/domains/case/urls.py
+++ b/web/domains/case/urls.py
@@ -120,10 +120,6 @@ urlpatterns = [
                 # misc stuff (import/export)
                 path("prepare-response/", views.prepare_response, name="prepare-response"),
                 #
-                # TODO: ICMSLST-669
-                # path("licence/", views.edit_licence, name="edit-licence"),
-                # path("licence/preview/", views.preview_licence, name="preview-licence"),
-                #
                 # TODO: ICMSLST-681
                 # path("authorisation/", views.authorisation, name="authorisation"),
                 # path(

--- a/web/domains/case/views.py
+++ b/web/domains/case/views.py
@@ -1230,9 +1230,12 @@ def prepare_response(request: HttpRequest, application_pk: int, case_type: str) 
         else:
             form = forms.ResponsePreparationForm()
 
-        cover_letter_flag = (
-            application.application_type.cover_letter_flag if case_type == "import" else False
-        )
+        if case_type == "import":
+            cover_letter_flag = application.application_type.cover_letter_flag
+            electronic_licence_flag = application.application_type.electronic_licence_flag
+        else:
+            cover_letter_flag = False
+            electronic_licence_flag = False
 
         context = {
             "case_type": case_type,
@@ -1240,6 +1243,7 @@ def prepare_response(request: HttpRequest, application_pk: int, case_type: str) 
             "page_title": "Response Preparation",
             "form": form,
             "cover_letter_flag": cover_letter_flag,
+            "electronic_licence_flag": electronic_licence_flag,
         }
 
     if application.process_type == OpenIndividualLicenceApplication.PROCESS_TYPE:

--- a/web/templates/partial/case/export/sidebar-management.html
+++ b/web/templates/partial/case/export/sidebar-management.html
@@ -3,10 +3,6 @@
   <li>
     <a href="{{ icms_url('case:manage', kwargs={'application_pk': process.pk, 'case_type': 'export'}) }}">Case {{ process.pk }}</a>
   </li>
-  {# TODO: add everything importer has (web/templates/partial/case/import/sidebar-management.html)
-     as working on tickets:
-       - ICMSLST-669
-  #}
   <li>
     {% with total = process.withdrawals.count(),
             processed = process.withdrawals.exclude(status="open").count() %}
@@ -44,6 +40,10 @@
     <a href="{{ icms_url('case:prepare-response', kwargs={'case_type': 'export', 'application_pk': process.pk}) }}">Response Preparation</a>
   </li>
   <li>
-    <a href="#">Authorisation</a>
+    {# TODO: add everything importer has (web/templates/partial/case/import/sidebar-management.html)
+      as working on tickets:
+        - ICMSLST-681
+    #}
+     <a href="#">Authorisation</a>
   </li>
 </ul>

--- a/web/templates/web/domains/case/import/manage/prepare-response.html
+++ b/web/templates/web/domains/case/import/manage/prepare-response.html
@@ -17,7 +17,7 @@
 
     {% if electronic_licence_flag %}
       <a
-        href="{{ icms_url('import:preview-licence', args=[process.pk]) }}"
+        href="{{ icms_url('import:preview-licence', kwargs={'application_pk': process.pk}) }}"
         target="blank"
         class="button">
         Preview Licence
@@ -93,7 +93,7 @@
           </td>
           <td>
             <a
-              href="{{ icms_url('import:edit-licence', args=[process.pk]) }}">
+              href="{{ icms_url('import:edit-licence', kwargs={'application_pk': process.pk}) }}">
               Edit
             </a>
         </tr>


### PR DESCRIPTION
Licences are only used for import applications, so it doesn't make sense
to move them up to case/views level.