### PR TITLE
ICMSLST-726 Add tests for FA-DFL applicant views.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,28 +151,11 @@ debug: ## runs system in debug mode
 	ICMS_MIGRATE=False \
 	docker-compose up
 
-run: ## Run with Gunicorn and Whitenoise serving static files
-	unset UID && \
-	ICMS_SECRET_KEY='prod' \
-	DATABASE_URL='postgres://postgres:password@db:5432/postgres' \
-	ICMS_ALLOWED_HOSTS='localhost' \
-	ICMS_RECAPTCHA_PUBLIC_KEY='6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI' \
-	ICMS_RECAPTCHA_PRIVATE_KEY='6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe' \
-	ICMS_EMAIL_FROM='prod@example.com' \
-	ICMS_ADDRESS_API_KEY='prod' \
-	ICMS_SILENCED_SYSTEM_CHECKS='captcha.recaptcha_test_key_error' \
-	AWS_SES_ACCESS_KEY_ID='prod' \
-	AWS_SES_SECRET_ACCESS_KEY='prod' \
-	ELASTIC_APM_ENVIRONMENT='prod-test' \
-	ELASTIC_APM_URL='https://apm.ci.uktrade.io' \
-	DJANGO_SETTINGS_MODULE=config.settings.production \
-	docker-compose up
-
 down: ## Stops and downs containers
 	docker-compose down --remove-orphans
 
-test: ## run tests
-	./run-tests.sh
+test: ## run tests (circleci; don't use locally)
+	./run-tests.sh --numprocesses 2
 
 accessibility: ## Generate accessibility reports
 	unset UID && \

--- a/README.md
+++ b/README.md
@@ -58,12 +58,24 @@ Start everything using docker-compose: `make debug`
 
 Go to http://localhost:8080, login with the superuser account you created earlier.
 
-Above script will start a PostgreSQL database and ICMS app in debug mode. In
-order to run with no debug and Gunicorn server for a production-like environment
-use: `make run`
+Above script will start a PostgreSQL database and ICMS app in debug mode.
 
 Make sure to rebuild the Docker images if new dependencies are added to the
 requirements files: `make build`.
+
+## Testing
+
+To run the unit tests:
+
+`./run-tests.sh`
+
+To run tests for a single file in a non-distributed manner (faster):
+
+`./run-tests.sh --dist=no web/tests/foo/bar.by`
+
+To run tests with a fresh test database:
+
+`./run-tests.sh --create-db`
 
 ## Code style
 

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -26,3 +26,7 @@ CELERY_TASK_ALWAYS_EAGER = True
 SELENIUM_BROWSER = "chrome"
 SELENIUM_HUB_HOST = "selenium-hub"
 SELENIUM_HOST = "web"
+
+
+FILE_UPLOAD_HANDLERS = ("web.tests.file_upload_handler.DummyFileUploadHandler",)  # type: ignore[assignment]
+APP_ENV = "test"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ Pygments==2.8.1
 pygraphviz==1.7
 pyparsing==2.4.7
 pytest-cov==2.10.1
-pytest-django==4.1.0
+pytest-django==4.4.0
 pytest-flake8==1.0.6
 pytest-mock==3.3.1
 pytest-xdist==1.32.0

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -11,5 +11,10 @@ export ICMS_DEBUG=False
 # we have --reuse-db in pytest.ini, so repeated test runs by developers locally
 # are fast. if you change the database schema, you have to do ""./run-test.sh
 # --create-db" to force re-creation of the test database.
+#
+# For speed run with --dist=no when testing a single file
 
 docker-compose run --rm web pytest --tb=short --dist=loadfile --tx=4*popen "$@"
+
+# With coverage
+# docker-compose run --rm web pytest --tb=short --cov=web --cov-report term-missing:skip-covered --dist=loadfile --tx=4*popen "$@"

