### PR TITLE
ICMSLST-1394 Add the CHIEF dashboard views and navigation

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -1242,3 +1242,8 @@ agent_id"
 2 contact_id
 param db
 V2
+ILBDOTI
+Licences</h4
+download">Download
+TBC
+ChiefRequest

--- a/web/domains/chief/urls.py
+++ b/web/domains/chief/urls.py
@@ -4,6 +4,11 @@ from . import views
 
 app_name = "chief"
 urlpatterns = [
+    path("", views.PendingBatches.as_view(), name="pending-batches"),
+    path("failed-batches/", views.FailedBatches.as_view(), name="failed-batches"),
+    path("pending-licences/", views.PendingLicences.as_view(), name="pending-licences"),
+    path("failed-licences/", views.FailedLicences.as_view(), name="failed-licences"),
+    # The LITE_API_URL path configured in icms-hmrc.
     path(
         "license-data-callback", views.LicenseDataCallback.as_view(), name="license-data-callback"
     ),

--- a/web/menu/menu.py
+++ b/web/menu/menu.py
@@ -196,6 +196,7 @@ class Menu:
         MenuDropDown(
             label="Admin",
             sub_menu_list=[
+                SubMenuLink(label="CHIEF Dashboard", view="chief:pending-batches"),
                 SubMenu(
                     label="Importers/Exporters",
                     links=[

--- a/web/templates/web/domains/chief/_base.html
+++ b/web/templates/web/domains/chief/_base.html
@@ -1,0 +1,25 @@
+{% extends "layout/no-sidebar.html" %}
+
+{% block main_content %}
+
+<ul class="tabs">
+    <li>
+        {{ icms_link(request, icms_url('chief:pending-batches'), 'Waiting on HRMC response') }}
+    </li>
+    <li>
+        {{ icms_link(request, icms_url('chief:pending-licences'), 'Pending Licences') }}
+        <span class="label small-label white-label">{{ pending_licences_count }}</span>
+    </li>
+    <li>
+        {{ icms_link(request, icms_url('chief:failed-batches'), 'Failed Batches') }}
+        <span class="label small-label red-label">{{ failed_batches_count }}</span>
+    </li>
+    <li>
+        {{ icms_link(request, icms_url('chief:failed-licences'), 'Failed Licences') }}
+        <span class="label small-label red-label">{{ failed_licences_count }}</span>
+    </li>
+</ul>
+
+{% block main_chief %}{% endblock %}
+
+{% endblock main_content %}

--- a/web/templates/web/domains/chief/failed_batches.html
+++ b/web/templates/web/domains/chief/failed_batches.html
@@ -1,0 +1,1 @@
+{% extends "web/domains/chief/_base.html" %}

--- a/web/templates/web/domains/chief/failed_licences.html
+++ b/web/templates/web/domains/chief/failed_licences.html
@@ -1,0 +1,45 @@
+{% extends "web/domains/chief/_base.html" %}
+
+{% block main_chief %}
+
+<h4>Failed Licences</h4>
+
+{% if failed_licences_count %}
+    <table>
+        <thead>
+            <tr>
+                <th>Reference</th>
+                <th>Sent Date</th>
+                <th>Received Date</th>
+                <th>Status</th>
+                <th>Error Code</th>
+                <th>Error Description</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for row in failed_licences %}
+            <tr>
+                <td>{{ row }}</td>
+                <td>{{ row }}</td>
+                <td>{{ row }}</td>
+                <td>{{ row }}</td>
+                <td>{{ row }}</td>
+                <td>{{ row }}</td>
+                <td>
+                    <ul class="menu-out">
+                        <li><a href="{{ icms_url('chief:pending-batches') }}" class=""link-button icon-redo2">Resend licence</a></li>
+                        <li><a href="{{ icms_url('chief:pending-batches') }}" class="link-button icon-eye">View Case</a></li>
+                        <li><a href="{{ icms_url('chief:pending-batches') }}" class="link-button icon-download">Download request XML</a></li>
+                        <li><a href="{{ icms_url('chief:pending-batches') }}" class="link-button icon-pencil">Update importer details</a></li>
+                    </ul>
+                </td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+{% else %}
+    <div class="info-box info-box-success">There are no failed licences</div>
+{% endif %}
+
+{% endblock %}

--- a/web/templates/web/domains/chief/pending_batches.html
+++ b/web/templates/web/domains/chief/pending_batches.html
@@ -1,0 +1,1 @@
+{% extends "web/domains/chief/_base.html" %}

--- a/web/templates/web/domains/chief/pending_licences.html
+++ b/web/templates/web/domains/chief/pending_licences.html
@@ -1,0 +1,44 @@
+{% extends "web/domains/chief/_base.html" %}
+
+{% block main_chief %}
+
+<h4>Pending Licences</h4>
+<div class="extra-info">
+    The next batch will be sent on TBC unless a response has not been received
+    from the previous batch.
+</div>
+
+{% if pending_licences_count %}
+    <table>
+        <thead>
+            <tr>
+                <th>Reference</th>
+                <th>Status</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for row in pending_licences %}
+            <tr>
+                <td>
+                    <span class="text-widget">{{ row.id }}</span>
+                </td>
+                <td>
+                    <span class="text-widget label small-label white-label">PENDING</span>
+                </td>
+                <td>
+                    <ul class="menu-out">
+                        <li><a href="{{ icms_url('chief:pending-batches') }}" class="link-button icon-eye">View Case</a></li>
+                        <li><a href="{{ icms_url('chief:pending-batches') }}" class="link-button icon-download">Download request XML</a></li>
+                        <li><a href="{{ icms_url('chief:pending-batches') }}" class="link-button icon-pencil">Update importer details</a></li>
+                    </ul>
+                </td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+{% else %}
+    <div class="info-box info-box-success">There are no pending licences</div>
+{% endif %}
+
+{% endblock %}

--- a/web/tests/domains/chief/test_views.py
+++ b/web/tests/domains/chief/test_views.py
@@ -1,4 +1,6 @@
+import pytest
 from django.urls import reverse
+from pytest_django.asserts import assertTemplateUsed
 
 from web.domains.chief.client import make_hawk_sender
 
@@ -36,3 +38,51 @@ class TestLicenseDataCallback:
         response = client.put(url, HTTP_AUTHORIZATION="Hawk foo")
 
         assert response.status_code == 400  # Bad request.
+
+
+@pytest.mark.django_db
+class TestPendingBatches:
+    def test_template_context(self, icms_admin_client):
+        url = reverse("chief:pending-batches")
+        response = icms_admin_client.get(url)
+
+        assert response.status_code == 200
+        assert response.context_data["pending_batches_count"] == 0
+        assert list(response.context_data["pending_batches"]) == []
+        assertTemplateUsed(response, "web/domains/chief/pending_batches.html")
+
+
+@pytest.mark.django_db
+class TestFailedBatches:
+    def test_template_context(self, icms_admin_client):
+        url = reverse("chief:failed-batches")
+        response = icms_admin_client.get(url)
+
+        assert response.status_code == 200
+        assert response.context_data["failed_batches_count"] == 0
+        assert list(response.context_data["failed_batches"]) == []
+        assertTemplateUsed(response, "web/domains/chief/failed_batches.html")
+
+
+@pytest.mark.django_db
+class TestPendingLicences:
+    def test_template_context(self, icms_admin_client):
+        url = reverse("chief:pending-licences")
+        response = icms_admin_client.get(url)
+
+        assert response.status_code == 200
+        assert response.context_data["pending_licences_count"] == 0
+        assert list(response.context_data["pending_licences"]) == []
+        assertTemplateUsed(response, "web/domains/chief/pending_licences.html")
+
+
+@pytest.mark.django_db
+class TestFailedLicences:
+    def test_template_context(self, icms_admin_client):
+        url = reverse("chief:failed-licences")
+        response = icms_admin_client.get(url)
+
+        assert response.status_code == 200
+        assert response.context_data["failed_licences_count"] == 0
+        assert list(response.context_data["failed_licences"]) == []
+        assertTemplateUsed(response, "web/domains/chief/failed_licences.html")


### PR DESCRIPTION
New dashboard views for CHIEF requests and errors:
    
- /chief/
- /chief/pending-licences/
- /chief/failed-batches/
- /chief/failed-licences/
    
The 4 views have a stub implementation that lists ImportApplication objects
and the links for actions in each row will be implemented next.