### PR TITLE
ICMSLST-1185 Fix Docker build for the web container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.9.5-slim
 
 # Install dependencies
-RUN apt-get update && apt-get install wget graphviz libgraphviz-dev gcc postgresql-client npm -y
+RUN apt-get update && apt-get install wget graphviz libgraphviz-dev gcc libpq-dev postgresql-client npm -y
 
 ENV DOCKERIZE_VERSION v0.6.1
 ENV ICMS_WEB_PORT ${ICMS_WEB_PORT}


### PR DESCRIPTION
Running `docker build -t [tag] .` was failing with an error about missing
the pg_config helper (when installing Python deps). Adding an explicit
dependency on libpq-dev fixes this.