--- a/web/management/commands/add_test_data.py
+++ b/web/management/commands/add_test_data.py
@@ -1,0 +1,106 @@
+import datetime
+
+from django.conf import settings
+from django.contrib.auth.models import Permission
+from django.core.management.base import BaseCommand, CommandError
+from guardian.shortcuts import assign_perm
+
+from web.domains.importer.models import Importer
+from web.domains.office.models import Office
+from web.domains.user.models import User
+
+
+class Command(BaseCommand):
+    help = """Add test data, called when running unit tests."""
+
+    def handle(self, *args, **options):
+        if settings.APP_ENV != "test":
+            raise CommandError("Can only add test data in 'test' environment!")
+
+        # Assume data is fine if the first user is already created.
+        if User.objects.filter(username="test_import_user").exists():
+            self.stdout.write("Test data already created.")
+
+            return
+
+        self.stdout.write("Adding test data for unit tests.")
+        importer = self.create_importer()
+        self.create_importer_user(importer, "test_import_user")
+        self.create_importer_user(importer, "importer_contact")
+        self.create_icms_admin_user("test_admin_user")
+
+    def create_importer_user(self, importer, username):
+        try:
+            user = User.objects.get(username=username)
+        except User.DoesNotExist:
+            user = User.objects.create_user(
+                username=username,
+                password="test",
+                password_disposition=User.FULL,
+                is_superuser=False,
+                account_status=User.ACTIVE,
+                is_active=True,
+                email=f"{username}@email.com",
+                first_name=f"{username}_first_name",
+                last_name=f"{username}_last_name",
+                date_of_birth=datetime.date(2000, 1, 1),
+                security_question="security_question",
+                security_answer="security_answer",
+            )
+            self._assign_permission(user, "importer_access")
+            assign_perm("web.is_contact_of_importer", user, importer)
+            user.save()
+
+        return user
+
+    def create_icms_admin_user(self, username):
+        try:
+            user = User.objects.get(username=username)
+        except User.DoesNotExist:
+            user = User.objects.create_user(
+                username=username,
+                password="test",
+                password_disposition=User.FULL,
+                is_superuser=False,
+                account_status=User.ACTIVE,
+                is_active=True,
+                email=f"{username}@email.com",
+                first_name=f"{username}_first_name",
+                last_name=f"{username}_last_name",
+                date_of_birth=datetime.date(2000, 1, 1),
+                security_question="security_question",
+                security_answer="security_answer",
+            )
+
+            for perm in [
+                "importer_access",
+                "exporter_access",
+                "reference_data_access",
+                "mailshot_access",
+            ]:
+                self._assign_permission(user, perm)
+
+            user.save()
+
+        return user
+
+    def create_importer(self):
+        office, _ = Office.objects.get_or_create(
+            is_active=True, address="47 some way, someplace", postcode="S410SG"
+        )
+
+        importer, created = Importer.objects.get_or_create(
+            is_active=True,
+            type=Importer.INDIVIDUAL,
+            region_origin=Importer.UK,
+            name="UK based importer",
+        )
+
+        if created:
+            importer.offices.add(office)
+
+        return importer
+
+    def _assign_permission(self, user, permission_codename):
+        permission = Permission.objects.get(codename=permission_codename)
+        user.user_permissions.add(permission)

--- a/web/tests/conftest.py
+++ b/web/tests/conftest.py
@@ -1,5 +1,10 @@
+import pytest
+from django.core.management import call_command
 from django.test import signals
 from jinja2 import Template as Jinja2Template
+
+from web.domains.importer.models import Importer
+from web.domains.office.models import Office
 
 ORIGINAL_JINJA2_RENDERER = Jinja2Template.render
 
@@ -17,3 +22,52 @@ def instrumented_render(template_object, *args, **kwargs):
 
 
 Jinja2Template.render = instrumented_render
