### PR TITLE
ICMSLST-1214 Do not trust message text as HTML-safe (fixes XSS bugs)

### DIFF
--- a/web/templates/messages/messages.html
+++ b/web/templates/messages/messages.html
@@ -2,8 +2,8 @@
   <div class="flash-message" style="display: block;">
     <div role="alert" class="info-box info-box-{{message.tags}} " tabindex="0">
       <button class="flash-message-close icon-cross" aria-label="Close this message"></button>
-      {{message|safe}}
+      {# Do not use the "safe" template filter here #}
+      {{message}}
     </div>
   </div>
 {% endmacro %}
-


### PR DESCRIPTION
The Django messages framework is used to provide flash messages to users
on actions like form saves, but we were marking the message text as safe
and at the same time using un-trusted user data (things like the template
name). This meant a user could inject arbitrary markup.

This change stops marking all messages as HTML safe. I don't see anywhere
in the view handlers where we actually expected HTML to be displayed in
a message.