### PR TITLE
ICMSLST-1190 Fix NoReverseMatch exception on template list view

### DIFF
--- a/web/templates/web/domains/cat/partials/table.html
+++ b/web/templates/web/domains/cat/partials/table.html
@@ -27,7 +27,7 @@
           class="link-button button icon-magic-wand" title="Create Application">
           Create Application
         </a>
-        <a href="{{ icms_url('cat:edit', kwargs={'pk': template.pk}) }}" class="link-button button icon-pencil" title="Edit Template">Edit</a>
+        <a href="{{ icms_url('cat:edit', kwargs={'cat_pk': template.pk}) }}" class="link-button button icon-pencil" title="Edit Template">Edit</a>
         {# TODO: ICMSLST-1178 Delete #}
       </td>
     </tr>


### PR DESCRIPTION
The path keyword argument was changed, but the template had not been updated,
causing a NoReverseMatch exception when the user visits /cat/ and there are
template objects.