### PR TITLE
Fix reset password form

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -2853,3 +2853,5 @@ impmgr.xview_imp_auth_archive_reasons xar
 Reassign
 Quick Issue
 Handover Details
+{{fields.field(form.question
+fields.field(form.date_of_birth

--- a/web/templates/auth/reset-password/reset-password-2.html
+++ b/web/templates/auth/reset-password/reset-password-2.html
@@ -21,8 +21,8 @@
 {% call forms.form(action=icms_url('reset-password'), method='post', csrf_input=csrf_input) -%}
   <input type="hidden" name="login_id" value="{{login_id}}" />
   {{fields.field(form.question, label_cols='four', input_cols='four')}}
-  {{fields.field(form.security_answer), label_cols='four', input_cols='four'}}
-  {{fields.field(form.date_of_birth), label_cols='four', input_cols='four'}}
+  {{fields.field(form.security_answer, label_cols='four', input_cols='four')}}
+  {{fields.field(form.date_of_birth, label_cols='four', input_cols='four')}}
   <div class="container">
     <div class="row">
       <div class="four columns"></div>


### PR DESCRIPTION
Fix for Internal Server error when reseting password

```
 File "/code/web/templates/auth/reset-password/reset-password-2.html", line 24, in template
{fields.field(form.security_answer), label_cols='four', input_cols='four'}}
 ^^^^^^^^^^^^^^^^^^^^^^^^^
jinja2.exceptions.TemplateSyntaxError: expected token 'end of print statement', got '='