### PR TITLE
ICMSLST-1044 Add a read-only version of the application templates

### DIFF
--- a/web/domains/cat/urls.py
+++ b/web/domains/cat/urls.py
@@ -6,8 +6,10 @@ app_name = "cat"
 urlpatterns = [
     path("", views.CATListView.as_view(), name="list"),
     path("create/", views.create, name="create"),
-    path("edit/<int:cat_pk>/", views.edit, name="edit"),
+    path("edit/<int:cat_pk>/", views.CATEditView.as_view(), name="edit"),
     path("edit/<int:cat_pk>/archive/", views.CATArchiveView.as_view(), name="archive"),
     path("edit/<int:cat_pk>/restore/", views.CATRestoreView.as_view(), name="restore"),
-    path("edit/<int:cat_pk>/<str:step>/", views.CATEditStepView.as_view(), name="edit-step"),
+    path("edit/<int:cat_pk>/<str:step>/", views.CATEditView.as_view(), name="edit-step"),
+    path("view/<int:cat_pk>/", views.CATReadOnlyView.as_view(), name="view"),
+    path("view/<int:cat_pk>/<str:step>/", views.CATReadOnlyView.as_view(), name="view-step"),
 ]

--- a/web/domains/cat/views.py
+++ b/web/domains/cat/views.py
@@ -73,51 +73,10 @@ def create(request: AuthenticatedHttpRequest) -> HttpResponse:
         context = {
             "page_title": "Create Certificate Application Template",
             "form": form,
+            "read_only": False,
         }
 
         return render(request, "web/domains/cat/create.html", context)
-
-
-@login_required
-def edit(request: AuthenticatedHttpRequest, *, cat_pk: int) -> HttpResponse:
-    cat = get_object_or_404(CertificateApplicationTemplate, pk=cat_pk)
-
-    with transaction.atomic():
-        if not _has_permission(request.user):
-            raise PermissionDenied
-
-        if request.POST:
-            if not cat.user_can_edit(request.user):
-                raise PermissionDenied
-
-            form = EditCATForm(request.POST, instance=cat)
-            if form.is_valid():
-                cat = form.save()
-
-                messages.success(request, f"Template '{cat.name}' updated.")
-
-                return redirect(reverse("cat:list"))
-        else:
-            form = EditCATForm(instance=cat)
-
-        type_ = cat.application_type
-        type_display = cat.get_application_type_display()
-        sidebar_links = [
-            (reverse("cat:edit", kwargs={"cat_pk": cat.pk}), "Template"),
-            (
-                reverse("cat:edit-step", kwargs={"cat_pk": cat.pk, "step": type_.lower()}),
-                f"{type_display} Application",
-            ),
-        ]
-
-        context = {
-            "page_title": "Edit Certificate Application Template",
-            "form": form,
-            "application_type": type_display,
-            "sidebar_links": sidebar_links,
-        }
-
-        return render(request, "web/domains/cat/edit.html", context)
 
 
 def _has_permission(user: User) -> bool:
@@ -127,14 +86,17 @@ def _has_permission(user: User) -> bool:
     return ilb_admin or exporter_user
 
 
-class CATEditStepView(PermissionRequiredMixin, LoginRequiredMixin, FormView):
+class CATEditView(PermissionRequiredMixin, LoginRequiredMixin, FormView):
     template_name = "web/domains/cat/edit.html"
     success_url = reverse_lazy("cat:list")
+    read_only = False  # Determines editing or read-only behaviour.
 
     def dispatch(self, request: AuthenticatedHttpRequest, *args, **kwargs) -> HttpResponse:
         self.object = get_object_or_404(CertificateApplicationTemplate, pk=kwargs["cat_pk"])
 
-        if not self.object.user_can_edit(self.request.user):
+        # Different permissions if this is editing / viewing a template.
+        predicate = self.object.user_can_view if self.read_only else self.object.user_can_edit
+        if not predicate(self.request.user):
             raise PermissionDenied
 
         return super().dispatch(request, *args, **kwargs)
@@ -143,37 +105,81 @@ class CATEditStepView(PermissionRequiredMixin, LoginRequiredMixin, FormView):
         return _has_permission(self.request.user)
 
     def get_form_class(self) -> ModelForm:
-        return form_class_for_application_type(self.object.application_type)
+        if "step" in self.kwargs:
+            return form_class_for_application_type(self.object.application_type)
+        else:
+            # This is the template's metadata form.
+            return EditCATForm
+
+    def get_form(self) -> ModelForm:
+        form = super().get_form()
+
+        if self.read_only:
+            for fname in form.fields:
+                form.fields[fname].disabled = True
+
+        return form
+
+    def get_form_kwargs(self) -> dict[str, Any]:
+        kwargs = super().get_form_kwargs()
+
+        if "step" not in self.kwargs:
+            kwargs["instance"] = self.object
+
+        return kwargs
 
     def get_initial(self) -> dict[str, Any]:
