### PR TITLE
Upgrade Jinja to fix ci bug.

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -18,7 +18,7 @@ gevent==20.9.0
 gunicorn==20.0.4
 html2text==2020.1.16
 humanize==3.1.0
-Jinja2==2.11.3
+Jinja2==3.0.3
 mohawk==1.1.0
 openpyxl==3.0.7
 phonenumbers==8.12.12


### PR DESCRIPTION
Older versions of jinja use soft_unicode:
![image](https://user-images.githubusercontent.com/8921101/154667566-54327169-4e04-43b8-9c2c-32559b331998.png)

Its deprecated:
![image](https://user-images.githubusercontent.com/8921101/154667538-97fa1748-e0cb-4308-aa1e-194460614414.png)

It has been fixed in Jinja 3.0.0
![image](https://user-images.githubusercontent.com/8921101/154667715-2cfcad3f-d172-4ac7-b490-fbdc1e236267.png)

