### PR TITLE
ICMSLST-1029 Create GMP app from template without query params.

### DIFF
--- a/web/domains/case/export/forms.py
+++ b/web/domains/case/export/forms.py
@@ -465,7 +465,9 @@ class GMPBrandForm(forms.ModelForm):
         fields = ("brand_name",)
 
 
-class EditGMPForm(forms.ModelForm):
+class EditGMPFormBase(forms.ModelForm):
+    """Base class for all GMP forms (editing and creating from a template)"""
+
     class Meta:
         model = CertificateOfGoodManufacturingPracticeApplication
 
@@ -517,6 +519,10 @@ class EditGMPForm(forms.ModelForm):
         # These are only sometimes required and will be checked in the clean method
         self.fields["auditor_accredited"].required = False
         self.fields["auditor_certified"].required = False
+
+
+class EditGMPForm(EditGMPFormBase):
+    """Form used when a user tries to save an application - contains all application specific cleaning logic."""
 
     def clean(self) -> dict[str, Any]:
         cleaned_data: dict[str, Any] = super().clean()
@@ -573,3 +579,14 @@ class EditGMPForm(forms.ModelForm):
                 )
 
         return cleaned_data
+
+
+class EditGMPTemplateForm(EditGMPFormBase):
+    """All fields are optional and only have basic model checks."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Used to enable partial saving (when creating from a template)
+        for f in self.fields:
+            self.fields[f].required = False

--- a/web/domains/case/export/forms.py
+++ b/web/domains/case/export/forms.py
@@ -135,7 +135,7 @@ class CreateExportApplicationForm(forms.Form):
         return cleaned_data
 
 
-class PrepareCertManufactureForm(forms.ModelForm):
+class PrepareCertManufactureFormBase(forms.ModelForm):
     class Meta:
         model = CertificateOfManufactureApplication
 
@@ -174,6 +174,8 @@ class PrepareCertManufactureForm(forms.ModelForm):
         )
         self.fields["countries"].queryset = application_countries
 
+
+class PrepareCertManufactureForm(PrepareCertManufactureFormBase):
     def clean_is_pesticide_on_free_sale_uk(self):
         val = self.cleaned_data["is_pesticide_on_free_sale_uk"]
 
@@ -218,6 +220,14 @@ class PrepareCertManufactureForm(forms.ModelForm):
         return val
 
 
+class PrepareCertManufactureTemplateForm(PrepareCertManufactureFormBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        for fname in self.fields:
+            self.fields[fname].required = False
+
+
 class EditCFSForm(forms.ModelForm):
     class Meta:
         model = CertificateOfFreeSaleApplication
@@ -241,6 +251,14 @@ class EditCFSForm(forms.ModelForm):
             is_active=True
         )
         self.fields["countries"].queryset = application_countries
+
+
+class EditCFSTemplateForm(EditCFSForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        for fname in self.fields:
+            self.fields[fname].required = False
 
 
 class EditCFScheduleForm(forms.ModelForm):

--- a/web/domains/case/export/urls.py
+++ b/web/domains/case/export/urls.py
@@ -70,7 +70,7 @@ urlpatterns = [
         name="create-application",
     ),
     path(
-        "create/<exportapplicationtype:type_code>/template/<int:template_pk>",
+        "create/<exportapplicationtype:type_code>/template/<int:template_pk>/",
         views.create_export_application,
         name="create-application-from-template",
     ),

--- a/web/domains/case/export/urls.py
+++ b/web/domains/case/export/urls.py
@@ -69,6 +69,11 @@ urlpatterns = [
         views.create_export_application,
         name="create-application",
     ),
+    path(
+        "create/<exportapplicationtype:type_code>/template/<int:template_pk>",
+        views.create_export_application,
+        name="create-application-from-template",
+    ),
     # Export application groups
     path(
         "com/<int:application_pk>/",

--- a/web/domains/cat/models.py
+++ b/web/domains/cat/models.py
@@ -43,11 +43,11 @@ class CertificateApplicationTemplate(models.Model):
     last_updated = models.DateTimeField(auto_now=True)
     data = models.JSONField(default=dict, encoder=DjangoJSONEncoder)
 
-    def initial_data(self) -> dict:
-        """Data to use as a Django form's initial argument."""
+    def form_data(self) -> dict:
+        """Data to use as a Django form's data argument."""
         return copy.deepcopy(self.data)
 
     def user_can_view(self, user: User) -> bool:
-        # A template may have sensitive information we check if the user
+        # A template may have sensitive information so we check if the user
         # should be allowed to view it (use it to create an application).
         return user == self.owner

--- a/web/templates/web/domains/cat/partials/table.html
+++ b/web/templates/web/domains/cat/partials/table.html
@@ -22,7 +22,11 @@
       <td>{{ template.created.strftime('%d-%b-%Y %H:%M') }}</td>
       <td>{{ template.last_updated.strftime('%d-%b-%Y %H:%M') }}</td>
       <td>
-        <a href="{{ icms_url('export:choose') }}?from-template={{ template.pk }}" class="link-button button icon-magic-wand" title="Create Application">Create Application</a>
+        <a
+          href="{{ icms_url('export:create-application-from-template', kwargs={'type_code': template.application_type|lower, "template_pk": template.pk }) }}"
+          class="link-button button icon-magic-wand" title="Create Application">
+          Create Application
+        </a>
         <a href="{{ icms_url('cat:edit', kwargs={'cat_pk': template.pk}) }}" class="link-button button icon-pencil" title="Edit Template">Edit</a>
         {# TODO: ICMSLST-1178 Delete #}
       </td>

--- a/web/tests/domains/cat/test_models.py
+++ b/web/tests/domains/cat/test_models.py
@@ -6,10 +6,10 @@ from web.domains.user.models import User
 
 @pytest.mark.django_db
 class TestCertificateApplicationTemplate:
-    def test_initial_data_makes_a_copy(self):
+    def test_form_data_makes_a_copy(self):
         original = {"foo": "bar"}
         obj = CertificateApplicationTemplate(data=original)
-        data = obj.initial_data()
+        data = obj.form_data()
         data["foo"] = "qux"
 
         assert original == {"foo": "bar"}


### PR DESCRIPTION
No need for query param or extra redirect hop to "export:choose".

Would still need to extend for the other two application types