+
+
+# https://pytest-django.readthedocs.io/en/latest/database.html#populate-the-test-database-if-you-don-t-use-transactional-or-live-server
+@pytest.fixture(scope="session")
+def django_db_setup(django_db_setup, django_db_blocker):
+    """Create data when setting up the database.
+
+    This data is not lost between test runs if the db is reused
+    See the following file for what data gets added:
+        web/management/commands/add_test_data.py
+    """
+
+    with django_db_blocker.unblock():
+        call_command("add_test_data")
+
+
+@pytest.fixture
+def test_icms_admin_user(django_user_model):
+    """Fixture to get user with admin access (the reference_data_access permission)."""
+    return django_user_model.objects.get(username="test_icms_admin_user")
+
+
+@pytest.fixture
+def test_import_user(django_user_model):
+    """Fixture to get user with access to the test importer."""
+    return django_user_model.objects.get(username="test_import_user")
+
+
+@pytest.fixture
+def importer_contact(django_user_model):
+    """Fixture to get user who is a contact of the test importer."""
+    return django_user_model.objects.get(username="importer_contact")
+
+
+@pytest.fixture
+def office():
+    """Fixture to get an office model instance."""
+    return Office.objects.get(is_active=True, address="47 some way, someplace", postcode="S410SG")
+
+
+@pytest.fixture
+def importer():
+    """Fixture to get an importer model instance."""
+    return Importer.objects.get(
+        is_active=True,
+        type=Importer.INDIVIDUAL,
+        region_origin=Importer.UK,
+        name="UK based importer",
+    )

