### PR TITLE
ICMSLST-1402 Bump pii-secret-check-hooks to version 0.0.0.34

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/uktrade/pii-secret-check-hooks
-    rev: 0.0.0.33
+    rev: 0.0.0.34
     hooks:
     -   id: pii_secret_filename
         files: ''

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -2203,3 +2203,4 @@ application_field(vr.when_varied.strftime('%d-%b-%Y
 # Country
 StopIteration
 ArgumentParser
+0.0.0.34


### PR DESCRIPTION
This version has a change to how Python source code is scanned, which
we hope will result in fewer false positives.