### PR TITLE
ICMSLST-634 Fix/work around mypy issues found by django-stubs.

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -7,3 +7,10 @@ check_untyped_defs = True
 
 ; [mypy-web.*]
 ; disallow_untyped_defs = True
+
+# ICMSLST-634 Note: Even if you comment out these sections you will see error if
+# you have the package installed in your venv.
+# plugins = mypy_django_plugin.main
+
+# [mypy.plugins.django-stubs]
+# django_settings_module = "config.settings.development"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,13 +6,16 @@ behave-django==1.4.0
 black==20.8b1
 django-debug-toolbar==3.2.1
 django-extensions==3.1.0
+# django-stubs==1.8.0
 factory-boy==3.0.1
 faker==4.1.2
 flake8==3.8.3
 ipdb==0.13.3
 isort==5.6.4
-mypy==0.812
+mypy==0.910
 pip-check==2.6
+Pygments==2.8.1
+pygraphviz==1.7
 pyparsing==2.4.7
 pytest-cov==2.10.1
 pytest-django==4.1.0
@@ -22,6 +25,6 @@ pytest-xdist==1.32.0
 pytest==6.0.1
 PyYAML==5.4.1
 selenium==3.141.0
-Pygments==2.8.1
-pygraphviz==1.7
 sqlparse==0.4.1
+types-pytz==2021.1.0
+types-requests==2.25.0

--- a/web/auth/views.py
+++ b/web/auth/views.py
@@ -64,7 +64,7 @@ def update_password(request):
     )
 
     if form.is_valid():
-        user = form.save(commit=False)
+        user: User = form.save(commit=False)  # type:ignore[assignment]
         user.password_disposition = User.FULL
         user.save()
         update_session_auth_hash(request, user)  # keep user logged in
@@ -80,10 +80,12 @@ def reset_password(request):
     if action == "reset_password":
         user = User.objects.get(username=login_id)
         form = ResetPasswordSecondForm(user, request.POST or None)
+
         if form.is_valid():
             temp_pass = user.set_temp_password()
             user.save()
             notify.register(user, temp_pass)
+
             return render(request, "auth/reset-password/reset-password-success.html")
 
         return render(
@@ -93,10 +95,12 @@ def reset_password(request):
         )
 
     form = ResetPasswordForm(request.POST or None)
+
     if form.is_valid():
         try:
             user = User.objects.get(username=form.cleaned_data.get("login_id", ""))
             form = ResetPasswordSecondForm(user)
+
             return render(
                 request,
                 "auth/reset-password/reset-password-2.html",

--- a/web/domains/case/_import/derogations/views.py
+++ b/web/domains/case/_import/derogations/views.py
@@ -219,9 +219,13 @@ def manage_checklist(request: AuthenticatedHttpRequest, *, application_pk) -> Ht
         )
 
         if request.POST:
-            form = DerogationsChecklistOptionalForm(request.POST, instance=checklist)
+            form: DerogationsChecklistForm = DerogationsChecklistOptionalForm(
+                request.POST, instance=checklist
+            )
+
             if form.is_valid():
                 form.save()
+
                 return redirect(
                     reverse(
                         "import:derogations:manage-checklist",

--- a/web/domains/case/_import/fa_dfl/views.py
+++ b/web/domains/case/_import/fa_dfl/views.py
@@ -344,7 +344,7 @@ def manage_checklist(request: AuthenticatedHttpRequest, *, application_pk):
         checklist, created = DFLChecklist.objects.get_or_create(import_application=application)
 
         if request.POST:
-            form = DFLChecklistOptionalForm(request.POST, instance=checklist)
+            form: DFLChecklistForm = DFLChecklistOptionalForm(request.POST, instance=checklist)
 
             if form.is_valid():
                 form.save()

--- a/web/domains/case/_import/fa_oil/views.py
+++ b/web/domains/case/_import/fa_oil/views.py
@@ -178,7 +178,10 @@ def manage_checklist(request: AuthenticatedHttpRequest, *, application_pk: int) 
         )
 
         if request.POST:
-            form = ChecklistFirearmsOILApplicationOptionalForm(request.POST, instance=checklist)
+            form: ChecklistFirearmsOILApplicationForm = ChecklistFirearmsOILApplicationOptionalForm(
+                request.POST, instance=checklist
+            )
+
             if form.is_valid():
                 form.save()
 

--- a/web/domains/case/_import/fa_sil/forms.py
+++ b/web/domains/case/_import/fa_sil/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.html import mark_safe
+from django.utils.safestring import mark_safe
 from django_select2 import forms as s2forms
 from guardian.shortcuts import get_users_with_perms
 

--- a/web/domains/case/_import/fa_sil/views.py
+++ b/web/domains/case/_import/fa_sil/views.py
@@ -722,7 +722,9 @@ def manage_checklist(request: AuthenticatedHttpRequest, *, application_pk: int) 
         )
 
         if request.POST:
