### PR TITLE
ICMSLST-1992 Update create import application view to use new permissions.

### DIFF
--- a/web/management/commands/add_dummy_data.py
+++ b/web/management/commands/add_dummy_data.py
@@ -110,7 +110,7 @@ class Command(BaseCommand):
         self.stdout.write("Created dummy importer/exporter")
 
         # agent for importer
-        agent_importer = Importer.objects.create(
+        importer_one_agent_one = Importer.objects.create(
             is_active=True,
             name="Dummy agent for importer",
             registered_number="842",
@@ -124,7 +124,23 @@ class Command(BaseCommand):
             address_2="London",
             postcode="WT6 2AL",  # /PS-IGNORE
         )
-        agent_importer.offices.add(office)
+        importer_one_agent_one.offices.add(office)
+
+        # Second agent for importer
+        importer_one_agent_two = Importer.objects.create(
+            is_active=True,
+            name="Dummy agent 2 for importer",
+            registered_number="123",
+            type=Importer.ORGANISATION,
+            main_importer=importer,
+        )
+        office = Office.objects.create(
+            is_active=True,
+            address_1="Some other office road",
+            address_2="London",
+            postcode="WT6 2AL",  # /PS-IGNORE
+        )
+        importer_one_agent_two.offices.add(office)
 
         # agent for exporter
         agent_exporter = Exporter.objects.create(
@@ -188,7 +204,7 @@ class Command(BaseCommand):
             first_name="Cameron",
             last_name="Hasra (agent)",
             groups=[importer_user_group, exporter_user_group],
-            linked_importer_agents=[agent_importer],
+            linked_importer_agents=[importer_one_agent_one, importer_one_agent_two],
             linked_exporter_agents=[agent_exporter],
         )
 

--- a/web/tests/domains/case/_import/textiles/test_views.py
+++ b/web/tests/domains/case/_import/textiles/test_views.py
@@ -11,17 +11,8 @@ def _get_view_url(view_name, kwargs=None):
     return reverse(f"import:textiles:{view_name}", kwargs=kwargs)
 
 
-@pytest.fixture(autouse=True)
-def log_in_test_user(client, test_import_user):
-    """Logs in the test_import_user for all tests."""
-
-    assert (
-        client.login(username=test_import_user.username, password="test") is True
-    ), "Failed to login"
-
-
 @pytest.fixture
-def textiles_app_pk(client, office, importer):
+def textiles_app_pk(importer_client, importer_one_main_contact, office, importer):
     "Creates a textiles application to be used in tests, also tests the create-textiles endpoint"
 
     url = reverse("import:create-textiles")
@@ -29,7 +20,7 @@ def textiles_app_pk(client, office, importer):
 
     count_before = TextilesApplication.objects.all().count()
 
-    resp = client.post(url, post_data)
+    resp = importer_client.post(url, post_data)
 
     assert TextilesApplication.objects.all().count() == count_before + 1
 
@@ -41,7 +32,15 @@ def textiles_app_pk(client, office, importer):
     return application_pk
 
 
-def _add_goods_to_app(client, textiles_app_pk, test_import_user):
+def test_textiles_app_edit(importer_client, textiles_app_pk, test_import_user):
+    _add_goods_to_app(importer_client, textiles_app_pk, test_import_user)
+    textiles_app = TextilesApplication.objects.get(pk=textiles_app_pk)
+
+    assert textiles_app.applicant_reference == "New textiles"
+    assert textiles_app.goods_description == "A lot of textiles"
+
+
+def _add_goods_to_app(importer_client, textiles_app_pk, test_import_user):
     url = _get_view_url("edit", kwargs={"application_pk": textiles_app_pk})
     belarus = Country.objects.get(name="Belarus")
     ghana = Country.objects.get(name="Ghana")
@@ -59,23 +58,15 @@ def _add_goods_to_app(client, textiles_app_pk, test_import_user):
         "quantity": 5,
     }
 
-    response = client.post(url, data=form_data)
+    response = importer_client.post(url, data=form_data)
 
     assert response.status_code == 302
 
     return response
 
 
-def test_textiles_app_edit(client, textiles_app_pk, test_import_user):
-    _add_goods_to_app(client, textiles_app_pk, test_import_user)
-    textiles_app = TextilesApplication.objects.get(pk=textiles_app_pk)
-
-    assert textiles_app.applicant_reference == "New textiles"
-    assert textiles_app.goods_description == "A lot of textiles"
-
-
-def test_textiles_app_edit_invalid_form_data(client, textiles_app_pk):
+def test_textiles_app_edit_invalid_form_data(importer_client, textiles_app_pk):
     url = _get_view_url("edit", kwargs={"application_pk": textiles_app_pk})
-    response = client.post(url, data={"shipping_year": "invalid form data"})
+    response = importer_client.post(url, data={"shipping_year": "invalid form data"})
 
     assert response.status_code == 200

--- a/web/tests/domains/workbasket/test_views.py
+++ b/web/tests/domains/workbasket/test_views.py
@@ -1,7 +1,6 @@
 import re
 
 import pytest
-from django.test import Client
 
 from web.models import (
     CertificateOfManufactureApplication,
@@ -11,6 +10,7 @@ from web.models import (
     ImportApplicationType,
     OpenIndividualLicenceApplication,
 )
+from web.tests.helpers import get_test_client
 
 
 @pytest.fixture
@@ -101,7 +101,7 @@ def in_progress_agent_imp_appl(importer, agent_importer, test_agent_import_user)
 
 @pytest.mark.django_db
 def test_importer_workbasket(
-    test_import_user,
+    importer_client,
     in_progress_imp_appl,
     submitted_imp_appl,
     in_progress_exp_appl,
@@ -109,10 +109,7 @@ def test_importer_workbasket(
     in_progress_agent_imp_appl,
     submitted_agent_imp_appl,
 ):
-    client = Client()
-    client.login(username=test_import_user.username, password="test")
-    response = client.get("/workbasket/")
-
+    response = importer_client.get("/workbasket/")
     assert response.status_code == 200
 
     html = response.content.decode()
@@ -125,7 +122,7 @@ def test_importer_workbasket(
 
 @pytest.mark.django_db
 def test_exporter_workbasket(
-    test_export_user,
+    exporter_client,
     in_progress_imp_appl,
     submitted_imp_appl,
     in_progress_exp_appl,
@@ -133,9 +130,7 @@ def test_exporter_workbasket(
     in_progress_agent_imp_appl,
     submitted_agent_imp_appl,
 ):
-    client = Client()
-    client.login(username=test_export_user.username, password="test")
-    response = client.get("/workbasket/")
+    response = exporter_client.get("/workbasket/")
 
     assert response.status_code == 200
 
@@ -156,8 +151,7 @@ def test_agent_import_workbasket(
     in_progress_agent_imp_appl,
     submitted_agent_imp_appl,
 ):
-    client = Client()
-    client.login(username=test_agent_import_user.username, password="test")
+    client = get_test_client(test_agent_import_user)
     response = client.get("/workbasket/")
 
     assert response.status_code == 200


### PR DESCRIPTION
Changes:
  - Update CreateImportApplicationForm to return correct importers and agents.
  - Fix bug when searching for agent office
  - Refactor importers_with_agents to use values_list
  - Add a second agent importer.
  - Fix several tests still explicitly creating test clients.
  - Fix delete_endorsement view permissions (it's an ILB admin view).