### PR TITLE
ICMSLST-1900 Archive draft packs when closing or withdrawing an app.

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -1821,3 +1821,4 @@ Withdrawal Request
 View Withdrawal Request
 Withdraw Pending
 Prefix
+PackStatus

--- a/web/domains/case/models.py
+++ b/web/domains/case/models.py
@@ -290,25 +290,6 @@ class ApplicationBase(Process):
 
         return update_requests
 
-    def history(self) -> None:
-        """Debug method to print the history of the application"""
-
-        print("*-" * 40)
-        print(f"Current status: {self.get_status_display()}")
-
-        all_tasks = self.tasks.all().order_by("created")
-        active = all_tasks.filter(is_active=True)
-
-        print("Active Tasks in order:")
-        for t in active:
-            print(f"Task: {t.get_task_type_display()}, {t.created}, {t.finished}")
-
-        print("All tasks in order:")
-        for t in all_tasks:
-            print(f"Task: {t.get_task_type_display()}, created={t.created}, finished={t.finished}")
-
-        print("*-" * 40)
-
 
 class CaseEmail(models.Model):
     class Status(models.TextChoices):

--- a/web/domains/case/services/document_pack.py
+++ b/web/domains/case/services/document_pack.py
@@ -59,6 +59,11 @@ __all__ = [
     "doc_ref_licence_get_optional",
     "doc_ref_cover_letter_get",
     "doc_ref_documents_all",
+    #
+    # Types
+    #
+    "PackStatus",
+    "DocumentType",
 ]
 
 
@@ -67,12 +72,13 @@ def pack_draft_create(application: ImpOrExp, *, variation_request: bool = False)
 
     This is the main entry point to the service which all licences / certificates use.
 
-    TODO: THis list needs extending
     It is used in the following places:
-        - Creating an import application
-        - Creating an export application
-        - A variation request is submitted for an import application
-        - A variation request is submitted for an export application
+        - Creating an import application.
+        - Creating an export application.
+        - A variation request is submitted for an import application.
+        - A variation request is submitted for an export application.
+        - A case is reopened after being withdrawn.
+        - A case is reopened after being stopped.
     """
 
     if application.is_import_application():
@@ -145,8 +151,10 @@ def pack_draft_archive(application: ImpOrExp) -> None:
     """Archives the draft licence or certificate.
 
     This occurs when the following happens:
-        - A variation request is refused by a caseworker.
         - An application is refused by a caseworker.
+        - A variation request is refused by a caseworker.
+        - When an application is withdrawn.
+        - When an application is stopped.
     """
 
     pack = pack_draft_get(application)

--- a/web/domains/case/utils.py
+++ b/web/domains/case/utils.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 
 from web.domains.case._import.models import ImportApplication
 from web.domains.case.export.models import ExportApplication
-from web.domains.case.services import reference
+from web.domains.case.services import document_pack, reference
 from web.domains.file.models import File
 from web.domains.user.models import User
 from web.flow.models import ProcessTypes, Task
@@ -173,3 +173,37 @@ def redirect_after_submit(app: ImpOrExp, request: AuthenticatedHttpRequest) -> H
     messages.success(request, msg)
 
     return redirect(reverse("workbasket"))
+
+
+def application_history(app_reference: str, is_import=True):
+    """Debug method to print the history of the application
+
+    >>> from web.domains.case.utils import application_history
+    >>> application_history("IMA/2023/00001")
+    """
+
+    if is_import:
+        app = ImportApplication.objects.get(reference__startswith=app_reference)
+    else:
+        app = ExportApplication.objects.get(reference__startswith=app_reference)
+
+    app = app.get_specific_model()
+
+    print("*-" * 40)
+    print(f"Current status: {app.get_status_display()}")
+
+    all_tasks = app.tasks.all().order_by("created")
+    active = all_tasks.filter(is_active=True)
+
+    print("Active Tasks in order:")
+    for t in active:
+        print(f"Task: {t.get_task_type_display()}, {t.created}, {t.finished}")
+
+    print("All tasks in order:")
+    for t in all_tasks:
+        print(f"Task: {t.get_task_type_display()}, created={t.created}, finished={t.finished}")
+
+    print("*-" * 40)
+
+    for p in document_pack._get_qm(app).order_by("created_at"):
+        print(f"DocumentPack: {p}")

--- a/web/domains/case/views/views_search.py
+++ b/web/domains/case/views/views_search.py
@@ -181,6 +181,7 @@ class ReopenApplicationView(
         self.application.update_order_datetime()
         self.update_application_status()
         self.update_application_tasks()
+        document_pack.pack_draft_create(self.application)
 
         messages.success(
             request,

--- a/web/tests/domains/case/_import/fa_oil/test_views.py
+++ b/web/tests/domains/case/_import/fa_oil/test_views.py
@@ -5,6 +5,7 @@ from guardian.shortcuts import assign_perm
 
 from web.domains.case._import.fa_oil.models import OpenIndividualLicenceApplication
 from web.domains.case._import.models import ImportApplicationType
+from web.domains.case.services import document_pack
 from web.domains.importer.models import Importer
 from web.flow.models import Task
 from web.models import ImportApplicationLicence
@@ -140,6 +141,7 @@ def test_close_case():
         case_owner=ilb_admin,
     )
     task = TaskFactory.create(process=process, task_type=Task.TaskType.PROCESS)
+    licence = document_pack.pack_draft_create(process)
 
     client = Client()
     client.login(username=ilb_admin.username, password="test")
@@ -147,6 +149,9 @@ def test_close_case():
 
     process.refresh_from_db()
     assert process.status == "STOPPED"
+
+    licence.refresh_from_db()
+    assert licence.status == document_pack.PackStatus.ARCHIVED
 
     task.refresh_from_db()
     assert task.is_active is False


### PR DESCRIPTION
Fixes incorrect licence details being shown on the search screen.
Changes:
  - Update prepare response view to only fetch licence when needed.
  - Archive pack when an application is withdrawn.
  - Archive pack when an application is stopped.
  - Add several docstrings.
  - Fix duplicate PROCESS task when a withdrawal request is refused.
  - Refactor debug function used to show application history.