### PR TITLE
ICMSLST-1827 Update ILB Case officer group permissions.

### DIFF
--- a/web/management/commands/add_dummy_data.py
+++ b/web/management/commands/add_dummy_data.py
@@ -5,7 +5,6 @@ from typing import Any
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.core.management.base import BaseCommand, CommandError
-from guardian.shortcuts import assign_perm
 
 from web.management.commands.utils.load_data import load_app_test_data
 from web.models import (
@@ -21,7 +20,7 @@ from web.models import (
     PersonalEmail,
     User,
 )
-from web.permissions import Perms
+from web.permissions import organisation_add_contact
 
 
 class Command(BaseCommand):
@@ -167,9 +166,7 @@ class Command(BaseCommand):
             password=options["password"],
             first_name="Ashley",
             last_name="Smith (ilb_admin)",
-            groups=[ilb_admin_group, importer_user_group, exporter_user_group],
-            linked_importers=[importer],
-            linked_exporters=[exporter],
+            groups=[ilb_admin_group],
         )
 
         self.create_user(
@@ -178,8 +175,6 @@ class Command(BaseCommand):
             first_name="Samantha",
             last_name="Stevens (ilb_admin)",
             groups=[ilb_admin_group],
-            linked_importers=[importer],
-            linked_exporters=[exporter],
         )
 
         self.create_user(
@@ -262,26 +257,16 @@ class Command(BaseCommand):
             user.groups.set(groups)
 
         for importer in linked_importers:
-            assign_perm(Perms.obj.importer.view, user, importer)
-            assign_perm(Perms.obj.importer.edit, user, importer)
-            assign_perm(Perms.obj.importer.manage_contacts_and_agents, user, importer)
+            organisation_add_contact(importer, user, assign_manage=True)
 
         for exporter in linked_exporters:
-            assign_perm(Perms.obj.exporter.view, user, exporter)
-            assign_perm(Perms.obj.exporter.edit, user, exporter)
-            assign_perm(Perms.obj.exporter.manage_contacts_and_agents, user, exporter)
+            organisation_add_contact(exporter, user, assign_manage=True)
 
         for agent in linked_importer_agents:
-            assign_perm(Perms.obj.importer.view, user, agent)
-            assign_perm(Perms.obj.importer.edit, user, agent)
-            assign_perm(Perms.obj.importer.manage_contacts_and_agents, user, agent)
-            assign_perm(Perms.obj.importer.is_agent, user, agent.get_main_org())
+            organisation_add_contact(agent, user)
 
         for agent in linked_exporter_agents:
-            assign_perm(Perms.obj.exporter.view, user, agent)
-            assign_perm(Perms.obj.exporter.edit, user, agent)
-            assign_perm(Perms.obj.exporter.manage_contacts_and_agents, user, agent)
-            assign_perm(Perms.obj.exporter.is_agent, user, agent.get_main_org())
+            organisation_add_contact(agent, user)
 
         user.save()
 

--- a/web/management/commands/create_icms_groups.py
+++ b/web/management/commands/create_icms_groups.py
@@ -29,8 +29,6 @@ def get_groups():
             #
             # Page permissions
             Perms.page.view_permission_harness.codename,
-            Perms.page.view_importer_details.codename,
-            Perms.page.view_exporter_details.codename,
             Perms.page.view_import_case_search.codename,
             Perms.page.view_export_case_search.codename,
             #
@@ -41,6 +39,8 @@ def get_groups():
             Perms.sys.search_all_cases.codename,
             Perms.sys.mailshot_access.codename,
         ],
+        #
+        # "Importer User": (System group + object permissions to related importers)
         Perms.obj.importer.get_group_name(): [
             #
             # Page permissions
@@ -50,6 +50,8 @@ def get_groups():
             # Sys permissions
             Perms.sys.importer_access.codename,
         ],