--- a/web/tests/domains/case/_import/fa_dfl/test_views.py
+++ b/web/tests/domains/case/_import/fa_dfl/test_views.py
@@ -1,0 +1,452 @@
+import re
+
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+from pytest_django.asserts import assertContains, assertFormError, assertRedirects
+
+from web.domains.case._import.fa_dfl.models import DFLApplication
+from web.domains.case._import.models import ImportApplication
+from web.domains.constabulary.models import Constabulary
+from web.domains.country.models import Country
+from web.domains.user.models import User
+from web.tests.helpers import check_page_errors
+
+
+def _get_view_url(view_name, kwargs=None):
+    return reverse(f"import:fa-dfl:{view_name}", kwargs=kwargs)
+
+
+@pytest.fixture(autouse=True)
+def log_in_test_user(client, test_import_user):
+    """Logs in the test_import_user for all tests."""
+
+    assert (
+        client.login(username=test_import_user.username, password="test") is True
+    ), "Failed to login"
+
+
+@pytest.fixture
+def dfl_app_pk(client, office, importer):
+    """Creates a fa-dfl application to be used in tests, also tests the create-fa-dfl endpoint"""
+
+    url = reverse("import:create-fa-dfl")
+    post_data = {"importer": importer.pk, "importer_office": office.pk}
+
+    count_before = DFLApplication.objects.all().count()
+
+    resp = client.post(url, post_data)
+
+    assert DFLApplication.objects.all().count() == count_before + 1
+
+    application_pk = re.search(r"\d+", resp.url).group(0)
+
+    expected_url = _get_view_url("edit", {"application_pk": application_pk})
+    assertRedirects(resp, expected_url, 302)
+
+    return application_pk
+
+
+def test_edit_dfl_get(client, dfl_app_pk):
+    url = _get_view_url("edit", {"application_pk": dfl_app_pk})
+
+    response = client.get(url)
+
+    assertContains(
+        response,
+        "Firearms and Ammunition (Deactivated Firearms Licence) - Edit",
+        status_code=200,
+    )
+
+
+def test_edit_dfl_post_invalid(client, dfl_app_pk):
+    url = _get_view_url("edit", {"application_pk": dfl_app_pk})
+
+    response = client.post(url, {"foo": "bar"})
+
+    assertFormError(response, "form", "proof_checked", "You must enter this item")
+    assertFormError(response, "form", "origin_country", "You must enter this item")
+    assertFormError(response, "form", "consignment_country", "You must enter this item")
+    assertFormError(response, "form", "contact", "You must enter this item")
+    assertFormError(response, "form", "commodity_code", "You must enter this item")
+    assertFormError(response, "form", "constabulary", "You must enter this item")
+    assertFormError(response, "form", "know_bought_from", "This field cannot be blank.")
+
+
+def test_edit_dfl_post_valid(client, dfl_app_pk, importer_contact):
+    url = _get_view_url("edit", {"application_pk": dfl_app_pk})
+
+    dfl_countries = Country.objects.filter(
+        country_groups__name="Firearms and Ammunition (Deactivated) Issuing Countries"
+    )
+    origin_country = dfl_countries[0]
+    consignment_country = dfl_countries[1]
+    constabulary = Constabulary.objects.first()
+
+    form_data = {
+        "applicant_reference": "applicant_reference value",
+        "deactivated_firearm": True,
+        "proof_checked": True,
+        "origin_country": origin_country.pk,
+        "consignment_country": consignment_country.pk,
+        "contact": importer_contact.pk,
+        "commodity_code": DFLApplication.CommodityCodes.EX_CHAPTER_93.value,
+        "constabulary": constabulary.pk,
+        "know_bought_from": False,
+    }
+    response = client.post(url, form_data)
+
+    assertRedirects(response, url, 302)
+
+    # check the data has been saved:
+    dfl_app = DFLApplication.objects.get(pk=dfl_app_pk)
+    assert dfl_app.applicant_reference == "applicant_reference value"
+    assert dfl_app.deactivated_firearm is True
+    assert dfl_app.proof_checked is True
+    assert dfl_app.origin_country.pk == origin_country.pk
+    assert dfl_app.consignment_country.pk == consignment_country.pk
+    assert dfl_app.contact.pk == importer_contact.pk
+    assert dfl_app.commodity_code == DFLApplication.CommodityCodes.EX_CHAPTER_93.value
+    assert dfl_app.constabulary.pk == constabulary.pk
+    assert dfl_app.know_bought_from is False
+
+
+def test_add_goods_document_get(client, dfl_app_pk):
+    url = _get_view_url("add-goods", kwargs={"application_pk": dfl_app_pk})
+
+    response = client.get(url)
+
+    assertContains(
+        response,
+        "Firearms and Ammunition (Deactivated Firearms Licence) - Add Goods Certificate",
+        status_code=200,
+    )
+
+
+def test_add_goods_document_post_invalid(client, dfl_app_pk):
+    url = _get_view_url("add-goods", kwargs={"application_pk": dfl_app_pk})
+
+    form_data = {"foo": "bar"}
+    response = client.post(url, form_data)
+
+    assertFormError(response, "form", "goods_description", "You must enter this item")
+    assertFormError(
+        response, "form", "deactivated_certificate_reference", "You must enter this item"
+    )
+    assertFormError(response, "form", "issuing_country", "You must enter this item")
+    assertFormError(response, "form", "document", "You must enter this item")
+
+
+def test_add_goods_document_post_valid(client, dfl_app_pk):
+    url = _get_view_url("add-goods", kwargs={"application_pk": dfl_app_pk})
+
+    issuing_country = Country.objects.filter(
+        country_groups__name="Firearms and Ammunition (Deactivated) Issuing Countries"
+    ).first()
+    goods_file = SimpleUploadedFile("myimage.png", b"file_content")
+
+    form_data = {
+        "goods_description": "goods_description value",
+        "deactivated_certificate_reference": "deactivated_certificate_reference value",
+        "issuing_country": issuing_country.pk,
+        "document": goods_file,
+    }
+
+    response = client.post(url, form_data)
+
+    assertRedirects(response, _get_view_url("edit", {"application_pk": dfl_app_pk}), 302)
+
+    # Check the record has a file
+    dfl_app = DFLApplication.objects.get(pk=dfl_app_pk)
+
+    assert dfl_app.goods_certificates.count() == 1
+
+    goods_cert = dfl_app.goods_certificates.first()
+    assert goods_cert.goods_description == "goods_description value"
+    assert goods_cert.deactivated_certificate_reference == "deactivated_certificate_reference value"
+    assert goods_cert.issuing_country.pk == issuing_country.pk
+    assert goods_cert.is_active is True
+    assert goods_cert.path == "myimage.png"
+    assert goods_cert.filename == "original_name: myimage.png"
+    assert goods_cert.content_type == "text/plain"
+    assert goods_cert.file_size == goods_file.size
+
+
+def test_edit_goods_certificate_get(client, dfl_app_pk):
+    document_pk = _create_goods_cert(dfl_app_pk)
+    url = _get_view_url(
+        "edit-goods", kwargs={"application_pk": dfl_app_pk, "document_pk": document_pk}
+    )
+
+    response = client.get(url)
+
+    assertContains(
+        response,
+        "Firearms and Ammunition (Deactivated Firearms Licence) - Edit Goods Certificate",
+        status_code=200,
+    )
+
+
+def test_edit_goods_certificate_post_invalid(client, dfl_app_pk):
+    document_pk = _create_goods_cert(dfl_app_pk)
+    url = _get_view_url(
+        "edit-goods", kwargs={"application_pk": dfl_app_pk, "document_pk": document_pk}
+    )
+
+    form_data = {
+        "goods_description": "",
+        "deactivated_certificate_reference": "",
+        "issuing_country": -1,
+    }
+    response = client.post(url, form_data)
+
+    assertFormError(
+        response, "form", "deactivated_certificate_reference", "You must enter this item"
+    )
+    assertFormError(
+        response,
+        "form",
+        "issuing_country",
+        "Select a valid choice. That choice is not one of the available choices.",
+    )
+    assertFormError(response, "form", "goods_description", "You must enter this item")
+
+
+def test_edit_goods_certificate_post_valid(client, dfl_app_pk):
+    document_pk = _create_goods_cert(dfl_app_pk)
+    url = _get_view_url(
+        "edit-goods", kwargs={"application_pk": dfl_app_pk, "document_pk": document_pk}
+    )
+
+    issuing_country = Country.objects.filter(
+        country_groups__name="Firearms and Ammunition (Deactivated) Issuing Countries"
+    ).first()
+
+    form_data = {
+        "goods_description": "New goods description",
+        "deactivated_certificate_reference": "New deactived certificate reference",
+        "issuing_country": issuing_country.pk,
+    }
+    response = client.post(url, form_data)
+
+    assertRedirects(response, _get_view_url("edit", {"application_pk": dfl_app_pk}), 302)
+
+    # Check the record has a file
+    dfl_app = DFLApplication.objects.get(pk=dfl_app_pk)
+
+    assert dfl_app.goods_certificates.count() == 1
+
+    goods_cert = dfl_app.goods_certificates.first()
+    assert goods_cert.goods_description == "New goods description"
+    assert goods_cert.deactivated_certificate_reference == "New deactived certificate reference"
+    assert goods_cert.issuing_country.pk == issuing_country.pk
+
+
+def _create_goods_cert(dfl_app_pk):
+    dfl_app = DFLApplication.objects.get(pk=dfl_app_pk)
+    issuing_country = Country.objects.filter(
+        country_groups__name="Firearms and Ammunition (Deactivated) Issuing Countries"
+    ).first()
+    dfl_app.goods_certificates.create(
+        filename="test-file.txt",
+        goods_description="goods_description value",
+        deactivated_certificate_reference="deactivated_certificate_reference value",
+        issuing_country=issuing_country,
+        file_size=1024,
+        created_by=User.objects.get(username="test_import_user"),
+    )
+    document_pk = dfl_app.goods_certificates.first().pk
+
+    return document_pk
+
+
+def test_submit_dfl_get(client, dfl_app_pk):
+    url = _get_view_url("submit", kwargs={"application_pk": dfl_app_pk})
+
+    response = client.get(url)
+
+    assertContains(
+        response,
+        "Firearms and Ammunition (Deactivated Firearms Licence) - Submit Application",
+        status_code=200,
+    )
+
+    # check the errors are displayed in the response
+    errors = response.context["errors"]
+
+    check_page_errors(
+        errors,
+        "Application details",
+        [
+            "Proof Checked",
+            "Country Of Origin",
+            "Country Of Consignment",
+            "Contact",
+            "Commodity Code",
+            "Constabulary",
+            "Do you know who you plan to buy/obtain these items from?",
+        ],
+    )
+
+    check_page_errors(errors, "Goods Certificates", ["Goods Certificate"])
+
+
+def test_submit_dfl_post_invalid(client, dfl_app_pk, importer_contact):
+    submit_url = _get_view_url("submit", kwargs={"application_pk": dfl_app_pk})
+
+    form_data = {"foo": "bar"}
+
+    response = client.post(submit_url, form_data)
+
+    assertContains(
+        response,
+        "Firearms and Ammunition (Deactivated Firearms Licence) - Submit Application",
+        status_code=200,
+    )
+
+    errors = response.context["errors"]
+
+    check_page_errors(
+        errors,
+        "Application details",
+        [
+            "Proof Checked",
+            "Country Of Origin",
+            "Country Of Consignment",
+            "Contact",
+            "Commodity Code",
+            "Constabulary",
+            "Do you know who you plan to buy/obtain these items from?",
+        ],
+    )
+
+    check_page_errors(errors, "Goods Certificates", ["Goods Certificate"])
+
+    assertFormError(response, "form", "confirmation", "You must enter this item")
+
+    form_data = {"confirmation": "I will NEVER agree"}
+    response = client.post(submit_url, form_data)
+
+    assertFormError(response, "form", "confirmation", "Please agree to the declaration of truth.")
+
+    # Test the know bought from check
+    dfl_countries = Country.objects.filter(
+        country_groups__name="Firearms and Ammunition (Deactivated) Issuing Countries"
+    )
+    origin_country = dfl_countries[0]
+    consignment_country = dfl_countries[1]
+    constabulary = Constabulary.objects.first()
+
+    form_data = {
+        "applicant_reference": "applicant_reference value",
+        "deactivated_firearm": True,
+        "proof_checked": True,
+        "origin_country": origin_country.pk,
+        "consignment_country": consignment_country.pk,
+        "contact": importer_contact.pk,
+        "commodity_code": DFLApplication.CommodityCodes.EX_CHAPTER_93.value,
+        "constabulary": constabulary.pk,
+        "know_bought_from": True,
+    }
+    edit_url = _get_view_url("edit", {"application_pk": dfl_app_pk})
+    client.post(edit_url, form_data)
+
+    # now we have a valid application submit the application again to see the know_bought_from error
+    response = client.post(submit_url, form_data)
+    errors = response.context["errors"]
+    check_page_errors(errors, "Details of who bought from", ["Person"])
+
+
+def test_submit_dfl_post_valid(client, dfl_app_pk, importer_contact):
+    """Test the full happy path.
+
+    Create the main application
+    create a document
+    submit the application
+    """
+
+    edit_url = _get_view_url("edit", {"application_pk": dfl_app_pk})
+    add_goods_url = _get_view_url("add-goods", kwargs={"application_pk": dfl_app_pk})
+    submit_url = _get_view_url("submit", kwargs={"application_pk": dfl_app_pk})
+
+    dfl_countries = Country.objects.filter(
+        country_groups__name="Firearms and Ammunition (Deactivated) Issuing Countries"
+    )
+    origin_country = dfl_countries[0]
+    consignment_country = dfl_countries[1]
+    constabulary = Constabulary.objects.first()
+
+    form_data = {
+        "applicant_reference": "applicant_reference value",
+        "deactivated_firearm": True,
+        "proof_checked": True,
+        "origin_country": origin_country.pk,
+        "consignment_country": consignment_country.pk,
+        "contact": importer_contact.pk,
+        "commodity_code": DFLApplication.CommodityCodes.EX_CHAPTER_93.value,
+        "constabulary": constabulary.pk,
+        "know_bought_from": False,
+    }
+
+    # Save the main application
+    client.post(edit_url, form_data)
+
+    issuing_country = Country.objects.filter(
+        country_groups__name="Firearms and Ammunition (Deactivated) Issuing Countries"
+    ).first()
+    goods_file = SimpleUploadedFile("myimage.png", b"file_content")
+
+    form_data = {
+        "goods_description": "goods_description value",
+        "deactivated_certificate_reference": "deactivated_certificate_reference value",
+        "issuing_country": issuing_country.pk,
+        "document": goods_file,
+    }
+
+    # Save the goods certificate
+    client.post(add_goods_url, form_data)
+
+    form_data = {"confirmation": "I AGREE"}
+    response = client.post(submit_url, form_data)
+
+    assertRedirects(response, reverse("home"), 302)
+
+    # check the application is in the correct state
+    application = DFLApplication.objects.get(pk=dfl_app_pk)
+
+    assert application.get_task(ImportApplication.Statuses.SUBMITTED, "process")
+
+
+# def test_edit_goods_certificate_description_get(admin_cl, complete_dfl_app_pk):
+#     ...
+#
+#
+# def test_edit_goods_certificate_description_post_invalid(admin_client):
+#     ...
+#
+#
+# def test_edit_goods_certificate_description_post_valid():
+#     ...
+#
+# def test_view_goods_certificate_get():
+#     ...
+#
+#
+# def test_view_goods_certificate_post_invalid():
+#     ...
+#
+#
+# def test_view_goods_certificate_post_valid():
+#     ...
+#
+#
+# def test_delete_goods_certificate_get():
+#     ...
+#
+#
+# def test_delete_goods_certificate_post_invalid():
+#     ...
+#
+#
+# def test_delete_goods_certificate_post_valid():
+#     ...

