### PR TITLE
ICMSLST-1442	Clear export app document references before authorising.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 
 [tool.black]
 line-length = 100
-target-version = ['py37']
+target-version = ['py39']
 exclude = '''
 /(
     \.eggs

--- a/web/domains/case/views/views_misc.py
+++ b/web/domains/case/views/views_misc.py
@@ -487,6 +487,9 @@ def _create_export_application_document_references(
     if certificate.status != CaseLicenceCertificateBase.Status.DRAFT:
         raise ValueError("Can only create references for a draft application")
 
+    # Clear all document references as they may have changed
+    certificate.document_references.all().delete()
+
     if application.process_type in [ProcessTypes.COM, ProcessTypes.CFS]:
         app: Union[
             CertificateOfManufactureApplication, CertificateOfFreeSaleApplication


### PR DESCRIPTION
Export applications can change the application countries and brands via a variation request / application update.
Therefore clear any existing document references before creating them.