-            form = forms.SILChecklistOptionalForm(request.POST, instance=checklist)
+            form: forms.SILChecklistForm = forms.SILChecklistOptionalForm(
+                request.POST, instance=checklist
+            )
 
             if form.is_valid():
                 form.save()

--- a/web/domains/case/_import/models.py
+++ b/web/domains/case/_import/models.py
@@ -292,6 +292,9 @@ class ImportApplication(ApplicationBase):
         else:
             raise NotImplementedError(f"Unknown process_type {self.process_type}")
 
+    def user_is_contact_of_org(self, user: User) -> bool:
+        return user.has_perm("web.is_contact_of_importer", self.importer)
+
     def get_workbasket_subject(self) -> str:
         return "\n".join(
             [

--- a/web/domains/case/_import/opt/views.py
+++ b/web/domains/case/_import/opt/views.py
@@ -487,7 +487,7 @@ def manage_checklist(request: AuthenticatedHttpRequest, *, application_pk):
         checklist, created = OPTChecklist.objects.get_or_create(import_application=application)
 
         if request.POST:
-            form = OPTChecklistOptionalForm(request.POST, instance=checklist)
+            form: OPTChecklistForm = OPTChecklistOptionalForm(request.POST, instance=checklist)
 
             if form.is_valid():
                 form.save()

--- a/web/domains/case/_import/wood/views.py
+++ b/web/domains/case/_import/wood/views.py
@@ -3,7 +3,8 @@ from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.forms.models import model_to_dict
 from django.http import HttpResponse
-from django.shortcuts import get_object_or_404, redirect, render, reverse
+from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
 from django.views.decorators.http import require_GET, require_POST
 
 from web.domains.case._import.models import ImportApplication
@@ -307,7 +308,9 @@ def manage_checklist(request: AuthenticatedHttpRequest, *, application_pk: int) 
         )
 
         if request.POST:
-            form = WoodQuotaChecklistOptionalForm(request.POST, instance=checklist)
+            form: WoodQuotaChecklistForm = WoodQuotaChecklistOptionalForm(
+                request.POST, instance=checklist
+            )
 
             if form.is_valid():
                 form.save()

--- a/web/domains/case/export/models.py
+++ b/web/domains/case/export/models.py
@@ -137,6 +137,9 @@ class ExportApplication(ApplicationBase):
         else:
             raise NotImplementedError(f"Unknown process_type {self.process_type}")
 
+    def user_is_contact_of_org(self, user: User) -> bool:
+        return user.has_perm("web.is_contact_of_exporter", self.exporter)
+
     def get_workbasket_subject(self) -> str:
         return "\n".join(
             [

--- a/web/domains/case/models.py
+++ b/web/domains/case/models.py
@@ -244,6 +244,10 @@ class ApplicationBase(WorkbasketBase, Process):
         """Get the edit view name."""
         raise NotImplementedError
 
+    def user_is_contact_of_org(self, user: User) -> bool:
+        """Is the user a contact of the org (Importer or Exporter)"""
+        raise NotImplementedError
+
     def get_workbasket_subject(self) -> str:
         """Get workbasket subject/topic column content."""
         raise NotImplementedError
@@ -268,10 +272,10 @@ class ApplicationBase(WorkbasketBase, Process):
         r.information = "Application Processing"
 
         if self.is_import_application():
-            r.company = self.importer
+            r.company = self.importer  # type: ignore[attr-defined]
             case_type = "import"
         else:
-            r.company = self.exporter
+            r.company = self.exporter  # type: ignore[attr-defined]
             case_type = "export"
 
         # common kwargs
@@ -287,7 +291,9 @@ class ApplicationBase(WorkbasketBase, Process):
             admin_actions: list[WorkbasketAction] = []
 
             if self.status in [self.Statuses.SUBMITTED, self.Statuses.WITHDRAWN]:
-                if not self.case_owner:
+                case_owner = self.case_owner  # type: ignore[attr-defined]
+
+                if not case_owner:
                     admin_actions.append(
                         WorkbasketAction(
                             is_post=True,
@@ -298,7 +304,7 @@ class ApplicationBase(WorkbasketBase, Process):
 
                     admin_actions.append(view_action)
 
-                elif (self.case_owner == user) and task and task.task_type == "process":
+                elif (case_owner == user) and task and task.task_type == "process":
                     admin_actions.append(
                         WorkbasketAction(
                             is_post=False, name="Manage", url=reverse("case:manage", kwargs=kwargs)
@@ -341,7 +347,7 @@ class ApplicationBase(WorkbasketBase, Process):
                     ),
                 )
 
-                for fir in self.further_information_requests.open():
+                for fir in self.further_information_requests.open():  # type: ignore[attr-defined]
                     applicant_actions.append(
                         WorkbasketAction(
                             is_post=False,

--- a/web/domains/case/utils.py
+++ b/web/domains/case/utils.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from django.utils import timezone
 
 from web.models.models import CaseReference
@@ -13,6 +15,8 @@ def allocate_case_reference(
     layer."""
 
     lock_manager.ensure_tables_are_locked([CaseReference])
+
+    year: Optional[int]
 
     if use_year:
         year = timezone.now().year

--- a/web/domains/file/models.py
+++ b/web/domains/file/models.py
@@ -17,13 +17,13 @@ class ActiveManager(models.Manager):
 class File(Archivable, models.Model):
     objects = ActiveManager()
 
-    is_active = models.BooleanField(blank=False, null=False, default=True)
-    filename = models.CharField(max_length=300, blank=False, null=True)
-    content_type = models.CharField(max_length=100, blank=False, null=True)
-    file_size = models.IntegerField(blank=False, null=True)
-    path = models.CharField(max_length=4000, blank=True, null=True)
-    created_datetime = models.DateTimeField(auto_now_add=True, blank=False, null=True)
-    created_by = models.ForeignKey(User, on_delete=models.PROTECT, blank=False, null=True)
+    is_active = models.BooleanField(default=True)
+    filename = models.CharField(max_length=300)
+    content_type = models.CharField(max_length=100)
+    file_size = models.IntegerField()
+    path = models.CharField(max_length=4000)
+    created_datetime = models.DateTimeField(auto_now_add=True)
+    created_by = models.ForeignKey(User, on_delete=models.PROTECT)
 
     class Meta:
         ordering = ["-created_datetime"]

--- a/web/domains/file/utils.py
+++ b/web/domains/file/utils.py
@@ -1,5 +1,5 @@
 import os.path
-from typing import Any, Dict, Type
+from typing import Any, Dict
 
 from django import forms
 from django.db import models
@@ -54,10 +54,13 @@ def validate_file_extension(file: S3Boto3StorageFile) -> None:
         )
 
 
+# TODO: related_file_manager is something like
+# models.manager.RelatedManager[File], but that's a class Django dynamically
+# creates at runtime, you can't even import it
 def create_file_model(
     f: S3Boto3StorageFile,
     created_by: User,
-    related_file_model: Type[models.ManyToManyField],
+    related_file_manager: Any,
     extra_args: Dict[str, Any] = None,
 ) -> models.Model:
     """Create File (or sub-class) model, add it to the related set. Note that
@@ -68,7 +71,7 @@ def create_file_model(
     if extra_args is None:
         extra_args = {}
 
-    return related_file_model.create(
+    return related_file_manager.create(
         filename=f.original_name,
         file_size=f.file_size,
         content_type=f.content_type,

--- a/web/domains/mailshot/views.py
+++ b/web/domains/mailshot/views.py
@@ -171,12 +171,15 @@ class MailshotDetailView(ModelDetailView):
 
         user: User = self.request.user
         has_permission = super().has_permission()
+
         if has_permission:
             return True
 
-        mailshot = self.get_object()
+        mailshot: Mailshot = self.get_object()  # type:ignore[assignment]
+
         if mailshot.is_to_importers and user.is_importer():
             return True
+
         if mailshot.is_to_exporters and user.is_exporter():
             return True
 
@@ -203,8 +206,10 @@ class MailshotRetractView(ModelUpdateView):
         """
         Add mailshot form into the context for displaying mailshot details
         """
+
         form = super().get_form(*args, **kwargs)
-        self.view_form = MailshotReadonlyForm(instance=self.object)
+        self.view_form = MailshotReadonlyForm(instance=self.object)  # type:ignore[attr-defined]
+
         return form
 
     def handle_notification(self, mailshot):
@@ -220,12 +225,14 @@ class MailshotRetractView(ModelUpdateView):
         mailshot.retracted_datetime = timezone.now()
         mailshot.retracted_by = self.request.user
         response = super().form_valid(form)
+
         if response.status_code == 302 and response.url == self.success_url:
             self.handle_notification(mailshot)
+
         return response
 
     def get_success_message(self, cleaned_data):
-        return f"{self.object} retracted successfully"
+        return f"{self.object} retracted successfully"  # type:ignore[attr-defined]
 
     def get_queryset(self):
         """
@@ -235,4 +242,4 @@ class MailshotRetractView(ModelUpdateView):
         return Mailshot.objects.filter(status=Mailshot.PUBLISHED)
 
     def get_page_title(self):
-        return f"Retract {self.object}"
+        return f"Retract {self.object}"  # type:ignore[attr-defined]

--- a/web/domains/sanction_email/views.py
+++ b/web/domains/sanction_email/views.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.decorators import login_required, permission_required
-from django.shortcuts import get_object_or_404, redirect, render, reverse
+from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
 
 from web.views import ModelFilterView, actions
 

--- a/web/domains/section5/views.py
+++ b/web/domains/section5/views.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.decorators import login_required, permission_required
-from django.shortcuts import get_object_or_404, redirect, render, reverse
+from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
 
 from web.domains.section5.filters import Section5Filter
 from web.domains.section5.forms import Section5ClauseForm

--- a/web/domains/template/views.py
+++ b/web/domains/template/views.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.decorators import login_required, permission_required
 from django.db import transaction
-from django.shortcuts import get_object_or_404, redirect, render, reverse
-from django.urls import reverse_lazy
+from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse, reverse_lazy
 
 from web.views import ModelCreateView, ModelFilterView
 from web.views.actions import Archive, EditTemplate, Unarchive

--- a/web/flow/models.py
+++ b/web/flow/models.py
@@ -34,12 +34,15 @@ class Process(models.Model):
         if not self.is_active:
             raise errors.ProcessInactiveError("Process is not active")
 
+        # status is set as a model field on all derived classes
+        status: str = self.status  # type: ignore[attr-defined]
+
         if isinstance(expected_state, list):
-            if self.status not in expected_state:
-                raise errors.ProcessStateError(f"Process is in the wrong state: {self.status}")
+            if status not in expected_state:
+                raise errors.ProcessStateError(f"Process is in the wrong state: {status}")
         else:
-            if self.status != expected_state:
-                raise errors.ProcessStateError(f"Process is in the wrong state: {self.status}")
+            if status != expected_state:
+                raise errors.ProcessStateError(f"Process is in the wrong state: {status}")
 
         tasks = (
             self.tasks.filter(is_active=True, task_type=task_type)

--- a/web/migrations/0001_initial.py
+++ b/web/migrations/0001_initial.py
@@ -395,16 +395,14 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("is_active", models.BooleanField(default=True)),
-                ("filename", models.CharField(max_length=300, null=True)),
-                ("content_type", models.CharField(max_length=100, null=True)),
-                ("file_size", models.IntegerField(null=True)),
-                ("path", models.CharField(blank=True, max_length=4000, null=True)),
-                ("created_datetime", models.DateTimeField(auto_now_add=True, null=True)),
+                ("filename", models.CharField(max_length=300)),
+                ("content_type", models.CharField(max_length=100)),
+                ("file_size", models.IntegerField()),
+                ("path", models.CharField(max_length=4000)),
+                ("created_datetime", models.DateTimeField(auto_now_add=True)),
                 (
                     "created_by",
-                    models.ForeignKey(
-                        null=True, on_delete=django.db.models.deletion.PROTECT, to="web.user"
-                    ),
+                    models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, to="web.user"),
                 ),
             ],
             options={


### PR DESCRIPTION
This is phase one, still 150+ to go.

In more detail:

 * Upgrade mypy, add types-pytz and types-requests.

 * Fix is_active mypy issues.

 * Ignore attr-defined error for status field.

 * Ignore several attributes that aren't defined in base class.

 * Import reverse from django.urls, not django.shortcuts.

 * Type optional forms.

 * Fix type complaints in mailshot/views.py.

 * Make all File fields non-nullable.

   They do not need to be nullable anymore, we only add valid files to the
   database nowadays.

   Marking them non-nullable removes mypy complaints about Optional[x].

 * Add user_is_contact_of_org method.

 * Type applications with a checklist.

 * Disable warnings for reverse one_to_one relationships.

 * Ignore mypy warnings regarding class type.

 * Fix related_file_manager type.