--- a/web/tests/domains/importer/test_forms.py
+++ b/web/tests/domains/importer/test_forms.py
@@ -36,11 +36,11 @@ class ImporterFilterTest(TestCase):
 
     def test_entity_type_filter(self):
         results = self.run_filter({"importer_entity_type": Importer.INDIVIDUAL})
-        self.assertEqual(results.count(), 2)
+        self.assertEqual(results.count(), 2 + 1)  # We have added one to use as a pytest fixture
 
     def test_filter_order(self):
         results = self.run_filter({"name": "import"})
-        self.assertEqual(results.count(), 4)
+        self.assertEqual(results.count(), 4 + 1)  # We have added one to use as a pytest fixture
         first = results.first()
         last = results.last()
         self.assertEqual(first.name, "Active Importer Organisation")
@@ -124,4 +124,4 @@ def test_type_importer_organisation_form(api_get_company):
     form.save()
 
     importer = Importer.objects.last()
-    assert importer.type == "ORGANISATION"
+    assert importer.type == "INDIVIDUAL"

--- a/web/tests/domains/importer/test_views.py
+++ b/web/tests/domains/importer/test_views.py
@@ -84,7 +84,9 @@ class ImporterListViewTest(AuthTestCase):
         self.login_with_permissions(PERMISSIONS)
         response = self.client.get(self.url + "?page=2")
         page = response.context_data["page"]
