### PR TITLE
ICMSLST-1460 Move FA-SIL section 5 documents to certificates page.

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -1398,3 +1398,4 @@ COVER_FIREARMS_SEC5"
 Save
 report__supplementary_info__imad
 XMLTYPE.getClobVal(XMLELEMENT("FA_GOODS_CERTS
+Section 5 Authority Documents

--- a/web/templates/web/domains/case/import/fa-sil/add-section5-document.html
+++ b/web/templates/web/domains/case/import/fa-sil/add-section5-document.html
@@ -8,9 +8,9 @@
   <ul class="menu-out flow-across">
     <li>
       <a
-        href="{{ icms_url('import:fa-sil:edit', kwargs={'application_pk': process.pk}) }}"
+        href="{{ icms_url('import:fa:manage-certificates', kwargs={'application_pk': process.pk}) }}"
         class="prev-link">
-        Main Application
+        Certificates
       </a>
     </li>
   </ul>
@@ -18,6 +18,7 @@
 {% endblock %}
 
 {% block main_content %}
+  <h3>Add Section 5 Authority</h3>
   {% call forms.form(action='', method='post', csrf_input=csrf_input, enctype='multipart/form-data') -%}
     {% for field in form %}
       {{fields.field(field)}}

--- a/web/templates/web/domains/case/import/fa-sil/edit.html
+++ b/web/templates/web/domains/case/import/fa-sil/edit.html
@@ -58,19 +58,6 @@
       Add Goods Item
     </a>
   </p>
-
-  <h4>Certificates/Documents</h4>
-  <h5>Section 5 Authorities</h5>
-  {% if verified_section5 %}
-    {% with read_only = False %}
-      {% include "web/domains/case/import/partials/fa-sil/verified-section5-authorities.html" %}
-    {% endwith %}
-  {% else %}
-    <p class="strong">Please upload any Section 5 Authority Document(s) below</p>
-    {% with read_only = False %}
-      {% include "web/domains/case/import/partials/fa-sil/user-section5-authorities.html" %}
-    {% endwith %}
-  {% endif %}
 {% endblock %}
 
 {% block page_js %}

--- a/web/templates/web/domains/case/import/fa-sil/view-verified-section5.html
+++ b/web/templates/web/domains/case/import/fa-sil/view-verified-section5.html
@@ -6,9 +6,9 @@
   <ul class="menu-out flow-across">
     <li>
       <a
-        href="{{ icms_url('import:fa-sil:edit', kwargs={'application_pk': process.pk}) }}"
+        href="{{ icms_url('import:fa:manage-certificates', kwargs={'application_pk': process.pk}) }}"
         class="prev-link">
-        Main Application
+        Certificates
       </a>
     </li>
   </ul>

--- a/web/templates/web/domains/case/import/fa/certificates/manage.html
+++ b/web/templates/web/domains/case/import/fa/certificates/manage.html
@@ -2,16 +2,16 @@
 
 
 {% block content_actions %}
-<div class="content-actions">
-  <ul class="menu-out flow-across">
-    <li>
+  <div class="content-actions">
+    <ul class="menu-out flow-across">
+      <li>
         <a href="{{ icms_url(process.get_edit_view_name(), kwargs={'application_pk': process.pk}) }}"
-          class="prev-link">
+           class="prev-link">
           Main Application
         </a>
-    </li>
-  </ul>
-</div>
+      </li>
+    </ul>
+  </div>
 {% endblock %}
 
 {% block main_content %}
@@ -20,4 +20,26 @@
 
   <h3>Other Certificates</h3>
   {% include "partial/certificates/list.html" %}
+
+  {# Application specific certificates #}
+  {% if process.process_type == "SILApplication" %}
+    <h3>Section 5 Authorities</h3>
+    {% if process.section5 %}
+      {% if verified_section5 %}
+        {% with read_only = False %}
+          {% include "web/domains/case/import/partials/fa-sil/verified-section5-authorities.html" %}
+        {% endwith %}
+      {% else %}
+        <p class="strong">Please upload any Section 5 Authority Document(s) below</p>
+        {% with read_only = False %}
+          {% include "web/domains/case/import/partials/fa-sil/user-section5-authorities.html" %}
+        {% endwith %}
+      {% endif %}
+    {% else %}
+      <div class="info-box info-box-info">
+        Please choose Section 5 in the "Licence For" section if you wish to upload Section 5 Authority Documents.
+      </div>
+    {% endif %}
+  {% endif %}
+
 {% endblock %}


### PR DESCRIPTION
Changes:
  - Remove section 5 documents from edit view.
  - Add section 5 documents to certificates list view.
  - Update error URL's in submit view to navigate to certificate list view.
  - Delete section 5 documents when submitting if section5 is not selected.