### PR TITLE
ICMSLST-1476 Update licence/certificate when a variation is requested.

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -1284,3 +1284,6 @@ ON ird.ir_id =
 updated_at
 Convert
 -O codecov.sh https://codecov.io/bash
+get_import_licence_reference
+CaseReference
+ICMSLST-1477 Disable

--- a/web/domains/case/app_checks.py
+++ b/web/domains/case/app_checks.py
@@ -49,7 +49,10 @@ def get_app_errors(application: ImpOrExp, case_type: str) -> ApplicationErrors:
         application_errors.add(checklist_errors)
 
     # When refusing an application the only thing we check is the checklist.
-    if application.decision == application.REFUSE:
+    if (
+        application.status == application.Statuses.VARIATION_REQUESTED
+        and application.variation_decision == application.REFUSE
+    ) or application.decision == application.REFUSE:
         return application_errors
 
     # Check the response prep screen errors

--- a/web/domains/case/export/views.py
+++ b/web/domains/case/export/views.py
@@ -60,6 +60,7 @@ from .models import (
     CFSProductType,
     CFSSchedule,
     ExportApplication,
+    ExportApplicationCertificate,
     ExportApplicationType,
     GMPFile,
     ProductLegislation,
@@ -150,6 +151,10 @@ def create_export_application(
                         is_active=True
                     ).first()
                     application.countries.add(country)
+
+                # Add a draft certificate when creating an application
+                # Ensures we never have to check for None
+                application.certificates.create(status=ExportApplicationCertificate.Status.DRAFT)
 
             return redirect(
                 reverse(application.get_edit_view_name(), kwargs={"application_pk": application.pk})

--- a/web/domains/case/views/views_variation_request.py
+++ b/web/domains/case/views/views_variation_request.py
@@ -23,7 +23,10 @@ from web.domains.case.models import VariationRequest
 from web.domains.case.services import reference
 from web.domains.case.shared import ImpExpStatus
 from web.domains.case.types import ImpOrExp
-from web.domains.case.utils import check_application_permission
+from web.domains.case.utils import (
+    archive_application_licence_or_certificate,
+    check_application_permission,
+)
 from web.flow.models import Process, Task
 from web.types import AuthenticatedHttpRequest
 
@@ -145,6 +148,9 @@ class VariationRequestCancelView(
             self.application.reference = reference.get_variation_request_case_reference(
                 self.application
             )
+
+        # Cancel the draft licence/Certificate
+        archive_application_licence_or_certificate(self.application)
 
         self.update_application_status()
         self.update_application_tasks()

--- a/web/tests/domains/case/test_utils.py
+++ b/web/tests/domains/case/test_utils.py
@@ -1,0 +1,26 @@
+from web.domains.case._import.models import CaseLicenceCertificateBase
+from web.domains.case.utils import set_application_licence_or_certificate_active
+
+
+def test_set_application_licence_or_certificate_active(wood_app_submitted):
+    assert wood_app_submitted.licences.count() == 1
+
+    licence_1 = wood_app_submitted.get_most_recent_licence()
+    assert licence_1.status == CaseLicenceCertificateBase.Status.DRAFT
+
+    # Set this licence as active so we can test making the second licence active
+    set_application_licence_or_certificate_active(wood_app_submitted)
+    licence_1.refresh_from_db()
+    assert licence_1.status == CaseLicenceCertificateBase.Status.ACTIVE
+
+    # Create a new draft licence
+    licence_2 = wood_app_submitted.licences.create()
+    assert licence_2.status == CaseLicenceCertificateBase.Status.DRAFT
+
+    # Test licence 2 is now active and licence 1 is archived.
+    set_application_licence_or_certificate_active(wood_app_submitted)
+    licence_1.refresh_from_db()
+    licence_2.refresh_from_db()
+
+    assert licence_1.status == CaseLicenceCertificateBase.Status.ARCHIVED
+    assert licence_2.status == CaseLicenceCertificateBase.Status.ACTIVE


### PR DESCRIPTION
Changes:
  - Create a draft licence/certificate when opening a VR.
  - Archive the licence/certificate when cancelling a VR.
  - Filter out archived licences from search results.
  - Create an export licence certificate when creating an export app.
  - Archive old licence when completing a case
  - Set completion date when completing an application.