### PR TITLE
ICMSLST-1905 Fix missing variation requests in data migration

### DIFF
--- a/data_migration/management/commands/_types.py
+++ b/data_migration/management/commands/_types.py
@@ -44,6 +44,8 @@ class CheckQuery:
     model: ModelT
     filter_params: Params = field(default_factory=dict)
     bind_vars: Params = field(default_factory=dict)
+    adjustment: int = 0
+    note: str = ""
 
 
 def source_target_list(lst: list[str]):

--- a/data_migration/management/commands/config/data_counts.py
+++ b/data_migration/management/commands/config/data_counts.py
@@ -52,6 +52,8 @@ CHECK_DATA_QUERIES: list[CheckQuery] = [
         query=queries.fa_goods_certificate_count,
         model=web.SILApplication.user_imported_certificates.through,
         bind_vars={"FA_TYPE": "SIL"},
+        adjustment=2,
+        note="Certficates without constabulary id or file upload are not migrated. See ICMSLST-1905",
     ),
     CheckQuery(
         name="SIL Firearms Authority Certificates",
@@ -219,6 +221,8 @@ CHECK_DATA_QUERIES: list[CheckQuery] = [
         ],
         filter_params={"is_no_firearm": True},
         bind_vars={"FA_TYPE": "SIL"},
+        adjustment=1,
+        note="Missing report data for one goods line in V1. See ICMSLST-1905",
     ),
     CheckQuery(
         name="Firearms Authority Act Quantity",
@@ -257,7 +261,7 @@ CHECK_DATA_QUERIES: list[CheckQuery] = [
         query=queries.import_application_variation_count,
         model=web.VariationRequest,
         filter_params={"importapplication__process_type": ProcessTypes.FA_DFL},
-        bind_vars={"IMA_TYPE": "FA", "IMA_SUB_TYPE": "DFL"},
+        bind_vars={"IMA_TYPE": "FA", "IMA_SUB_TYPE": "DEACTIVATED"},
     ),
     CheckQuery(
         name="Variation Requests - OIL",

--- a/data_migration/management/commands/import_v1_data.py
+++ b/data_migration/management/commands/import_v1_data.py
@@ -144,6 +144,14 @@ class Command(MigrationBaseCommand):
             ("Archived", ["COMPLETED", "STOPPED", "WITHDRAWN"], "AR"),
         )
 
+        match app_model:
+            case dm.ImportApplication:
+                application_field = "import_application_id"
+            case dm.ExportApplication:
+                application_field = "export_application_id"
+            case _:
+                raise ValueError("app_model must be ImportApplication or ExportApplication")
+
         for name, app_status, pack_status in statuses:
             self.stdout.write(f"Creating {name} {pack_model.__name__}")
 
@@ -157,7 +165,7 @@ class Command(MigrationBaseCommand):
 
             while True:
                 batch = [
-                    pack_model(import_application_id=pk, status=pack_status)
+                    pack_model(status=pack_status, **{application_field: pk})
                     for pk in islice(pks, self.batch_size)
                 ]
 

--- a/data_migration/queries/data_counts.py
+++ b/data_migration/queries/data_counts.py
@@ -83,6 +83,6 @@ WHERE xtd.status_control = 'C'
 
 iat_endorsement_count = """
 SELECT COUNT(*)
-FROM impmgr.xview_iat_templates
+FROM impmgr.xview_iat_templates iat
 WHERE iat.ima_type <> 'GS'
 """

--- a/data_migration/queries/export_application/cfs.py
+++ b/data_migration/queries/export_application/cfs.py
@@ -85,7 +85,10 @@ FROM impmgr.xview_certificate_app_details xcad
 WHERE xcad.status_control = 'C'
   AND xcad.application_type = 'CFS'
   AND xcad.status <> 'DELETED'
-  AND (xcad.submitted_datetime IS NOT NULL OR xcad.last_updated_datetime > CURRENT_DATE - INTERVAL '14' DAY)
+  AND (
+    (xcad.submitted_datetime IS NOT NULL AND ca.case_reference IS NOT NULL)
+    OR xcad.last_updated_datetime > CURRENT_DATE - INTERVAL '14' DAY
+  )
 """
 
 cfs_schedule = """
@@ -160,7 +163,10 @@ LEFT JOIN
 WHERE xcad.status_control = 'C'
   AND xcad.application_type = 'CFS'
   AND xcad.status <> 'DELETED'
-  AND (xcad.submitted_datetime IS NOT NULL OR xcad.last_updated_datetime > CURRENT_DATE - INTERVAL '14' DAY)
+  AND (
+    (xcad.submitted_datetime IS NOT NULL AND ca.case_reference IS NOT NULL)
+    OR xcad.last_updated_datetime > CURRENT_DATE - INTERVAL '14' DAY
+  )
 ORDER BY xcas.cad_id, xcas.schedule_ordinal
 """
 

--- a/data_migration/queries/export_application/com.py
+++ b/data_migration/queries/export_application/com.py
@@ -77,6 +77,7 @@ FROM impmgr.xview_certificate_app_details xcad
       , x.chemical_name
       , x.manufacturing_process
       , x.case_note_xml
+      , XMLTYPE.getClobVal(x.variations_xml) variations_xml
     FROM
       impmgr.certificate_app_details cad,
       XMLTABLE('/*'

--- a/data_migration/queries/export_application/com.py
+++ b/data_migration/queries/export_application/com.py
@@ -99,5 +99,8 @@ FROM impmgr.xview_certificate_app_details xcad
 WHERE xcad.status_control = 'C'
   AND xcad.application_type = 'COM'
   AND xcad.status <> 'DELETED'
-  AND (xcad.submitted_datetime IS NOT NULL OR xcad.last_updated_datetime > CURRENT_DATE - INTERVAL '14' DAY)
+  AND (
+    (xcad.submitted_datetime IS NOT NULL AND ca.case_reference IS NOT NULL)
+    OR xcad.last_updated_datetime > CURRENT_DATE - INTERVAL '14' DAY
+  )
 """

--- a/data_migration/queries/export_application/gmp.py
+++ b/data_migration/queries/export_application/gmp.py
@@ -123,7 +123,10 @@ FROM impmgr.xview_certificate_app_details xcad
 WHERE xcad.status_control = 'C'
   AND xcad.application_type = 'GMP'
   AND xcad.status <> 'DELETED'
-  AND (xcad.submitted_datetime IS NOT NULL OR xcad.last_updated_datetime > CURRENT_DATE - INTERVAL '14' DAY)
+  AND (
+    (xcad.submitted_datetime IS NOT NULL AND ca.case_reference IS NOT NULL)
+    OR xcad.last_updated_datetime > CURRENT_DATE - INTERVAL '14' DAY
+  )
 """
 
 beis_emails = """

--- a/data_migration/queries/export_application/gmp.py
+++ b/data_migration/queries/export_application/gmp.py
@@ -89,6 +89,7 @@ FROM impmgr.xview_certificate_app_details xcad
     , gmp_certificate_issued
     , file_folder_id
     , case_note_xml
+    , XMLTYPE.getClobVal(x.variations_xml) variations_xml
   FROM
     impmgr.certificate_app_details cad,
     XMLTABLE('/*'

--- a/data_migration/queries/import_application/fa/dfl.py
+++ b/data_migration/queries/import_application/fa/dfl.py
@@ -90,6 +90,7 @@ SELECT
   , XMLTYPE.getClobVal(XMLELEMENT("FA_GOODS_CERTS", XMLCONCAT(commodities_xml, fa_certs_xml))) fa_goods_certs_xml
   , x.file_folder_id
   , XMLTYPE.getClobVal(x.cover_letter_text) cover_letter_text
+  , XMLTYPE.getClobVal(x.variations_xml) variations_xml
 FROM impmgr.import_application_details ad
 CROSS JOIN XMLTABLE('/*'
   PASSING ad.xml_data

--- a/data_migration/queries/import_application/fa/oil.py
+++ b/data_migration/queries/import_application/fa/oil.py
@@ -91,6 +91,7 @@ SELECT
   , x.completed_by_id
   , TO_DATE(x.completed_datetime, 'YYYY-MM-DD') completed_datetime
   , x.file_folder_id
+  , XMLTYPE.getClobVal(x.variations_xml) variations_xml
 FROM impmgr.import_application_details ad
 CROSS JOIN XMLTABLE('/*'
   PASSING ad.xml_data

--- a/data_migration/queries/import_application/fa/sil.py
+++ b/data_migration/queries/import_application/fa/sil.py
@@ -99,6 +99,7 @@ SELECT
   , XMLTYPE.getClobVal(commodities_xml) commodities_xml
   , XMLTYPE.getClobVal(user_import_certs_xml) user_import_certs_xml
   , x.file_folder_id
+  , XMLTYPE.getClobVal(x.variations_xml) variations_xml
 FROM impmgr.import_application_details ad
 CROSS JOIN XMLTABLE('/*'
   PASSING ad.xml_data

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -2684,7 +2684,6 @@ is_ilb_admin
 Create Individual
 Select an Exporter
 Exporter Details
-<<<<<<< HEAD
 address_5__icontains
 "If Sentry
 Test Importer 1
@@ -2694,7 +2693,6 @@ Test Importer 2
 ILB Admin/Caseworker
 main_org
 E1_A1
-=======
 file_folder_id
 VARCHAR(4000
 PATH '/CA/APPLICATION/GMP_DETAILS
@@ -2707,4 +2705,15 @@ x.product_name
 PATH '/CA/APPLICATION//SCHEDULE/IS_DOMESTIC_MARKET_PESTICIDE[not(fox-error)]/text
 is_manufacturer
 x.file_folder_id
->>>>>>> f06b82e5 (ICMSLST-1905 Fix missing variation requests in data migration)
+SELECT xcas.ca_id
+schedules.brand_name_holder , schedules.product_eligibility
+xcas.start_datetime
+x.final_product_end_use
+XMLTYPE.getClobVal(product_xml
+ORDINALITY
+ON schedules.cad_id
+ON st_rp.cad_id
+st_gmp.schedule_ordinal = xcas.schedule_ordinal
+e.email_status
+INNER
+ON r.status

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -2218,62 +2218,62 @@ Pending Further Information
 Certificate Country
 \.git
 \.mypy_cache
-Resource Co-ordinator    
-RESOURCE_COORDINATOR                                  
-Description              
-Maintain All             
+Resource Co-ordinator
+RESOURCE_COORDINATOR
+Description
+Maintain All
 IMP_IMPORTER_CONTACTS<
 Dashboard User
-DASHBOARD_USER                                             
+DASHBOARD_USER
 ResourceTypes
-Search Cases             
+Search Cases
 Import Application Case Officer
-Description                      
-Description                           
+Description
+Description
 Constabulary Contacts
 CON
-FIREARMS_AUTHORITY_EDITOR                                                                                              
-Description                         
+FIREARMS_AUTHORITY_EDITOR
+Description
 Exporter Agent Contacts
 EXP
 View Applications/Certificates
 |---------------------------------|----------------------------------------------------------------------------------------------------------|
-Description                     
+Description
 Edit Applications        |                                                                                       |
-EDIT_APPLICATION                                                                      
+EDIT_APPLICATION
 Approve/Reject Agents
 Exporters
-AGENT_APPROVER                                                                                     
-Description                          
+AGENT_APPROVER
+Description
 Verified Section 5 Authority
 Importer Agent Contacts
 IMP
 View Applications/Licences
-VIEW_APP                                                                                             
-Description                 
+VIEW_APP
+Description
 IMP_VIEW_APP
-EDIT_APP                                                                              
+EDIT_APP
 IMP_EDIT_APP
 IMP_VARY_APP
 IMP_AGENT_APPROVER
-Team Coordinator         
+Team Coordinator
 |--------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
 REPORT_ADMINISTRATOR
 RCAT
 REPORTING_TEAM
 RPT
-REPORT_VIEWER                                                       
-Runner           
-Schedule Runner          
+REPORT_VIEWER
+Runner
+Schedule Runner
 Repeat Runner
 REPORT_RUNNER_REPEAT                                                                                       |
 Workbasket Viewers
-Team Coordinator            
-Workbasket Viewer        
-WORKBASKET_VIEWER                                                                        
-Workbasket Viewee        
+Team Coordinator
+Workbasket Viewer
+WORKBASKET_VIEWER
+Workbasket Viewee
 Country Set Super User
-COUNTRY_SET_ADMIN                                                                      
+COUNTRY_SET_ADMIN
 ILB External
 Country Super Users](#country-super
 Exporter Contacts
@@ -2684,6 +2684,7 @@ is_ilb_admin
 Create Individual
 Select an Exporter
 Exporter Details
+<<<<<<< HEAD
 address_5__icontains
 "If Sentry
 Test Importer 1
@@ -2693,3 +2694,17 @@ Test Importer 2
 ILB Admin/Caseworker
 main_org
 E1_A1
+=======
+file_folder_id
+VARCHAR(4000
+PATH '/CA/APPLICATION/GMP_DETAILS
+PATH '/CA/APPLICATION/GMP_DETAILS/RESPONSIBLE_ADDRESS_DETAILS/RESPONSIBLE_PERSON_COUNTRY[not(fox-error)]/text
+PATH '/CA/APPLICATION/GMP_DETAILS/MANUFACTURER_ADDRESS_DETAILS/COUNTRY_OF_MANUFACTURE[not(fox-error)]/text
+FILE_FOLDER_ID
+INNER JOIN impmgr.beis_email_recipients
+e.cad_id
+x.product_name
+PATH '/CA/APPLICATION//SCHEDULE/IS_DOMESTIC_MARKET_PESTICIDE[not(fox-error)]/text
+is_manufacturer
+x.file_folder_id
+>>>>>>> f06b82e5 (ICMSLST-1905 Fix missing variation requests in data migration)

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -2218,62 +2218,62 @@ Pending Further Information
 Certificate Country
 \.git
 \.mypy_cache
-Resource Co-ordinator
-RESOURCE_COORDINATOR
-Description
-Maintain All
+Resource Co-ordinator    
+RESOURCE_COORDINATOR                                  
+Description              
+Maintain All             
 IMP_IMPORTER_CONTACTS<
 Dashboard User
-DASHBOARD_USER
+DASHBOARD_USER                                             
 ResourceTypes
-Search Cases
+Search Cases             
 Import Application Case Officer
-Description
-Description
+Description                      
+Description                           
 Constabulary Contacts
 CON
-FIREARMS_AUTHORITY_EDITOR
-Description
+FIREARMS_AUTHORITY_EDITOR                                                                                              
+Description                         
 Exporter Agent Contacts
 EXP
 View Applications/Certificates
 |---------------------------------|----------------------------------------------------------------------------------------------------------|
-Description
+Description                     
 Edit Applications        |                                                                                       |
-EDIT_APPLICATION
+EDIT_APPLICATION                                                                      
 Approve/Reject Agents
 Exporters
-AGENT_APPROVER
-Description
+AGENT_APPROVER                                                                                     
+Description                          
 Verified Section 5 Authority
 Importer Agent Contacts
 IMP
 View Applications/Licences
-VIEW_APP
-Description
+VIEW_APP                                                                                             
+Description                 
 IMP_VIEW_APP
-EDIT_APP
+EDIT_APP                                                                              
 IMP_EDIT_APP
 IMP_VARY_APP
 IMP_AGENT_APPROVER
-Team Coordinator
+Team Coordinator         
 |--------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
 REPORT_ADMINISTRATOR
 RCAT
 REPORTING_TEAM
 RPT
-REPORT_VIEWER
-Runner
-Schedule Runner
+REPORT_VIEWER                                                       
+Runner           
+Schedule Runner          
 Repeat Runner
 REPORT_RUNNER_REPEAT                                                                                       |
 Workbasket Viewers
-Team Coordinator
-Workbasket Viewer
-WORKBASKET_VIEWER
-Workbasket Viewee
+Team Coordinator            
+Workbasket Viewer        
+WORKBASKET_VIEWER                                                                        
+Workbasket Viewee        
 Country Set Super User
-COUNTRY_SET_ADMIN
+COUNTRY_SET_ADMIN                                                                      
 ILB External
 Country Super Users](#country-super
 Exporter Contacts
@@ -2693,27 +2693,3 @@ Test Importer 2
 ILB Admin/Caseworker
 main_org
 E1_A1
-file_folder_id
-VARCHAR(4000
-PATH '/CA/APPLICATION/GMP_DETAILS
-PATH '/CA/APPLICATION/GMP_DETAILS/RESPONSIBLE_ADDRESS_DETAILS/RESPONSIBLE_PERSON_COUNTRY[not(fox-error)]/text
-PATH '/CA/APPLICATION/GMP_DETAILS/MANUFACTURER_ADDRESS_DETAILS/COUNTRY_OF_MANUFACTURE[not(fox-error)]/text
-FILE_FOLDER_ID
-INNER JOIN impmgr.beis_email_recipients
-e.cad_id
-x.product_name
-PATH '/CA/APPLICATION//SCHEDULE/IS_DOMESTIC_MARKET_PESTICIDE[not(fox-error)]/text
-is_manufacturer
-x.file_folder_id
-SELECT xcas.ca_id
-schedules.brand_name_holder , schedules.product_eligibility
-xcas.start_datetime
-x.final_product_end_use
-XMLTYPE.getClobVal(product_xml
-ORDINALITY
-ON schedules.cad_id
-ON st_rp.cad_id
-st_gmp.schedule_ordinal = xcas.schedule_ordinal
-e.email_status
-INNER
-ON r.status


### PR DESCRIPTION
* Add flag to data counts to only show fails
* Fix queries pulling application variation requests from V1
* Fix method to add missing document packs to export applications
* Exclude submitted export applications with no case reference from data migration
* Add adjustments to data counts to account for data which has been excluded from data migration
** Add adjustments rather than change the query checking the V1 data as it will flag the issue if it occurs again rather than just automatically excluding the data