### PR TITLE
ICMSLST-1615 Fix to show verified and user section 5 authorities together.

### DIFF
--- a/web/templates/web/domains/case/import/fa-sil/view.html
+++ b/web/templates/web/domains/case/import/fa-sil/view.html
@@ -130,15 +130,12 @@
     <hr />
 
     <h5>Section 5 Authorities</h5>
-    {% if verified_section5 %}
       {% with read_only = True %}
         {% include "web/domains/case/import/partials/fa-sil/verified-section5-authorities.html" %}
       {% endwith %}
-    {% else %}
       {% with read_only = True %}
         {% include "web/domains/case/import/partials/fa-sil/user-section5-authorities.html" %}
       {% endwith %}
-    {% endif %}
   {% endcall %}
 
 

--- a/web/templates/web/domains/case/import/fa/certificates/manage.html
+++ b/web/templates/web/domains/case/import/fa/certificates/manage.html
@@ -24,15 +24,13 @@
   {# Application specific certificates #}
   {% if process.process_type == "SILApplication" and process.section5 %}
       <h3>Section 5 Authorities</h3>
-      {% if verified_section5 %}
-        {% with read_only = False %}
-          {% include "web/domains/case/import/partials/fa-sil/verified-section5-authorities.html" %}
-        {% endwith %}
-      {% else %}
-        <p class="strong">Please upload any Section 5 Authority Document(s) below</p>
-        {% with read_only = False %}
-          {% include "web/domains/case/import/partials/fa-sil/user-section5-authorities.html" %}
-        {% endwith %}
-      {% endif %}
+      {% with read_only = False %}
+        {% include "web/domains/case/import/partials/fa-sil/verified-section5-authorities.html" %}
+      {% endwith %}
+
+      <p class="bold">Please upload any Section 5 Authority Document(s) below</p>
+      {% with read_only = False %}
+        {% include "web/domains/case/import/partials/fa-sil/user-section5-authorities.html" %}
+      {% endwith %}
   {% endif %}
 {% endblock %}

--- a/web/templates/web/domains/case/import/partials/fa-sil/verified-section5-authorities.html
+++ b/web/templates/web/domains/case/import/partials/fa-sil/verified-section5-authorities.html
@@ -5,7 +5,7 @@
       the correct authority is not listed and request that they verify it on ICMS.
     </div>
 
-    <h6>Available Verified Section 5</h6>
+    <h6>Available Verified Section 5 Authorities</h6>
 
     <table class="setoutList">
       <thead>
@@ -56,7 +56,7 @@
   {% endif %}
 
   {% if selected_section5 %}
-    <h6>Selected Verified Section 5</h6>
+    <h6>Selected Verified Section 5 Authorities</h6>
     <table class="setoutList">
       <thead>
         <tr>


### PR DESCRIPTION
A user who creates a SIL app can now choose verified section 5 authorities
as well as upload additional authority documents.