### PR TITLE
Fix all incorrect "if request.POST:" calls.

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -1165,3 +1165,42 @@ Add Firearm Details
 Edit Firearm Details
 Calibre 1
 Calibre 2
+Contract Document"
+Edit Goods
+Provide
+Prior Surveillance Import Licence - Edit
+Prior Surveillance Import Licence - Submit
+Prior Surveillance Import Licence - Add
+Prior Surveillance Import Licence - Edit Goods
+commodity_group_unit
+Application Template
+Edit Product
+Add Active Ingredient
+Edit Active Ingredient
+Edit Product Type Number
+CFS Product Upload
+CFS Product Upload Biocide
+ForeignKeys
+Product Type Numbers"
+ICMSLST-1344
+Firearms and Ammunition - Certificates"
+Firearms and Ammunition - Create Certificate
+Edit Firearm Supplementary Report
+f"Unknown Firearm
+Add Goods Certificate
+Edit Goods Certificate
+Submit Application
+Adhoc License Application - Edit
+Adhoc License Application
+Commodity List
+Goods - Commodity Code
+Outward Processing Trade Import Licence - Edit
+Outward Processing Trade Import Licence - Edit Compensating Products
+Outward Processing Trade Import Licence - Edit Temporary Exported Goods
+Outward Processing Trade Import Licence - Edit Further Questions
+Compensating Products
+Temporary Exported Goods
+Further Questions - "
+Outward Processing Trade Import Licence - Submit
+Outward Processing Trade Licence - Add
+Outward Processing Trade Licence - Checklist

