### PR TITLE
ICMSLST-1958 Update search views permissions and update template links.

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -2710,3 +2710,14 @@ fields.field(form.status
 {{ fields.field(form.goods_category
 {{ fields.field(form.commodity_code
 x.file_folder_id
+ILB
+"Implement in child view
+rec.app_pk
+function(event
+document.querySelector("#id_application_type
+setupDownloadSpreadsheetEventHandler
+Variations
+{{ application_field(get_status_widget("OPEN
+Submit Variation
+columns"><label
+north">Case

--- a/web/domains/case/views/mixins.py
+++ b/web/domains/case/views/mixins.py
@@ -1,6 +1,6 @@
 from typing import Any, ClassVar
 
-from django.core.exceptions import ImproperlyConfigured
+from django.core.exceptions import ImproperlyConfigured, PermissionDenied
 from django.db import models
 from django.http import HttpRequest
 from django.views import View
@@ -64,8 +64,12 @@ class ApplicationTaskMixin(SingleObjectMixin, View):
         self.application = self.get_object()
         self.task = self.get_task()
 
-        # TODO ICMSLST-1240: a method could be called / overridden here.
-        # self.check_application_permission()
+        if not self.has_object_permission():
+            raise PermissionDenied
+
+    def has_object_permission(self) -> bool:
+        """Implement in child view if required."""
+        return True
 
     def get_object(self, queryset: models.QuerySet | None = None) -> ImpOrExp:
         """Downcast to specific model class."""

--- a/web/jinja2.py
+++ b/web/jinja2.py
@@ -20,6 +20,7 @@ from web.domains.case.services import case_progress
 from web.domains.case.types import ImpOrExp
 from web.domains.workbasket.actions.ilb_admin_actions import TakeOwnershipAction
 from web.menu import Menu
+from web.permissions import Perms
 from web.permissions.context_processors import UserObjectPerms
 from web.types import AuthenticatedHttpRequest
 
@@ -140,6 +141,17 @@ def show_take_ownership_url(
     return action.show_link()
 
 
+def get_view_case_url(request: AuthenticatedHttpRequest, case_type: str, app_pk: int):
+    """Used to retrieve the correct view case url based on the user permissions."""
+
+    kwargs = {"application_pk": app_pk, "case_type": case_type}
+
+    if request.user.has_perm(Perms.sys.ilb_admin):
+        return reverse("case:manage", kwargs={"application_pk": app_pk, "case_type": case_type})
+    else:
+        return reverse("case:view", kwargs=kwargs)
+
+
 def get_latest_issued_document(application):
     """Used to get the active document pack in one template"""
 
@@ -174,6 +186,7 @@ def environment(**options):
             "show_optional_label": show_optional_label,
             # Reuse the workbasket logic to show url.
             "show_take_ownership_url": show_take_ownership_url,
+            "get_view_case_url": get_view_case_url,
             "get_latest_issued_document": get_latest_issued_document,
             "get_active_task_list": get_active_task_list,
             "get_user_obj_perms": get_user_obj_perms,

--- a/web/static/web/js/pages/search-export.js
+++ b/web/static/web/js/pages/search-export.js
@@ -1,12 +1,15 @@
 window.addEventListener('load', function (event) {
   const reassignmentCB = document.querySelector("#id_reassignment");
-  const showReassignUser = UTILS.getShowElementFunc("#reassignment-user-wrapper")
+  // The reassignment checkbox doesn't always appear on the page.
+  if (reassignmentCB !== null) {
+    const showReassignUser = UTILS.getShowElementFunc("#reassignment-user-wrapper");
 
-  reassignmentCB.addEventListener("change", (e) => {
-    showReassignUser(e.target.checked, {
-      onHide: () => $("#id_reassignment_user").djangoSelect2().empty()
+    reassignmentCB.addEventListener("change", (e) => {
+      showReassignUser(e.target.checked, {
+        onHide: () => $("#id_reassignment_user").djangoSelect2().empty()
+      });
     });
-  });
+  }
 
   setupDownloadSpreadsheetEventHandler({
     downloadId: "#download-search-spreadsheet",

--- a/web/static/web/js/pages/search-import.js
+++ b/web/static/web/js/pages/search-import.js
@@ -10,13 +10,16 @@ window.addEventListener('load', function(event) {
   });
 
   const reassignmentCB = document.querySelector("#id_reassignment");
-  const showReassignUser = UTILS.getShowElementFunc("#reassignment-user-wrapper")
+  // The reassignment checkbox doesn't always appear on the page.
+  if (reassignmentCB !== null) {
+    const showReassignUser = UTILS.getShowElementFunc("#reassignment-user-wrapper")
 
-  reassignmentCB.addEventListener("change", (e) => {
-    showReassignUser(e.target.checked, {
-      onHide: () => $("#id_reassignment_user").djangoSelect2().empty()
+    reassignmentCB.addEventListener("change", (e) => {
+      showReassignUser(e.target.checked, {
+        onHide: () => $("#id_reassignment_user").djangoSelect2().empty()
+      });
     });
-  });
+  }
 
   /* strips empty search values */
   setupSearchFormEventHandler();

--- a/web/templates/web/domains/case/search/export/case_details.html
+++ b/web/templates/web/domains/case/search/export/case_details.html
@@ -6,10 +6,7 @@
 
   <div class="row">
     <div class="twelve columns">
-      <a
-        target="_blank"
-        href="{{ icms_url('case:manage', kwargs={'application_pk': rec.app_pk, 'case_type': 'export'}) }}"
-      >
+      <a target="_blank" href="{{ get_view_case_url(request, 'export', rec.app_pk) }}">
         {{ rec.case_reference }}
       </a>
     </div>

--- a/web/templates/web/domains/case/search/export/results-table.html
+++ b/web/templates/web/domains/case/search/export/results-table.html
@@ -6,7 +6,7 @@
     <th scope="col">Submitted Date</th>
     <th scope="col">Certificate Details</th>
     <th scope="col">Applicant Details</th>
-    {% if reassignment_search %}
+    {% if reassignment_enabled and reassignment_search %}
       <th scope="col">Assignee Details<div aria-describedby="applicant-details-tooltip" class="hint icon-info tooltipstered"></div></th>
     {% endif %}
     <th scope="col">Actions</th>
@@ -21,7 +21,7 @@
       <td>{% include "web/domains/case/search/export/submitted_date.html" %}</td>
       <td>{% include "web/domains/case/search/export/certificate_details.html" %}</td>
       <td>{% include "web/domains/case/search/export/applicant_details.html" %}</td>
-      {% if reassignment_search %}
+      {% if reassignment_enabled and reassignment_search %}
         <td>{% include "web/domains/case/search/assignee_details.html" %}</td>
       {% endif %}
       <td>{% include "web/domains/case/search/results-row-actions.html" %}</td>

--- a/web/templates/web/domains/case/search/export/search-form-fields.html
+++ b/web/templates/web/domains/case/search/export/search-form-fields.html
@@ -26,7 +26,9 @@
   {{ fields.field(form.pending_update_reqs, show_optional_indicator=False) }}
 {% endif %}
 
-{{ fields.field(form.reassignment, show_optional_indicator=False, checkbox_label="Enable reassignment searching") }}
-<div id="reassignment-user-wrapper" {% if not reassignment_search %} style="display: none"{% endif %}>
-  {{ fields.field(form.reassignment_user, show_optional_indicator=False) }}
-</div>
+{% if reassignment_enabled %}
+  {{ fields.field(form.reassignment, show_optional_indicator=False, checkbox_label="Enable reassignment searching") }}
+  <div id="reassignment-user-wrapper" {% if not reassignment_search %} style="display: none"{% endif %}>
+    {{ fields.field(form.reassignment_user, show_optional_indicator=False) }}
+  </div>
+{% endif %}

--- a/web/templates/web/domains/case/search/import/case_details.html
+++ b/web/templates/web/domains/case/search/import/case_details.html
@@ -15,10 +15,7 @@
   </div>
   <div class="row">
     <div class="twelve columns">
-      <a
-        target="_blank"
-        href="{{ icms_url('case:manage', kwargs={'application_pk': rec.app_pk, 'case_type': 'import'}) }}"
-      >
+      <a target="_blank" href="{{ get_view_case_url(request, 'import', rec.app_pk) }}">
         {{ cs.case_reference }}
       </a>
     </div>

--- a/web/templates/web/domains/case/search/import/search-form-fields.html
+++ b/web/templates/web/domains/case/search/import/search-form-fields.html
@@ -50,7 +50,9 @@
   {{ fields.field(form.pending_update_reqs, show_optional_indicator=False) }}
 {% endif %}
 
-{{ fields.field(form.reassignment, show_optional_indicator=False, checkbox_label="Enable reassignment searching") }}
-<div id="reassignment-user-wrapper" {% if not reassignment_search %} style="display: none"{% endif %}>
-  {{ fields.field(form.reassignment_user, show_optional_indicator=False) }}
-</div>
+{% if reassignment_enabled %}
+  {{ fields.field(form.reassignment, show_optional_indicator=False, checkbox_label="Enable reassignment searching") }}
+  <div id="reassignment-user-wrapper" {% if not reassignment_search %} style="display: none"{% endif %}>
+    {{ fields.field(form.reassignment_user, show_optional_indicator=False) }}
+  </div>
+{% endif %}

--- a/web/templates/web/domains/case/variation-request-add.html
+++ b/web/templates/web/domains/case/variation-request-add.html
@@ -24,7 +24,7 @@
     {% if case_type == "import" %}
       {{ icms_link(request, icms_url('case:search-request-variation', kwargs={'application_pk': process.pk, 'case_type': case_type}), 'Variations') }}
       {{ icms_link(request, icms_url('case:view', kwargs={'application_pk': process.pk, 'case_type': case_type}), 'View Application', "_blank") }}
-      <li><a href="#" target="_blank">Sent Responses</a></li>
+      {{ icms_link(request, icms_url('case:applicant-case-history', kwargs={'application_pk': process.pk, 'case_type': case_type}), 'Sent Responses', "_blank") }}
     {% else %}
       {{ icms_link(request, icms_url('case:search-open-variation', kwargs={'application_pk': process.pk, 'case_type': case_type}), 'Variations') }}
       {{ icms_link(request, icms_url('case:manage', kwargs={'application_pk': process.pk, 'case_type': case_type}), 'View Case', "_blank") }}

--- a/web/templates/web/domains/case/variation-request-update.html
+++ b/web/templates/web/domains/case/variation-request-update.html
@@ -30,7 +30,7 @@
       )
     }}
     {{ icms_link(request, icms_url('case:view', kwargs={'application_pk': process.pk, 'case_type': 'import'}), 'View Application', "_blank") }}
-    <li><a href="#" target="_blank">Sent Responses</a></li>
+    {{ icms_link(request, icms_url('case:applicant-case-history', kwargs={'application_pk': process.pk, 'case_type': "import"}), 'Sent Responses', "_blank") }}
   </ul>
 {% endblock %}
 

--- a/web/tests/helpers.py
+++ b/web/tests/helpers.py
@@ -268,3 +268,7 @@ class SearchURLS:
             "case:search-revoke-licence",
             kwargs={"application_pk": application_pk, "case_type": case_type},
         )
+
+    @staticmethod
+    def reassign_case_owner(case_type: str = "import") -> str:
+        return reverse("case:search-reassign-case-owner", kwargs={"case_type": case_type})

--- a/web/utils/search/api.py
+++ b/web/utils/search/api.py
@@ -501,9 +501,6 @@ def _apply_search(model: QuerySet[Model], terms: types.SearchTerms) -> QuerySet[
     if terms.pending_update_reqs == YesNoChoices.yes:
         model = model.filter(update_requests__status=UpdateRequest.Status.OPEN)
 
-    # TODO: Revisit this when doing ICMSLST-964
-    # reassignment_search (searches for people not assigned to me)
-
     if terms.case_type == "import":
         model = _apply_import_application_filter(model, terms)
 


### PR DESCRIPTION
Changes:
  - Add has_object_permission hook to ApplicationTaskMixin.
  - Restrict reassignment feature to only work for ILB admin users.
  - Implement has_object_permission for RequestVariationUpdateView class.
  - Add jinja function to show correct view case url.
  - Add missing Sent Responses urls to variation request views.
  - Add missing permission tests for all search views.