-        return self.object.form_data()
+        if "step" in self.kwargs:
+            return self.object.form_data()
+        else:
+            return super().get_initial()
 
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         type_ = self.object.application_type
         type_display = self.object.get_application_type_display()
+
+        if self.read_only:
+            url_name = "view"
+            page_title = "View Certificate Application Template"
+        else:
+            url_name = "edit"
+            page_title = "Edit Certifcate Application Template"
+
         sidebar_links = [
-            (reverse("cat:edit", kwargs={"cat_pk": self.object.pk}), "Template"),
+            (reverse(f"cat:{url_name}", kwargs={"cat_pk": self.object.pk}), "Template"),
             (
-                reverse("cat:edit-step", kwargs={"cat_pk": self.object.pk, "step": type_.lower()}),
+                reverse(
+                    f"cat:{url_name}-step", kwargs={"cat_pk": self.object.pk, "step": type_.lower()}
+                ),
                 f"{type_display} Application",
             ),
         ]
         kwargs = {
-            "page_title": "Edit Certificate Application Template",
+            "page_title": page_title,
             "application_type": type_display,
             "sidebar_links": sidebar_links,
+            "read_only": self.read_only,
         }
         return super().get_context_data(**kwargs)
 
     def form_valid(self, form: ModelForm) -> HttpResponse:
         result = super().form_valid(form)
-        # The JSON field encoder handles querysets as a list of PKs.
-        self.object.data = form.cleaned_data
-        self.object.save()
+
+        if "step" in self.kwargs:
+            # The JSON field encoder handles querysets as a list of PKs.
+            self.object.data = form.cleaned_data
+            self.object.save()
+        else:
+            # This is the metadata form for the template itself.
+            form.save()
 
         messages.success(self.request, f"Template '{self.object.name}' updated.")
 
         return result
+
+
+class CATReadOnlyView(CATEditView):
+    read_only = True
 
 
 class CATArchiveView(PermissionRequiredMixin, LoginRequiredMixin, View):

--- a/web/templates/web/domains/cat/base_form.html
+++ b/web/templates/web/domains/cat/base_form.html
@@ -43,6 +43,7 @@
       <div class="row">
         <div class="three columns"></div>
           <div class="eight columns">
+            {% if not read_only %}
             <ul class="menu-out flow-across">
               <li>
                 <button id="btn-submit" type="submit" class="primary-button button">
@@ -54,6 +55,7 @@
                 </button>
               </li>
             </ul>
+            {% endif %}
           </div>
           <div class="one columns"></div>
         </div>

--- a/web/templates/web/domains/cat/partials/table.html
+++ b/web/templates/web/domains/cat/partials/table.html
@@ -14,7 +14,7 @@
   <tbody>
   {% for template in templates %}
     <tr>
-      <td>{{ template.name }}</td>
+      <td><a href="{{ icms_url('cat:view', kwargs={'cat_pk': template.pk}) }}">{{ template.name }}</a></td>
       <td>{{ template.description|nl2br }}</td>
       <td>{{ template.application_type }}</td>
       <td>{{ template.get_sharing_display() }}</td>

--- a/web/tests/domains/cat/test_views.py
+++ b/web/tests/domains/cat/test_views.py
@@ -243,3 +243,33 @@ class TestCATRestoreView(AuthTestCase):
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, 403)
+
+
+class TestCATReadOnlyView(AuthTestCase):
+    def test_show_disabled_form_for_template(self):
+        cat = CertificateApplicationTemplate.objects.create(
+            owner=self.user,
+            name="CFS template",
+            application_type=ExportApplicationType.Types.FREE_SALE,
+        )
+        url = reverse("cat:view", kwargs={"cat_pk": cat.pk})
+
+        self.login_with_permissions(["exporter_access"])
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context["read_only"])
+
+    def test_show_disabled_form_for_step(self):
+        cat = CertificateApplicationTemplate.objects.create(
+            owner=self.user,
+            name="CFS template",
+            application_type=ExportApplicationType.Types.FREE_SALE,
+        )
+        url = reverse("cat:view-step", kwargs={"cat_pk": cat.pk, "step": "cfs"})
+
+        self.login_with_permissions(["exporter_access"])
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context["read_only"])


### PR DESCRIPTION
In the list of templates ("/cat/"), clicking the _name_ of a template links to a read-only version of the templates, like "/cat/view/[id]/". The read-only view re-uses the editing views, but with form inputs disabled.