--- a/web/domains/case/_import/derogations/views.py
+++ b/web/domains/case/_import/derogations/views.py
@@ -103,7 +103,7 @@ def add_supporting_document(
 
         task = get_application_current_task(application, "import", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = DocumentForm(data=request.POST, files=request.FILES)
 
             if form.is_valid():
@@ -180,7 +180,7 @@ def submit_derogations(request: AuthenticatedHttpRequest, *, application_pk: int
 
         errors = _get_derogations_errors(application)
 
-        if request.POST:
+        if request.method == "POST":
             form = SubmitForm(data=request.POST)
 
             if form.is_valid() and not errors.has_errors():
@@ -299,7 +299,7 @@ def edit_goods_licence(request: AuthenticatedHttpRequest, *, application_pk: int
 
         task = get_application_current_task(application, "import", Task.TaskType.PROCESS)
 
-        if request.POST:
+        if request.method == "POST":
             form = GoodsDerogationsLicenceForm(request.POST, instance=application)
 
             if form.is_valid():

--- a/web/domains/case/_import/fa/views.py
+++ b/web/domains/case/_import/fa/views.py
@@ -142,7 +142,7 @@ def create_import_contact(
             application.get_expected_task(Task.TaskType.PREPARE, select_for_update=False)
             template = "web/domains/case/import/fa/import-contacts/create.html"
 
-        if request.POST:
+        if request.method == "POST":
             form = form_class(data=request.POST)
 
             if form.is_valid():
@@ -208,7 +208,7 @@ def edit_import_contact(
             application.get_expected_task(Task.TaskType.PREPARE, select_for_update=False)
             template = "web/domains/case/import/fa/import-contacts/edit.html"
 
-        if request.POST:
+        if request.method == "POST":
             form = form_class(data=request.POST, instance=person)
 
             if form.is_valid():
@@ -315,7 +315,7 @@ def create_certificate(request: AuthenticatedHttpRequest, *, application_pk: int
 
         task = get_application_current_task(application, "import", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = UserImportCertificateForm(
                 data=request.POST, application=application, files=request.FILES
             )
@@ -371,7 +371,7 @@ def edit_certificate(
 
         task = get_application_current_task(application, "import", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = UserImportCertificateForm(
                 data=request.POST, application=application, instance=certificate
             )
@@ -548,7 +548,7 @@ def provide_report(request: AuthenticatedHttpRequest, *, application_pk: int) ->
 
         form_class = _get_supplementary_info_form(application)
 
-        if request.POST:
+        if request.method == "POST":
             form = form_class(
                 data=request.POST, instance=application.supplementary_info, application=application
             )
@@ -623,7 +623,7 @@ def create_report(request: AuthenticatedHttpRequest, *, application_pk: int) -> 
         supplementary_info: FaSupplementaryInfo = application.supplementary_info
         form_class = _get_supplementary_report_form(application)
 
-        if request.POST:
+        if request.method == "POST":
             form = form_class(data=request.POST, application=application)
 
             if form.is_valid():
@@ -675,7 +675,7 @@ def edit_report(
         report_type = _get_report_type(application)
         form_class = _get_supplementary_report_form(application)
 
-        if request.POST:
+        if request.method == "POST":
             form = form_class(data=request.POST, instance=report, application=application)
 
             if form.is_valid():

--- a/web/domains/case/_import/fa_dfl/views.py
+++ b/web/domains/case/_import/fa_dfl/views.py
@@ -62,7 +62,7 @@ def edit_dfl(request: AuthenticatedHttpRequest, *, application_pk: int) -> HttpR
 
         task = get_application_current_task(application, "import", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = PrepareDFLForm(data=request.POST, instance=application)
 
             if form.is_valid():
@@ -103,7 +103,7 @@ def add_goods_certificate(
         check_application_permission(application, request.user, "import")
         task = get_application_current_task(application, "import", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = AddDLFGoodsCertificateForm(data=request.POST, files=request.FILES)
 
             if form.is_valid():
@@ -153,7 +153,7 @@ def edit_goods_certificate(
 
         document = application.goods_certificates.get(pk=document_pk)
 
-        if request.POST:
+        if request.method == "POST":
             form = EditDLFGoodsCertificateForm(data=request.POST, instance=document)
 
             if form.is_valid():
@@ -196,7 +196,7 @@ def edit_goods_certificate_description(
 
         document = application.goods_certificates.get(pk=document_pk)
 
-        if request.POST:
+        if request.method == "POST":
             form = EditDFLGoodsCertificateDescriptionForm(data=request.POST, instance=document)
 
             if form.is_valid():
@@ -271,7 +271,7 @@ def submit_dfl(request: AuthenticatedHttpRequest, *, application_pk: int) -> Htt
 
         errors = _get_dfl_errors(application)
 
-        if request.POST:
+        if request.method == "POST":
             form = SubmitForm(data=request.POST)
 
             if form.is_valid() and not errors.has_errors():
@@ -426,7 +426,7 @@ def add_report_firearm_manual(
         report: DFLSupplementaryReport = supplementary_info.reports.get(pk=report_pk)
         goods_certificate: DFLGoodsCertificate = application.goods_certificates.get(pk=goods_pk)
 
-        if request.POST:
+        if request.method == "POST":
             form = DFLSupplementaryReportFirearmForm(data=request.POST)
 
             if form.is_valid():
@@ -481,7 +481,7 @@ def edit_report_firearm_manual(
         report: DFLSupplementaryReport = supplementary_info.reports.get(pk=report_pk)
         report_firearm: DFLSupplementaryReportFirearm = report.firearms.get(pk=report_firearm_pk)
 
-        if request.POST:
+        if request.method == "POST":
             form = DFLSupplementaryReportFirearmForm(data=request.POST, instance=report_firearm)
 
             if form.is_valid():
@@ -533,7 +533,7 @@ def add_report_firearm_upload(
         report: DFLSupplementaryReport = supplementary_info.reports.get(pk=report_pk)
         goods_certificate: DFLGoodsCertificate = application.goods_certificates.get(pk=goods_pk)
 
-        if request.POST:
+        if request.method == "POST":
             form = DFLSupplementaryReportUploadFirearmForm(data=request.POST, files=request.FILES)
 
             if form.is_valid():

--- a/web/domains/case/_import/fa_oil/views.py
+++ b/web/domains/case/_import/fa_oil/views.py
@@ -54,7 +54,7 @@ def edit_oil(request: AuthenticatedHttpRequest, *, application_pk: int) -> HttpR
 
         task = get_application_current_task(application, "import", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = PrepareOILForm(data=request.POST, instance=application)
 
             if form.is_valid():
@@ -139,7 +139,7 @@ def submit_oil(request: AuthenticatedHttpRequest, *, application_pk: int) -> Htt
 
         errors.add(get_org_update_request_errors(application, "import"))
 
-        if request.POST:
+        if request.method == "POST":
             form = SubmitForm(data=request.POST)
 
             if form.is_valid() and not errors.has_errors():
@@ -261,7 +261,7 @@ def add_report_firearm_manual(
         supplementary_info: OILSupplementaryInfo = application.supplementary_info
         report: OILSupplementaryReport = supplementary_info.reports.get(pk=report_pk)
 
-        if request.POST:
+        if request.method == "POST":
             form = OILSupplementaryReportFirearmForm(data=request.POST)
 
             if form.is_valid():
@@ -317,7 +317,7 @@ def edit_report_firearm_manual(
 
         report_firearm: OILSupplementaryReportFirearm = report.firearms.get(pk=report_firearm_pk)
 
-        if request.POST:
+        if request.method == "POST":
             form = OILSupplementaryReportFirearmForm(data=request.POST, instance=report_firearm)
 
             if form.is_valid():
@@ -365,7 +365,7 @@ def add_report_firearm_upload(
         supplementary_info: OILSupplementaryInfo = application.supplementary_info
         report: OILSupplementaryReport = supplementary_info.reports.get(pk=report_pk)
 
-        if request.POST:
+        if request.method == "POST":
             form = OILSupplementaryReportUploadFirearmForm(data=request.POST, files=request.FILES)
 
             if form.is_valid():

--- a/web/domains/case/_import/fa_sil/views.py
+++ b/web/domains/case/_import/fa_sil/views.py
@@ -321,7 +321,7 @@ def edit(request: AuthenticatedHttpRequest, *, application_pk: int) -> HttpRespo
 
         task = get_application_current_task(application, "import", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = forms.EditFaSILForm(data=request.POST, instance=application)
 
             if form.is_valid():
@@ -401,7 +401,7 @@ def add_section(
 
         config = _get_sil_section_app_config(sil_section_type)
 
-        if request.POST:
+        if request.method == "POST":
             form = config.form_class(request.POST)
 
             if form.is_valid():
@@ -445,7 +445,7 @@ def edit_section(
 
         task = get_application_current_task(application, "import", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = config.form_class(request.POST, instance=goods)
             if form.is_valid():
                 goods = form.save(commit=False)
@@ -512,7 +512,7 @@ def response_preparation_edit_goods(
         config = _get_sil_section_resp_prep_config(sil_section_type)
         goods: types.GoodsModel = get_object_or_404(config.model_class, pk=section_pk)
 
-        if request.POST:
+        if request.method == "POST":
             form = config.form_class(request.POST, instance=goods)
             if form.is_valid():
                 form.save()
@@ -553,7 +553,7 @@ def submit(request: AuthenticatedHttpRequest, *, application_pk: int) -> HttpRes
 
         errors = _get_sil_errors(application)
 
-        if request.POST:
+        if request.method == "POST":
             form = SubmitForm(data=request.POST)
 
             if form.is_valid() and not errors.has_errors():
@@ -810,7 +810,7 @@ def set_cover_letter(request: AuthenticatedHttpRequest, *, application_pk: int) 
         )
         task = get_application_current_task(application, "import", Task.TaskType.PROCESS)
 
-        if request.POST:
+        if request.method == "POST":
             form = forms.SILCoverLetterTemplateForm(request.POST)
             if form.is_valid():
                 template = form.cleaned_data["template"]
@@ -880,7 +880,7 @@ def add_report_firearm_manual(
 
         form_class = _get_report_firearm_form_class(sil_section_type)
 
-        if request.POST:
+        if request.method == "POST":
             form = form_class(data=request.POST)
 
             if form.is_valid():
@@ -943,7 +943,7 @@ def edit_report_firearm_manual(
 
         form_class = _get_report_firearm_form_class(sil_section_type)
 
-        if request.POST:
+        if request.method == "POST":
             form = form_class(instance=report_firearm, data=request.POST)
 
             if form.is_valid():

--- a/web/domains/case/_import/ironsteel/views.py
+++ b/web/domains/case/_import/ironsteel/views.py
@@ -52,7 +52,7 @@ def edit_ironsteel(request: AuthenticatedHttpRequest, *, application_pk: int) ->
 
         task = get_application_current_task(application, "import", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = EditIronSteelForm(data=request.POST, instance=application)
 
             if form.is_valid():
@@ -165,7 +165,7 @@ def submit_ironsteel(request: AuthenticatedHttpRequest, *, application_pk: int) 
 
         errors.add(get_org_update_request_errors(application, "import"))
 
-        if request.POST:
+        if request.method == "POST":
             form = SubmitForm(data=request.POST)
 
             if form.is_valid() and not errors.has_errors():
@@ -217,7 +217,7 @@ def add_document(request: AuthenticatedHttpRequest, *, application_pk: int) -> H
 
         task = get_application_current_task(application, "import", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = DocumentForm(data=request.POST, files=request.FILES)
 
             if form.is_valid():
@@ -288,7 +288,7 @@ def add_certificate(request: AuthenticatedHttpRequest, *, application_pk: int) -
 
         task = get_application_current_task(application, "import", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = AddCertificateForm(data=request.POST, files=request.FILES)
 
             if form.is_valid():
@@ -371,7 +371,7 @@ def edit_certificate(
 
         document = application.certificates.get(pk=document_pk)
 
-        if request.POST:
+        if request.method == "POST":
             form = EditCertificateForm(data=request.POST, instance=document)
 
             if form.is_valid():
@@ -457,7 +457,7 @@ def response_preparation_edit_goods(
 
         task = get_application_current_task(application, "import", Task.TaskType.PROCESS)
 
-        if request.POST:
+        if request.method == "POST":
             form = ResponsePrepGoodsForm(data=request.POST, instance=application)
 
             if form.is_valid():
@@ -503,7 +503,7 @@ def response_preparation_edit_certificate(
 
         document = application.certificates.get(pk=document_pk)
 
-        if request.POST:
+        if request.method == "POST":
             form = ResponsePrepCertificateForm(data=request.POST, instance=document)
 
             if form.is_valid():

--- a/web/domains/case/_import/opt/views.py
+++ b/web/domains/case/_import/opt/views.py
@@ -53,7 +53,7 @@ def edit_opt(request: AuthenticatedHttpRequest, *, application_pk: int) -> HttpR
 
         task = get_application_current_task(application, "import", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = EditOPTForm(data=request.POST, instance=application)
 
             if form.is_valid():
@@ -98,7 +98,7 @@ def edit_compensating_products(
 
         task = get_application_current_task(application, "import", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = CompensatingProductsOPTForm(data=request.POST, instance=application)
 
             if form.is_valid():
@@ -146,7 +146,7 @@ def edit_temporary_exported_goods(
 
         task = get_application_current_task(application, "import", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = TemporaryExportedGoodsOPTForm(data=request.POST, instance=application)
 
             if form.is_valid():
@@ -189,7 +189,7 @@ def edit_further_questions(
 
         task = get_application_current_task(application, "import", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = FurtherQuestionsOPTForm(data=request.POST, instance=application)
 
             if form.is_valid():
@@ -232,7 +232,7 @@ def edit_further_questions_shared(
 
         form_class = get_fq_form(fq_type)
 
-        if request.POST:
+        if request.method == "POST":
             has_files = application.documents.filter(is_active=True, file_type=fq_type).exists()
 
             form = form_class(data=request.POST, instance=application, has_files=has_files)
@@ -352,7 +352,7 @@ def submit_opt(request: AuthenticatedHttpRequest, *, application_pk: int) -> Htt
 
         errors.add(get_org_update_request_errors(application, "import"))
 
-        if request.POST:
+        if request.method == "POST":
             form = SubmitForm(data=request.POST)
 
             if form.is_valid() and not errors.has_errors():
@@ -420,7 +420,7 @@ def add_document(
 
         task = get_application_current_task(application, "import", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = DocumentForm(data=request.POST, files=request.FILES)
 
             if form.is_valid():
@@ -554,7 +554,7 @@ def response_preparation_edit_compensating_products(
 
         task = get_application_current_task(application, "import", Task.TaskType.PROCESS)
 
-        if request.POST:
+        if request.method == "POST":
             form = ResponsePrepCompensatingProductsOPTForm(data=request.POST, instance=application)
 
             if form.is_valid():
@@ -595,7 +595,7 @@ def response_preparation_edit_temporary_exported_goods(
 
         task = get_application_current_task(application, "import", Task.TaskType.PROCESS)
 
-        if request.POST:
+        if request.method == "POST":
             form = ResponsePrepTemporaryExportedGoodsOPTForm(
                 data=request.POST, instance=application
             )

--- a/web/domains/case/_import/sanctions/views.py
+++ b/web/domains/case/_import/sanctions/views.py
@@ -145,7 +145,7 @@ def edit_goods(
         task = get_application_current_task(application, "import", Task.TaskType.PREPARE)
 
         goods = get_object_or_404(application.sanctionsandadhocapplicationgoods_set, pk=goods_pk)
-        if request.POST:
+        if request.method == "POST":
             form = GoodsForm(request.POST, instance=goods, application=application)
 
             if form.is_valid():
@@ -199,7 +199,7 @@ def edit_goods_licence(
 
         goods = get_object_or_404(application.sanctionsandadhocapplicationgoods_set, pk=goods_pk)
 
-        if request.POST:
+        if request.method == "POST":
             form = GoodsSanctionsLicenceForm(request.POST, instance=goods)
 
             if form.is_valid():
@@ -374,7 +374,7 @@ def submit_sanctions(request: AuthenticatedHttpRequest, *, application_pk: int) 
 
         errors.add(get_org_update_request_errors(application, "import"))
 
-        if request.POST:
+        if request.method == "POST":
             form = SubmitForm(data=request.POST)
 
             if form.is_valid() and not errors.has_errors():

--- a/web/domains/case/_import/sps/views.py
+++ b/web/domains/case/_import/sps/views.py
@@ -47,7 +47,7 @@ def edit_sps(request: AuthenticatedHttpRequest, *, application_pk: int) -> HttpR
 
         task = get_application_current_task(application, "import", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = EditSPSForm(data=request.POST, instance=application)
 
             if form.is_valid():
@@ -117,7 +117,7 @@ def submit_sps(request: AuthenticatedHttpRequest, *, application_pk: int) -> Htt
 
         errors.add(get_org_update_request_errors(application, "import"))
 
-        if request.POST:
+        if request.method == "POST":
             form = SubmitForm(data=request.POST)
 
             if form.is_valid() and not errors.has_errors():
@@ -162,7 +162,7 @@ def add_supporting_document(
 
         task = get_application_current_task(application, "import", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = DocumentForm(data=request.POST, files=request.FILES)
 
             if form.is_valid():
@@ -235,7 +235,7 @@ def add_contract_document(
 
         task = get_application_current_task(application, "import", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = AddContractDocumentForm(data=request.POST, files=request.FILES)
 
             if application.contract_file:
@@ -339,7 +339,7 @@ def edit_contract_document(
 
         document = application.contract_file
 
-        if request.POST:
+        if request.method == "POST":
             form = EditContractDocumentForm(data=request.POST, instance=document)
 
             if not document:
@@ -379,7 +379,7 @@ def response_preparation_edit_goods(
 
         task = get_application_current_task(application, "import", Task.TaskType.PROCESS)
 
-        if request.POST:
+        if request.method == "POST":
             form = ResponsePrepGoodsForm(data=request.POST, instance=application)
 
             if form.is_valid():

--- a/web/domains/case/_import/textiles/views.py
+++ b/web/domains/case/_import/textiles/views.py
@@ -46,7 +46,7 @@ def edit_textiles(request: AuthenticatedHttpRequest, *, application_pk: int) -> 
 
         task = get_application_current_task(application, "import", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = EditTextilesForm(data=request.POST, instance=application)
 
             if form.is_valid():
@@ -113,7 +113,7 @@ def submit_textiles(request: AuthenticatedHttpRequest, *, application_pk: int) -
 
         errors.add(get_org_update_request_errors(application, "import"))
 
-        if request.POST:
+        if request.method == "POST":
             form = SubmitForm(data=request.POST)
 
             if form.is_valid() and not errors.has_errors():
@@ -166,7 +166,7 @@ def add_document(request: AuthenticatedHttpRequest, *, application_pk: int) -> H
 
         task = get_application_current_task(application, "import", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = DocumentForm(data=request.POST, files=request.FILES)
 
             if form.is_valid():
@@ -285,7 +285,7 @@ def edit_goods_licence(request: AuthenticatedHttpRequest, *, application_pk: int
 
         task = get_application_current_task(application, "import", Task.TaskType.PROCESS)
 
-        if request.POST:
+        if request.method == "POST":
             form = GoodsTextilesLicenceForm(request.POST, instance=application)
 
             if form.is_valid():

--- a/web/domains/case/_import/views.py
+++ b/web/domains/case/_import/views.py
@@ -223,7 +223,7 @@ def _create_application(
     if form_class is None:
         form_class = CreateImportApplicationForm
 
-    if request.POST:
+    if request.method == "POST":
         form = form_class(request.POST, user=request.user)
 
         if form.is_valid():
@@ -290,7 +290,7 @@ def edit_cover_letter(request: AuthenticatedHttpRequest, *, application_pk: int)
 
         task = get_application_current_task(application, "import", Task.TaskType.PROCESS)
 
-        if request.POST:
+        if request.method == "POST":
             form = CoverLetterForm(request.POST, instance=application)
 
             if form.is_valid():
@@ -341,7 +341,7 @@ def edit_licence(request: AuthenticatedHttpRequest, *, application_pk: int) -> H
         else:
             form_class = LicenceDateForm
 
-        if request.POST:
+        if request.method == "POST":
             form = form_class(request.POST, instance=application)
 
             if form.is_valid():
@@ -395,7 +395,7 @@ def _add_endorsement(
 
         task = get_application_current_task(application, "import", Task.TaskType.PROCESS)
 
-        if request.POST:
+        if request.method == "POST":
             form = Form(request.POST)
 
             if form.is_valid():
@@ -440,7 +440,7 @@ def edit_endorsement(
 
         task = get_application_current_task(application, "import", Task.TaskType.PROCESS)
 
-        if request.POST:
+        if request.method == "POST":
             form = EndorsementImportApplicationForm(request.POST, instance=endorsement)
 
             if form.is_valid():

--- a/web/domains/case/_import/wood/views.py
+++ b/web/domains/case/_import/wood/views.py
@@ -48,7 +48,7 @@ def edit_wood_quota(request: AuthenticatedHttpRequest, *, application_pk: int) -
 
         task = get_application_current_task(application, "import", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = PrepareWoodQuotaForm(data=request.POST, instance=application)
 
             if form.is_valid():
@@ -92,7 +92,7 @@ def add_supporting_document(
 
         task = get_application_current_task(application, "import", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = DocumentForm(data=request.POST, files=request.FILES)
 
             if form.is_valid():
@@ -163,7 +163,7 @@ def add_contract_document(
 
         task = get_application_current_task(application, "import", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = AddContractDocumentForm(data=request.POST, files=request.FILES)
 
             if form.is_valid():
@@ -246,7 +246,7 @@ def edit_contract_document(
 
         document = application.contract_documents.get(pk=document_pk)
 
-        if request.POST:
+        if request.method == "POST":
             form = EditContractDocumentForm(data=request.POST, instance=document)
 
             if form.is_valid():
@@ -312,7 +312,7 @@ def submit_wood_quota(request: AuthenticatedHttpRequest, *, application_pk: int)
 
         errors.add(get_org_update_request_errors(application, "import"))
 
-        if request.POST:
+        if request.method == "POST":
             form = SubmitForm(data=request.POST)
 
             if form.is_valid() and not errors.has_errors():
@@ -404,7 +404,7 @@ def edit_goods(request: AuthenticatedHttpRequest, *, application_pk: int) -> Htt
 
         task = get_application_current_task(application, "import", Task.TaskType.PROCESS)
 
-        if request.POST:
+        if request.method == "POST":
             form = GoodsWoodQuotaLicenceForm(request.POST, instance=application)
 
             if form.is_valid():

--- a/web/domains/case/access/approval/views.py
+++ b/web/domains/case/access/approval/views.py
@@ -47,7 +47,7 @@ def management_access_approval(
         except ApprovalRequest.DoesNotExist:
             approval_request = None
 
-        if request.POST:
+        if request.method == "POST":
             form = Form(application, data=request.POST)
             if form.is_valid():
 
@@ -223,7 +223,7 @@ def case_approval_respond(
 
         get_application_current_task(application, "access", Task.TaskType.PROCESS)
 
-        if request.POST:
+        if request.method == "POST":
             form = ApprovalRequestResponseForm(request.POST, instance=approval)
             if form.is_valid():
                 approval = form.save(commit=False)

--- a/web/domains/case/access/views.py
+++ b/web/domains/case/access/views.py
@@ -89,7 +89,7 @@ class ListExporterAccessRequest(ModelFilterView):
 @login_required
 def importer_access_request(request: AuthenticatedHttpRequest) -> HttpResponse:
     with transaction.atomic():
-        if request.POST:
+        if request.method == "POST":
             form = forms.ImporterAccessRequestForm(data=request.POST)
 
             if form.is_valid():
@@ -139,7 +139,7 @@ def exporter_access_request(request: AuthenticatedHttpRequest) -> HttpResponse:
     with transaction.atomic():
         form = forms.ExporterAccessRequestForm()
 
-        if request.POST:
+        if request.method == "POST":
             form = forms.ExporterAccessRequestForm(data=request.POST)
 
             if form.is_valid():
@@ -200,7 +200,7 @@ def management(request, pk, entity):
 
         task = get_application_current_task(application, "access", Task.TaskType.PROCESS)
 
-        if request.POST:
+        if request.method == "POST":
             form = Form(instance=application, data=request.POST)
             if form.is_valid():
                 form.save()
@@ -243,7 +243,7 @@ def management_response(request, pk, entity):
 
         task = get_application_current_task(application, "access", Task.TaskType.PROCESS)
 
-        if request.POST:
+        if request.method == "POST":
             form = forms.CloseAccessRequestForm(instance=application, data=request.POST)
             if form.is_valid():
                 form.save()

--- a/web/domains/case/export/views.py
+++ b/web/domains/case/export/views.py
@@ -116,7 +116,7 @@ def create_export_application(
     else:
         app_template = None
 
-    if request.POST:
+    if request.method == "POST":
         form = config.form_class(request.POST, user=request.user)
 
         if form.is_valid():
@@ -246,7 +246,7 @@ def edit_com(request: AuthenticatedHttpRequest, *, application_pk: int) -> HttpR
         check_application_permission(application, request.user, "export")
         task = get_application_current_task(application, "export", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = PrepareCertManufactureForm(data=request.POST, instance=application)
 
             if form.is_valid():
@@ -293,7 +293,7 @@ def submit_com(request: AuthenticatedHttpRequest, *, application_pk: int) -> Htt
 
         errors.add(get_org_update_request_errors(application, "export"))
 
-        if request.POST:
+        if request.method == "POST":
             form = SubmitForm(data=request.POST)
 
             if form.is_valid() and not errors.has_errors():
@@ -326,7 +326,7 @@ def edit_cfs(request: AuthenticatedHttpRequest, *, application_pk: int) -> HttpR
         check_application_permission(application, request.user, "export")
         task = get_application_current_task(application, "export", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = EditCFSForm(data=request.POST, instance=application)
 
             if form.is_valid():
@@ -389,7 +389,7 @@ def cfs_edit_schedule(
             CFSSchedule.objects.select_for_update(), pk=schedule_pk
         )
 
-        if request.POST:
+        if request.method == "POST":
             form = EditCFScheduleForm(data=request.POST, instance=schedule)
 
             if form.is_valid():
@@ -468,7 +468,7 @@ def cfs_set_manufacturer(
             CFSSchedule.objects.select_for_update(), pk=schedule_pk
         )
 
-        if request.POST:
+        if request.method == "POST":
             form = CFSManufacturerDetailsForm(data=request.POST, instance=schedule)
 
             if form.is_valid():
@@ -545,7 +545,7 @@ def cfs_add_product(
             CFSSchedule.objects.select_for_update(), pk=schedule_pk
         )
 
-        if request.POST:
+        if request.method == "POST":
             form = CFSProductForm(data=request.POST, schedule=schedule)
 
             if form.is_valid():
@@ -609,7 +609,7 @@ def cfs_edit_product(
             schedule.products.select_for_update(), pk=product_pk
         )
 
-        if request.POST:
+        if request.method == "POST":
             form = CFSProductForm(data=request.POST, instance=product, schedule=schedule)
 
             if form.is_valid():
@@ -695,7 +695,7 @@ def cfs_add_ingredient(
             schedule.products.select_for_update(), pk=product_pk
         )
 
-        if request.POST:
+        if request.method == "POST":
             form = CFSActiveIngredientForm(data=request.POST, product=product)
 
             if form.is_valid():
@@ -757,7 +757,7 @@ def cfs_edit_ingredient(
             product.active_ingredients.select_for_update(), pk=ingredient_pk
         )
 
-        if request.POST:
+        if request.method == "POST":
             form = CFSActiveIngredientForm(data=request.POST, instance=ingredient, product=product)
 
             if form.is_valid():
@@ -855,7 +855,7 @@ def cfs_add_product_type(
             schedule.products.select_for_update(), pk=product_pk
         )
 
-        if request.POST:
+        if request.method == "POST":
             form = CFSProductTypeForm(data=request.POST, product=product)
 
             if form.is_valid():
@@ -917,7 +917,7 @@ def cfs_edit_product_type(
             product.product_type_numbers.select_for_update(), pk=product_type_pk
         )
 
-        if request.POST:
+        if request.method == "POST":
             form = CFSProductTypeForm(data=request.POST, instance=product_type, product=product)
 
             if form.is_valid():
@@ -1160,7 +1160,7 @@ def submit_cfs(request: AuthenticatedHttpRequest, *, application_pk: int) -> Htt
 
         errors = _get_cfs_errors(application)
 
-        if request.POST:
+        if request.method == "POST":
             form = SubmitForm(data=request.POST)
 
             if form.is_valid() and not errors.has_errors():
@@ -1296,7 +1296,7 @@ def edit_gmp(request: AuthenticatedHttpRequest, *, application_pk: int) -> HttpR
 
         task = get_application_current_task(application, "export", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = EditGMPForm(data=request.POST, instance=application)
 
             if form.is_valid():
@@ -1370,7 +1370,7 @@ def add_gmp_document(
 
         task = get_application_current_task(application, "export", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = DocumentForm(data=request.POST, files=request.FILES)
 
             if form.is_valid():
@@ -1465,7 +1465,7 @@ def submit_gmp(request: AuthenticatedHttpRequest, *, application_pk: int) -> Htt
 
         errors.add(get_org_update_request_errors(application, "export"))
 
-        if request.POST:
+        if request.method == "POST":
             form = SubmitForm(data=request.POST)
 
             if form.is_valid() and not errors.has_errors():
@@ -1544,7 +1544,7 @@ def gmp_add_brand(request: AuthenticatedHttpRequest, *, application_pk: int) -> 
 
         task = get_application_current_task(application, "export", Task.TaskType.PREPARE)
 
-        if request.POST:
+        if request.method == "POST":
             form = GMPBrandForm(data=request.POST)
 
             if form.is_valid():
@@ -1589,7 +1589,7 @@ def gmp_edit_brand(
         if not instance:
             return redirect(reverse("export:gmp-edit", kwargs={"application_pk": application_pk}))
 
-        if request.POST:
+        if request.method == "POST":
             form = GMPBrandForm(instance=instance, data=request.POST)
 
             if form.is_valid():

--- a/web/domains/case/views/views_email.py
+++ b/web/domains/case/views/views_email.py
@@ -146,7 +146,7 @@ def edit_case_email(
         )
 
         case_email_config = _get_case_email_config(application)
-        if request.POST:
+        if request.method == "POST":
             form = forms.CaseEmailForm(
                 request.POST, instance=case_email, case_email_config=case_email_config
             )
@@ -262,7 +262,7 @@ def add_response_case_email(
 
         case_email = get_object_or_404(application.case_emails, pk=case_email_pk)
 
-        if request.POST:
+        if request.method == "POST":
             form = forms.CaseEmailResponseForm(request.POST, instance=case_email)
             if form.is_valid():
                 case_email = form.save(commit=False)

--- a/web/domains/case/views/views_fir.py
+++ b/web/domains/case/views/views_fir.py
@@ -149,7 +149,7 @@ def edit_fir(request, *, application_pk: int, fir_pk: int, case_type: str) -> Ht
 
         task = get_application_current_task(application, case_type, Task.TaskType.PROCESS)
 
-        if request.POST:
+        if request.method == "POST":
             form = fir_forms.FurtherInformationRequestForm(request.POST, instance=fir)
 
             if form.is_valid():
@@ -280,7 +280,7 @@ def _add_fir_file(
 
         fir = get_object_or_404(application.further_information_requests, pk=fir_pk)
 
-        if request.POST:
+        if request.method == "POST":
             form = forms.DocumentForm(data=request.POST, files=request.FILES)
 
             if form.is_valid():
@@ -427,7 +427,7 @@ def respond_fir(
         )
         fir = get_object_or_404(application.further_information_requests.open(), pk=fir_pk)
 
-        if request.POST:
+        if request.method == "POST":
             form = fir_forms.FurtherInformationRequestResponseForm(instance=fir, data=request.POST)
 
             if form.is_valid():

--- a/web/domains/case/views/views_misc.py
+++ b/web/domains/case/views/views_misc.py
@@ -78,7 +78,7 @@ def withdraw_case(
             [ImpExpStatus.SUBMITTED, ImpExpStatus.PROCESSING, ImpExpStatus.VARIATION_REQUESTED]
         )
 
-        if request.POST:
+        if request.method == "POST":
             form = forms.WithdrawForm(request.POST)
 
             if form.is_valid():
@@ -435,7 +435,7 @@ def authorise_documents(
 
         task = get_application_current_task(application, case_type, Task.TaskType.AUTHORISE)
 
-        if request.POST:
+        if request.method == "POST":
             form = forms.AuthoriseForm(data=request.POST, request=request)
 
             if form.is_valid():
@@ -592,7 +592,7 @@ def ack_notification(
         check_application_permission(application, request.user, case_type)
         application.check_expected_status([ImpExpStatus.COMPLETED])
 
-        if request.POST:
+        if request.method == "POST":
             task = application.get_expected_task(Task.TaskType.ACK, select_for_update=True)
             form = forms.AckReceiptForm(request.POST)
 

--- a/web/domains/case/views/views_note.py
+++ b/web/domains/case/views/views_note.py
@@ -145,7 +145,7 @@ def edit_note(
                 )
             )
 
-        if request.POST:
+        if request.method == "POST":
             note_form = forms.CaseNoteForm(request.POST, instance=note)
 
             if note_form.is_valid():
@@ -195,7 +195,7 @@ def add_note_document(
 
         note = application.case_notes.get(pk=note_pk)
 
-        if request.POST:
+        if request.method == "POST":
             form = forms.DocumentForm(data=request.POST, files=request.FILES)
 
             if form.is_valid():

--- a/web/domains/case/views/views_update_request.py
+++ b/web/domains/case/views/views_update_request.py
@@ -191,7 +191,7 @@ def start_update_request(
         )
         previous_update_requests = update_requests.filter(status=models.UpdateRequest.Status.CLOSED)
 
-        if request.POST:
+        if request.method == "POST":
             update_request.status = models.UpdateRequest.Status.UPDATE_IN_PROGRESS
             update_request.save()
 
@@ -238,7 +238,7 @@ def respond_update_request(
         )
         previous_update_requests = update_requests.filter(status=models.UpdateRequest.Status.CLOSED)
 
-        if request.POST:
+        if request.method == "POST":
             form = forms.UpdateRequestResponseForm(request.POST, instance=update_request)
             if form.is_valid():
                 update_request = form.save(commit=False)

--- a/web/domains/cat/views.py
+++ b/web/domains/cat/views.py
@@ -57,7 +57,7 @@ def create(request: AuthenticatedHttpRequest) -> HttpResponse:
         if not _has_permission(request.user):
             raise PermissionDenied
 
-        if request.POST:
+        if request.method == "POST":
             form = CreateCATForm(request.POST)
             if form.is_valid():
                 cat = form.save(commit=False)

--- a/web/domains/commodity/views.py
+++ b/web/domains/commodity/views.py
@@ -138,7 +138,7 @@ class CommodityGroupDetailView(ModelDetailView):
 def add_usage(request, pk):
     commodity_group = get_object_or_404(CommodityGroup, pk=pk)
 
-    if request.POST:
+    if request.method == "POST":
         form = UsageForm(request.POST, initial={"commodity_group": pk})
         if form.is_valid():
             usage = form.save()
@@ -164,7 +164,7 @@ def edit_usage(request, commodity_group_pk, usage_pk):
     commodity_group = get_object_or_404(CommodityGroup, pk=commodity_group_pk)
     usage = get_object_or_404(Usage, pk=usage_pk)
 
-    if request.POST:
+    if request.method == "POST":
         form = UsageForm(request.POST, instance=usage)
         if form.is_valid():
             form.save()

--- a/web/domains/exporter/views.py
+++ b/web/domains/exporter/views.py
@@ -38,7 +38,7 @@ class ExporterListView(ModelFilterView):
 def edit_exporter(request: AuthenticatedHttpRequest, *, pk: int) -> HttpResponse:
     exporter: Exporter = get_object_or_404(Exporter, pk=pk)
 
-    if request.POST:
+    if request.method == "POST":
         form = ExporterForm(request.POST, instance=exporter)
         if form.is_valid():
             form.save()
@@ -75,7 +75,7 @@ def detail_exporter(request: AuthenticatedHttpRequest, *, pk: int) -> HttpRespon
 @login_required
 @permission_required("web.ilb_admin", raise_exception=True)
 def create_exporter(request: AuthenticatedHttpRequest) -> HttpResponse:
-    if request.POST:
+    if request.method == "POST":
         form = ExporterForm(request.POST)
         if form.is_valid():
             exporter: Exporter = form.save()
@@ -92,7 +92,7 @@ def create_exporter(request: AuthenticatedHttpRequest) -> HttpResponse:
 def create_office(request, pk):
     exporter = get_object_or_404(Exporter, pk=pk)
 
-    if request.POST:
+    if request.method == "POST":
         form = OfficeForm(request.POST)
         if form.is_valid():
             office = form.save()
@@ -117,7 +117,7 @@ def edit_office(request, exporter_pk, office_pk):
     exporter = get_object_or_404(Exporter, pk=exporter_pk)
     office = get_object_or_404(exporter.offices, pk=office_pk)
 
-    if request.POST:
+    if request.method == "POST":
         form = OfficeForm(request.POST, instance=office)
         if form.is_valid():
             form.save()
@@ -162,7 +162,7 @@ def create_agent(request, exporter_pk):
     exporter: Exporter = get_object_or_404(Exporter, pk=exporter_pk)
 
     initial = {"main_exporter": exporter_pk}
-    if request.POST:
+    if request.method == "POST":
         form = AgentForm(request.POST, initial=initial)
         if form.is_valid():
             agent = form.save()
@@ -184,7 +184,7 @@ def create_agent(request, exporter_pk):
 def edit_agent(request: AuthenticatedHttpRequest, *, pk: int) -> HttpResponse:
     agent: Exporter = get_object_or_404(Exporter.objects.agents(), pk=pk)
 
-    if request.POST:
+    if request.method == "POST":
         form = AgentForm(request.POST, instance=agent)
         if form.is_valid():
             agent = form.save()

--- a/web/domains/firearms/views.py
+++ b/web/domains/firearms/views.py
@@ -58,7 +58,7 @@ class ObsoleteCalibreListView(PostActionMixin, ModelFilterView):
 @login_required
 @permission_required("web.ilb_admin", raise_exception=True)
 def create_obsolete_calibre_group(request):
-    if request.POST:
+    if request.method == "POST":
         form = ObsoleteCalibreGroupForm(request.POST)
         if form.is_valid():
             group = form.save(commit=False)
@@ -84,7 +84,7 @@ def create_obsolete_calibre_group(request):
 def edit_obsolete_calibre_group(request, pk):
     calibre_group = get_object_or_404(ObsoleteCalibreGroup, pk=pk)
 
-    if request.POST:
+    if request.method == "POST":
         form = ObsoleteCalibreGroupForm(request.POST, instance=calibre_group)
         if form.is_valid():
             form.save()
@@ -140,7 +140,7 @@ def unarchive_obsolete_calibre_group(request, pk):
 @permission_required("web.ilb_admin", raise_exception=True)
 def create_obsolete_calibre(request, calibre_group_pk):
     calibre_group = get_object_or_404(ObsoleteCalibreGroup, pk=calibre_group_pk)
-    if request.POST:
+    if request.method == "POST":
         form = ObsoleteCalibreForm(request.POST)
         if form.is_valid():
             calibre = form.save(commit=False)
@@ -173,7 +173,7 @@ def edit_obsolete_calibre(request, calibre_group_pk, calibre_pk):
     calibre_group = get_object_or_404(ObsoleteCalibreGroup, pk=calibre_group_pk)
     calibre = get_object_or_404(calibre_group.calibres, pk=calibre_pk)
 
-    if request.POST:
+    if request.method == "POST":
         form = ObsoleteCalibreForm(request.POST, instance=calibre)
         if form.is_valid():
             form.save()
@@ -245,7 +245,7 @@ def view_obsolete_calibre_group(request, pk):
 def create_firearms(request: AuthenticatedHttpRequest, pk: int) -> HttpResponse:
     importer: Importer = get_object_or_404(Importer, pk=pk)
 
-    if request.POST:
+    if request.method == "POST":
         form = FirearmsAuthorityForm(importer, request.POST, request.FILES)
         ClauseQuantityFormSet = inlineformset_factory(
             FirearmsAuthority, ActQuantity, extra=0, form=FirearmsQuantityForm, can_delete=False
@@ -289,7 +289,7 @@ def create_firearms(request: AuthenticatedHttpRequest, pk: int) -> HttpResponse:
 def edit_firearms(request: AuthenticatedHttpRequest, pk: int) -> HttpResponse:
     firearms: FirearmsAuthority = get_object_or_404(FirearmsAuthority, pk=pk)
 
-    if request.POST:
+    if request.method == "POST":
         ClauseQuantityFormSet = inlineformset_factory(
             FirearmsAuthority, ActQuantity, extra=0, form=FirearmsQuantityForm, can_delete=False
         )
@@ -365,7 +365,7 @@ def unarchive_firearms(request: AuthenticatedHttpRequest, pk: int) -> HttpRespon
 def add_document_firearms(request: AuthenticatedHttpRequest, pk: int) -> HttpResponse:
     firearms: FirearmsAuthority = get_object_or_404(FirearmsAuthority, pk=pk)
 
-    if request.POST:
+    if request.method == "POST":
         form = DocumentForm(data=request.POST, files=request.FILES)
 
         if form.is_valid():

--- a/web/domains/importer/views.py
+++ b/web/domains/importer/views.py
@@ -80,7 +80,7 @@ def edit_importer(request: AuthenticatedHttpRequest, *, pk: int) -> HttpResponse
     else:
         NotImplementedError(f"Unknown importer type {importer.type}")
 
-    if request.POST:
+    if request.method == "POST":
         form = ImporterForm(request.POST, instance=importer)
         if form.is_valid():
             form.save()
@@ -110,7 +110,7 @@ def create_importer(request: AuthenticatedHttpRequest, *, entity_type: str) -> H
     else:
         NotImplementedError(f"Unknown entity type {entity_type}")
 
-    if request.POST:
+    if request.method == "POST":
         form = ImporterForm(request.POST)
         if form.is_valid():
             importer: Importer = form.save()
@@ -133,7 +133,7 @@ def create_importer(request: AuthenticatedHttpRequest, *, entity_type: str) -> H
 def create_section5(request: AuthenticatedHttpRequest, pk: int) -> HttpResponse:
     importer: Importer = get_object_or_404(Importer, pk=pk)
 
-    if request.POST:
+    if request.method == "POST":
         form = Section5AuthorityForm(importer, request.POST, request.FILES)
         ClauseQuantityFormSet = inlineformset_factory(
             Section5Authority, ClauseQuantity, extra=0, form=ClauseQuantityForm, can_delete=False
@@ -177,7 +177,7 @@ def create_section5(request: AuthenticatedHttpRequest, pk: int) -> HttpResponse:
 def edit_section5(request: AuthenticatedHttpRequest, pk: int) -> HttpResponse:
     section5: Section5Authority = get_object_or_404(Section5Authority, pk=pk)
 
-    if request.POST:
+    if request.method == "POST":
         ClauseQuantityFormSet = inlineformset_factory(
             Section5Authority, ClauseQuantity, extra=0, form=ClauseQuantityForm, can_delete=False
         )
@@ -255,7 +255,7 @@ def unarchive_section5(request: AuthenticatedHttpRequest, pk: int) -> HttpRespon
 def add_document_section5(request: AuthenticatedHttpRequest, pk: int) -> HttpResponse:
     section5: Section5Authority = get_object_or_404(Section5Authority, pk=pk)
 
-    if request.POST:
+    if request.method == "POST":
         form = DocumentForm(data=request.POST, files=request.FILES)
 
         if form.is_valid():
@@ -315,7 +315,7 @@ def create_office(request, pk):
     else:
         Form = OfficeEORIForm
 
-    if request.POST:
+    if request.method == "POST":
         form = Form(request.POST)
         if form.is_valid():
             office = form.save()
@@ -344,7 +344,7 @@ def edit_office(request, importer_pk, office_pk):
     else:
         Form = OfficeEORIForm
 
-    if request.POST:
+    if request.method == "POST":
         form = Form(request.POST, instance=office)
         if form.is_valid():
             form.save()
@@ -398,7 +398,7 @@ def create_agent(
         NotImplementedError(f"Unknown entity type {entity_type}")
 
     initial = {"main_importer": importer_pk}
-    if request.POST:
+    if request.method == "POST":
         form = AgentForm(request.POST, initial=initial)
         if form.is_valid():
             agent = form.save()
@@ -429,7 +429,7 @@ def edit_agent(request: AuthenticatedHttpRequest, *, pk: int) -> HttpResponse:
     else:
         AgentForm = AgentIndividualForm
 
-    if request.POST:
+    if request.method == "POST":
         form = AgentForm(request.POST, instance=agent)
         if form.is_valid():
             agent = form.save()

--- a/web/domains/mailshot/views.py
+++ b/web/domains/mailshot/views.py
@@ -321,7 +321,7 @@ def add_document(request: AuthenticatedHttpRequest, *, mailshot_pk: int) -> Http
     with transaction.atomic():
         mailshot = get_object_or_404(Mailshot.objects.select_for_update(), pk=mailshot_pk)
 
-        if request.POST:
+        if request.method == "POST":
             form = DocumentForm(data=request.POST, files=request.FILES)
 
             if form.is_valid():

--- a/web/domains/sanction_email/views.py
+++ b/web/domains/sanction_email/views.py
@@ -27,7 +27,7 @@ class SanctionEmailsListView(ModelFilterView):
 @login_required
 @permission_required("web.ilb_admin", raise_exception=True)
 def create_sanction_email(request):
-    if request.POST:
+    if request.method == "POST":
         form = forms.SanctionEmailForm(request.POST)
         if form.is_valid():
             sanction_email = form.save()
@@ -48,7 +48,7 @@ def create_sanction_email(request):
 def edit_sanction_email(request, pk):
     sanction_email = get_object_or_404(models.SanctionEmail, pk=pk)
 
-    if request.POST:
+    if request.method == "POST":
         form = forms.SanctionEmailForm(request.POST, instance=sanction_email)
         if form.is_valid():
             form.save()

--- a/web/domains/section5/views.py
+++ b/web/domains/section5/views.py
@@ -29,7 +29,7 @@ class ListSection5(ModelFilterView):
 @login_required
 @permission_required("web.ilb_admin", raise_exception=True)
 def create_section5(request):
-    if request.POST:
+    if request.method == "POST":
         form = Section5ClauseForm(request.POST)
         if form.is_valid():
             clause = form.save(commit=False)
@@ -47,7 +47,7 @@ def create_section5(request):
 def edit_section5(request, pk):
     clause = get_object_or_404(Section5Clause, pk=pk)
 
-    if request.POST:
+    if request.method == "POST":
         form = Section5ClauseForm(request.POST, instance=clause)
         if form.is_valid():
             clause = form.save(commit=False)

--- a/web/domains/template/views.py
+++ b/web/domains/template/views.py
@@ -125,7 +125,7 @@ def edit_template(request, pk):
     else:
         raise UnknownTemplateTypeException(f"Unknown template type '{template.template_type}'")
 
-    if request.POST:
+    if request.method == "POST":
         form = TemplateForm(request.POST, instance=template)
         if form.is_valid():
             template = form.save()
@@ -173,7 +173,7 @@ def list_endorsement_usages(request):
 @permission_required("web.ilb_admin", raise_exception=True)
 def edit_endorsement_usage(request, pk):
     usage = get_object_or_404(EndorsementUsage, pk=pk)
-    if request.POST:
+    if request.method == "POST":
         form = EndorsementUsageForm(request.POST)
         if form.is_valid():
             linked_endorsement = form.cleaned_data["linked_endorsement"]
@@ -198,7 +198,7 @@ def archive_endorsement_usage_link(request, usage_pk, link_pk):
 @login_required
 @permission_required("web.ilb_admin", raise_exception=True)
 def create_cfs_declaration_translation(request):
-    if request.POST:
+    if request.method == "POST":
         form = CFSDeclarationTranslationForm(request.POST)
         if form.is_valid():
             template = form.save()
@@ -217,7 +217,7 @@ def create_cfs_declaration_translation(request):
 @permission_required("web.ilb_admin", raise_exception=True)
 def edit_cfs_declaration_translation(request, pk):
     template = get_object_or_404(Template, pk=pk)
-    if request.POST:
+    if request.method == "POST":
         form = CFSDeclarationTranslationForm(request.POST, instance=template)
         if form.is_valid():
             template = form.save()
@@ -234,7 +234,7 @@ def edit_cfs_declaration_translation(request, pk):
 @login_required
 @permission_required("web.ilb_admin", raise_exception=True)
 def create_cfs_schedule_translation(request):
-    if request.POST:
+    if request.method == "POST":
         form = CFSScheduleTranslationForm(request.POST)
 
         if form.is_valid():
@@ -263,7 +263,7 @@ def edit_cfs_schedule_translation(request, pk):
 
     assert len(english_paras) > 0
 
-    if request.POST:
+    if request.method == "POST":
         form = CFSScheduleTranslationForm(request.POST, instance=template)
 
         if form.is_valid():
@@ -300,7 +300,7 @@ def edit_cfs_schedule_translation_paragraphs(request, pk):
 
     assert len(english_paras) > 0
 
-    if request.POST:
+    if request.method == "POST":
         form = CFSScheduleTranslationParagraphsForm(english_paras, data=request.POST)
 
         if form.is_valid():

--- a/web/domains/user/views.py
+++ b/web/domains/user/views.py
@@ -173,7 +173,7 @@ def _details_update(request: AuthenticatedHttpRequest, action: str, pk: int) -> 
             forms["personal_emails_formset"] = new_personal_emails_formset(request)
             messages.success(request, "Central contact details have been saved.")
         else:
-            if request.POST:
+            if request.method == "POST":
                 messages.error(request, "Please correct the highlighted errors.")
 
     return render(
@@ -194,7 +194,7 @@ def _init_user_details_forms(
     user = User.objects.get(pk=pk)
     address = None
 
-    if request.POST:
+    if request.method == "POST":
         if action == "save_address":
             address = request.POST.get("address")
             data = request.session.pop("user_details")

--- a/web/forms/utils.py
+++ b/web/forms/utils.py
@@ -44,7 +44,7 @@ def save_forms_to_session(request, forms):
 
 def remove_from_session(request, key):
     logger.debug('Removing "%s" from session', key)
-    if request.POST:
+    if request.method == "POST":
         data = request.session.pop(key)
         if data:
             return json.loads(data)


### PR DESCRIPTION
Reason for change:
"request.POST" evalulates to false when the POST dictionary is empty.
This is normally fine in production as the csrf token is present in the
post data.
It causes bugs when testing post endpoints that don't have any post data.
e.g. certain file upload views.