+        #
+        # "Exporter User": (System group + object permissions to related exporters)
         Perms.obj.exporter.get_group_name(): [
             #
             # Page permissions

--- a/web/menu/menu.py
+++ b/web/menu/menu.py
@@ -216,8 +216,6 @@ class Menu:
                     links=[
                         SubMenuLink(label="Importers", view="importer-list"),
                         SubMenuLink(label="Exporters", view="exporter-list"),
-                        SubMenuLink(label="Importer Access Requests", view="access:importer-list"),
-                        SubMenuLink(label="Exporter Access Requests", view="access:exporter-list"),
                     ],
                 ),
                 SubMenu(
@@ -233,8 +231,8 @@ class Menu:
                         SubMenuLink(label="Obsolete Calibres", view="obsolete-calibre-group-list"),
                         SubMenuLink(label="Section 5 Clauses", view="section5:list"),
                         SubMenuLink(label="Product legislation", view="product-legislation-list"),
-                        SubMenuLink(label="Templates", view="template-list"),
                         SubMenuLink(label="Countries", view="country:list"),
+                        SubMenuLink(label="Templates", view="template-list"),
                     ],
                 ),
                 SubMenu(

--- a/web/permissions/service.py
+++ b/web/permissions/service.py
@@ -179,10 +179,22 @@ def organisation_get_contacts(
     return org_contacts.filter(is_active=True)
 
 
-def organisation_add_contact(org: ORGANISATION, user: User) -> None:
-    """Add a user to an organisation."""
+def organisation_add_contact(org: ORGANISATION, user: User, assign_manage: bool = False) -> None:
+    """Add a user to an organisation.
+
+    :param org: Organisation instance
+    :param user: User instance
+    :param assign_manage: Assigns the manage_contacts_and_agents object permission if True.
+    """
 
     obj_perms = get_org_obj_permissions(org)
+
+    if assign_manage:
+        if org.is_agent():
+            # Agent organisation contacts never have the manage permission set.
+            raise ValueError(f"Unable to assign manage perm to agent org: {org.name}")
+
+        assign_perm(obj_perms.manage_contacts_and_agents, user, org)
 
     for perm in [obj_perms.view, obj_perms.edit]:
         assign_perm(perm, user, org)

--- a/web/tests/domains/exporter/test_views.py
+++ b/web/tests/domains/exporter/test_views.py
@@ -42,7 +42,7 @@ class TestExporterListView(AuthTestCase):
         assert response.status_code == HTTPStatus.FORBIDDEN
 
 
-class TestImporterListUserView(AuthTestCase):
+class TestExporterListUserView(AuthTestCase):
     url = reverse("user-exporter-list")
 
     def test_permission(self):
@@ -53,7 +53,7 @@ class TestImporterListUserView(AuthTestCase):
         assert response.status_code == HTTPStatus.FORBIDDEN
 
         response = self.ilb_admin_client.get(self.url)
-        assert response.status_code == HTTPStatus.OK
+        assert response.status_code == HTTPStatus.FORBIDDEN
 
     def test_get(self):
         response = self.exporter_client.get(self.url)

--- a/web/tests/domains/importer/test_views.py
+++ b/web/tests/domains/importer/test_views.py
@@ -84,7 +84,7 @@ class TestImporterListUserView(AuthTestCase):
         assert response.status_code == HTTPStatus.FORBIDDEN
 
         response = self.ilb_admin_client.get(self.url)
-        assert response.status_code == HTTPStatus.OK
+        assert response.status_code == HTTPStatus.FORBIDDEN
 
     def test_get(self):
         response = self.importer_client.get(self.url)

--- a/web/tests/permissions/test_service.py
+++ b/web/tests/permissions/test_service.py
@@ -345,6 +345,31 @@ class TestPermissionsService:
         organisation_add_contact(self.agent_exporter, self.importer_contact)
         assert self.importer_contact.has_perm(Perms.obj.exporter.is_agent, self.exporter)
 
+    def test_organisation_add_contact_assign_manage_permission(self):
+        #
+        # Check exporter contact has manage_contacts_and_agents for importer
+        #
+        organisation_add_contact(self.importer, self.exporter_contact, assign_manage=True)
+        assert self.exporter_contact.has_perm(
+            Perms.obj.importer.manage_contacts_and_agents, self.importer
+        )
+
+        #
+        # Check importer contact has manage_contacts_and_agents for exporter
+        #
+        organisation_add_contact(self.exporter, self.importer_contact, assign_manage=True)
+        assert self.importer_contact.has_perm(
+            Perms.obj.exporter.manage_contacts_and_agents, self.exporter
+        )
+
+        #
+        # Check assigning manage_contacts_and_agents permission for agent raises ValueError
+        #
+        with pytest.raises(
+            ValueError, match="Unable to assign manage perm to agent org: Test Exporter 1 Agent 1"
+        ):
+            organisation_add_contact(self.agent_exporter, self.importer_contact, assign_manage=True)
+
     def test_organisation_get_contacts(self):
         importer_contacts = organisation_get_contacts(self.importer)
         for i in importer_contacts:


### PR DESCRIPTION
The ILB Case Officers group should have feature parity with V1 users. The V2 group is a combination of V1 Team roles:
  - Country Super Users
  - ILB Admin Users
  - ILB Case Officers

A few menu items have been removed in V2 that aren't in V1. They can still be accessed by the Importers / Exporters views.