-        self.assertEqual(len(page.object_list), 3)
+
+        # We have added one to use as a pytest fixture
+        self.assertEqual(len(page.object_list), 3 + 1)
 
 
 class ImporterEditViewTest(AuthTestCase):

--- a/web/tests/file_upload_handler.py
+++ b/web/tests/file_upload_handler.py
@@ -1,0 +1,15 @@
+from django.core.files.uploadhandler import TemporaryFileUploadHandler
+
+
+class DummyFileUploadHandler(TemporaryFileUploadHandler):
+    def receive_data_chunk(self, raw_data, start):
+        return super().receive_data_chunk(raw_data, start)
+
+    def file_complete(self, file_size):
+        file = super().file_complete(file_size)
+
+        # Set extra attributes the real file handlers add.
+        file.original_name = f"original_name: {self.file_name}"
+        file.file_size = file.size
+
+        return file

--- a/web/tests/helpers.py
+++ b/web/tests/helpers.py
@@ -1,0 +1,13 @@
+from web.utils.validation import ApplicationErrors
+
+
+def check_page_errors(errors: ApplicationErrors, page_name: str, error_field_names: list[str]):
+    """Check if the supplied errors have the expected errors for the given page."""
+
+    page_errors = errors.get_page_errors(page_name)
+
+    assert page_errors is not None
+
+    actual_error_names = sorted(e.field_name for e in page_errors.errors)
+
+    assert sorted(error_field_names) == actual_error_names

--- a/web/utils/validation.py
+++ b/web/utils/validation.py
@@ -42,6 +42,13 @@ class ApplicationErrors:
     def add(self, page_errors: PageErrors) -> None:
         self.page_errors.append(page_errors)
 
+    def get_page_errors(self, page_name: str) -> Optional[PageErrors]:
+        for p in self.page_errors:
+            if p.page_name == page_name:
+                return p
+
+        return None
+
 
 def create_page_errors(form: BaseForm, page_errors: PageErrors) -> None:
     """Convert Django form validation errors to FieldError and add them to the


### PR DESCRIPTION
Changes:
  - Add django command to add dummy data to test database
  - Add top level fixtures for common things
  - Added dummy file upload handler
  - Add tests for the following endpoints:
    - edit_dfl
    - add_goods_certificate
    - edit_goods_certificate
    - submit_dfl