### PR TITLE
ICMSLST-1908 Show revoked licence on response preparation screen.

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -1878,27 +1878,6 @@ Reassign Applications to the chosen ILB
 Generates
 "Check for a search_results_url and rebuild the search
 "Store the variation
-args
-NER
-Licence Type
-Licence End Date
-Shipping Year
-Goods Category
-BEIS
-Processing (HSE
-Search ImportApplication
-Application Processing (
-kwargs={
-rec.latest_certificate_pk
-"Converts the incoming records
-Revoke Licence
-Open Variation
-Revoke Certificates
-Certificate
-Reassign Applications to the chosen ILB
-Generates
-"Check for a search_results_url and rebuild the search
-"Store the variation
 GBOIL0000003D
 f"{initial_reference}/5
 EAR/1
@@ -1976,3 +1955,26 @@ Certificate Applications
 e.g: Template.get_choice_entry(Template
 DOMAINS
 Paragraphs for Certificate of Free Sale Schedule and Certificate of Free Sale Schedule Translation
+Case</h4
+kwargs={'application_pk
+process.process_type ==
+process.process_type == "WoodQuotaApplication" %}
+kwargs={"application_pk
+process.process_type == "
++ open_vr_count|string +
+process.update_requests.exclude(status="OPEN").count
+imi-case-detail'
+View Firearms
+Response Preparation</h3
+=False
+Cover Letter</h4
+Licence</h4
+{{ licence.licence_start_date.strftime('%d-%b-%Y'
+{{ licence.licence_end_date.strftime('%d-%b-%Y'
+{{ endorsement.content|nl2br }
+{{ csrf_input }
+Add Custom Endorsement
+{{ application_field("Refuse
+Decision
+{{ application_field(process.refuse_reason
+Refuse Reason"

--- a/web/domains/case/views/views_prepare_response.py
+++ b/web/domains/case/views/views_prepare_response.py
@@ -102,6 +102,8 @@ def prepare_response(
             and application.decision == application.APPROVE
         ):
             context["licence"] = document_pack.pack_active_get(application)
+        elif application.status == ImpExpStatus.REVOKED:
+            context["licence"] = document_pack.pack_revoked_get(application)
         elif (
             application.status == ImpExpStatus.VARIATION_REQUESTED
             and application.variation_decision == application.REFUSE

--- a/web/templates/partial/case/import/sidebar-management.html
+++ b/web/templates/partial/case/import/sidebar-management.html
@@ -93,7 +93,7 @@
 <ul class="menu-out">
   {{ icms_link(request, icms_url('case:view', kwargs={'application_pk': process.pk, 'case_type': 'import'}), 'View Application', "_blank") }}
 
-  {% if process.status == "COMPLETED" %}
+  {% if process.status in ["COMPLETED", "REVOKED"] %}
     {{ icms_link(request, icms_url('case:history', kwargs={'application_pk': process.pk, 'case_type': 'import'}), "Responses" ) }}
   {% endif %}
 </ul>

--- a/web/templates/web/domains/case/import_licence_history.html
+++ b/web/templates/web/domains/case/import_licence_history.html
@@ -10,11 +10,12 @@
 
 {% block main_content %}
   <h3>Responses</h3>
+  {% set revoke_suffix = " - Revoked" if process.status == "REVOKED" else "" %}
   {% for l in licences %}
     {% if l.variation_request %}
-      <p class="bold">Variation Request {{ l.variation_request[0] }} Response (case reference: {{ l.case_reference }})</p>
+      <p class="bold">Variation Request {{ l.variation_request[0] }} Response (case reference: {{ l.case_reference }}){{ revoke_suffix }}</p>
     {% else %}
-      <h5>Initial Response (case reference: {{ l.case_reference }})</h5>
+      <h5>Initial Response (case reference: {{ l.case_reference }}){{ revoke_suffix }}</h5>
     {% endif %}
     <table class="setoutList">
       <thead>

--- a/web/templates/web/domains/case/manage/prepare-response.html
+++ b/web/templates/web/domains/case/manage/prepare-response.html
@@ -52,6 +52,11 @@
 
 
   {% if process.application_approved %}
+    {% if process.status == "REVOKED" %}
+      <div class="info-box info-box-warning"><div class="screen-reader-only">Warning information box,</div>
+        The licence for the following quantities has been revoked:
+      </div>
+    {% endif %}
 
     {% block goods_content %}{% endblock %}
 


### PR DESCRIPTION
Changes:
- Set revoked licence in response prep context
- Show warking when a licence is revoked
- show ILB admin "Responses" link when a case is revoked.
- Add suffix to response header when revoked.