### PR TITLE
ICMSLST-1619 Show DEBUG logging by default

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -208,26 +208,6 @@ CLAM_AV_DOMAIN = env.str("CLAM_AV_DOMAIN", default="clamav.london.cloudapps.digi
 # Storage Folders
 PATH_STORAGE_FIR = "/documents/fir/"  # start with /
 
-# Structured logging shared configuration
-structlog.configure(
-    processors=[
-        structlog.stdlib.filter_by_level,
-        structlog.processors.TimeStamper(fmt="iso"),
-        structlog.stdlib.add_logger_name,
-        structlog.stdlib.add_log_level,
-        structlog.stdlib.PositionalArgumentsFormatter(),
-        structlog.processors.StackInfoRenderer(),
-        structlog.processors.format_exc_info,
-        structlog.processors.UnicodeDecoder(),
-        structlog.processors.ExceptionPrettyPrinter(),
-        structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
-    ],
-    context_class=structlog.threadlocal.wrap_dict(dict),
-    logger_factory=structlog.stdlib.LoggerFactory(),
-    wrapper_class=structlog.stdlib.BoundLogger,
-    cache_logger_on_first_use=True,
-)
-
 # Celery & Redis shared configuration
 if "redis" in VCAP_SERVICES:
     REDIS_URL = VCAP_SERVICES["redis"][0]["credentials"]["uri"]
@@ -325,3 +305,52 @@ ICMS_PROD_PASSWORD = env.str("ICMS_PROD_PASSWORD", default="")
 
 # Workbasket pagination setting
 WORKBASKET_PER_PAGE = env.int("WORKBASKET_PER_PAGE", 100)
+
+# Structured logging shared configuration
+structlog.configure(
+    processors=[
+        structlog.stdlib.filter_by_level,
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
+        structlog.processors.UnicodeDecoder(),
+        structlog.processors.ExceptionPrettyPrinter(),
+        structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+    ],
+    context_class=structlog.threadlocal.wrap_dict(dict),
+    logger_factory=structlog.stdlib.LoggerFactory(),
+    wrapper_class=structlog.stdlib.BoundLogger,
+    cache_logger_on_first_use=True,
+)
+
+# Print json formatted logs to console. We override this for local development
+# and testing.
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "json_formatter": {
+            "()": structlog.stdlib.ProcessorFormatter,
+            "processor": structlog.processors.JSONRenderer(),
+        },
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "json_formatter",
+        },
+    },
+    "loggers": {
+        "django": {
+            "handlers": ["console"],
+            "level": "ERROR",
+        },
+        "web": {
+            "handlers": ["console"],
+            "level": "INFO",
+        },
+    },
+}

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -87,3 +87,17 @@ COMPRESS_OFFLINE = False
 
 # Need to use the local docker-compose network name to access the static files.
 PDF_DEFAULT_DOMAIN = "http://web:8080/"
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+        },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": "DEBUG",
+    },
+}

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -1,6 +1,4 @@
 # flake8: noqa: F405
-import structlog
-
 from web.utils.sentry import init_sentry
 
 from .base import *
@@ -31,34 +29,6 @@ ELASTIC_APM = {
     "SERVER_URL": env.str("ELASTIC_APM_URL"),
     "ENVIRONMENT": env.str("ELASTIC_APM_ENVIRONMENT", default="development"),
     "SERVER_TIMEOUT": env.str("ELASTIC_APM_SERVER_TIMEOUT", default="20s"),
-}
-
-# Print json formatted logs to console
-LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "formatters": {
-        "json_formatter": {
-            "()": structlog.stdlib.ProcessorFormatter,
-            "processor": structlog.processors.JSONRenderer(),
-        },
-    },
-    "handlers": {
-        "console": {
-            "class": "logging.StreamHandler",
-            "formatter": "json_formatter",
-        },
-    },
-    "loggers": {
-        "django": {
-            "handlers": ["console"],
-            "level": "ERROR",
-        },
-        "web": {
-            "handlers": ["console"],
-            "level": "INFO",
-        },
-    },
 }
 
 init_sentry()

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -28,3 +28,17 @@ APP_ENV = "test"
 
 # Add so we can test the bypass chief views.
 ALLOW_BYPASS_CHIEF_NEVER_ENABLE_IN_PROD = True
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+        },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": "DEBUG",
+    },
+}


### PR DESCRIPTION
This is useful for local development. When deployed to Cloud Foundry, we
also use this as a base logging config, except for the "production" env.