### PR TITLE
ICMSLST-1737/1738/1739 Update organisation contact group permissions.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,5 @@ ICMS_HMRC_UPDATE_LICENCE_ENDPOINT="mail/update-licence/"
 HAWK_AUTH_ID="lite-api" # NOTE: For now hmrc-lite only accepts "lite-api" as a client.
 HAWK_AUTH_KEY="LITE_API_HAWK_KEY"
 SEND_LICENCE_TO_CHIEF=False
+
+SET_INACTIVE_APP_TYPES_ACTIVE=False

--- a/README.md
+++ b/README.md
@@ -67,7 +67,15 @@ developing, only within Docker.
 
 Start everything using docker-compose: `make debug`
 
-Go to http://localhost:8080, login with the superuser account you created earlier.
+Go to http://localhost:8080, login with the one of the test accounts:
+  - ilb_admin
+  - ilb_admin_2
+  - importer_user
+  - exporter_user
+  - importer_agent
+  - exporter_agent
+
+The password is the same for each user: `admin`
 
 Above script will start a PostgreSQL database and ICMS app in debug mode.
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -330,6 +330,9 @@ ICMS_PROD_PASSWORD = env.str("ICMS_PROD_PASSWORD", default="")
 # Workbasket pagination setting
 WORKBASKET_PER_PAGE = env.int("WORKBASKET_PER_PAGE", 100)
 
+# Set to true to mark inactive application types active when running add_dummy_data.py
+SET_INACTIVE_APP_TYPES_ACTIVE = env.bool("SET_INACTIVE_APP_TYPES_ACTIVE", default=False)
+
 # Structured logging shared configuration
 structlog.configure(
     processors=[

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,7 @@ services:
             - HAWK_AUTH_ID
             - HAWK_AUTH_KEY
             - SEND_LICENCE_TO_CHIEF
+            - SET_INACTIVE_APP_TYPES_ACTIVE
         # stdin_open: true
         # tty: true
         ports:

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -2988,3 +2988,16 @@ Django 4.1.9
 Activate
 Postcodes
 NDD
+docker-compose.yml
+COMPANIES_HOUSE_TOKEN=
+HAWK_AUTH_KEY="LITE_API_HAWK_KEY
+north">Subject
+north">Company
+Tag
+aria-describedby="hint160
+class="icon-loop2
+aria-describedby="hint161
+type="radio">/ Topic
+# Actions
+Marie
+Jacobs

--- a/web/domains/workbasket/views.py
+++ b/web/domains/workbasket/views.py
@@ -59,7 +59,7 @@ def show_workbasket(request: AuthenticatedHttpRequest) -> HttpResponse:
 
         rows.append(row)
 
-    context = {"rows": rows, "page_obj": page_obj}
+    context = {"page_title": "Workbasket", "rows": rows, "page_obj": page_obj}
 
     return render(request, "web/domains/workbasket/workbasket.html", context)
 

--- a/web/management/commands/add_dummy_data.py
+++ b/web/management/commands/add_dummy_data.py
@@ -50,16 +50,10 @@ class Command(BaseCommand):
         importer_user_group = Group.objects.get(name="Importer User")
         exporter_user_group = Group.objects.get(name="Exporter User")
 
-        # enable disabled application types so we can test/develop them
-        ImportApplicationType.objects.filter(
-            type__in=[
-                ImportApplicationType.Types.DEROGATION,
-                ImportApplicationType.Types.IRON_STEEL,
-                ImportApplicationType.Types.OPT,
-                ImportApplicationType.Types.SPS,
-                ImportApplicationType.Types.TEXTILES,
-            ]
-        ).update(is_active=True)
+        # Enable disabled application types to test / develop them
+        if settings.SET_INACTIVE_APP_TYPES_ACTIVE:
+            ImportApplicationType.objects.update(is_active=True)
+            ExportApplicationType.objects.update(is_active=True)
 
         # exporter
         exporter = Exporter.objects.create(
@@ -196,12 +190,20 @@ class Command(BaseCommand):
         )
 
         self.create_user(
-            username="agent",
+            username="importer_agent",
             password=options["password"],
             first_name="Cameron",
             last_name="Hasra (agent)",
-            groups=[importer_user_group, exporter_user_group],
+            groups=[importer_user_group],
             linked_importer_agents=[importer_one_agent_one, importer_one_agent_two],
+        )
+
+        self.create_user(
+            username="exporter_agent",
+            password=options["password"],
+            first_name="Marie",
+            last_name="Jacobs (agent)",
+            groups=[exporter_user_group],
             linked_exporter_agents=[agent_exporter],
         )
 

--- a/web/management/commands/utils/add_application_type_data.py
+++ b/web/management/commands/utils/add_application_type_data.py
@@ -52,6 +52,9 @@ def add_import_application_type_data():
     sps_dec = Template.objects.get(template_code="IMA_SPS_DECLARATION")
     wd_dec = Template.objects.get(template_code="IMA_WD_DECLARATION")
 
+    #
+    # Active application types
+    #
     ImportApplicationType.objects.create(
         is_active=True,
         type="FA",
@@ -132,11 +135,11 @@ def add_import_application_type_data():
     )
 
     ImportApplicationType.objects.create(
-        is_active=False,
-        type="SAN",
-        sub_type="SAN1",
-        name="Derogation from Sanctions Import Ban",
-        licence_type_code="SANCTIONS",
+        is_active=True,
+        type="ADHOC",
+        sub_type="ADHOC1",
+        name="Sanctions and Adhoc Licence Application",
+        licence_type_code="ADHOC",
         sigl_flag=False,
         chief_flag=True,
         chief_licence_prefix="GBSAN",
@@ -149,7 +152,7 @@ def add_import_application_type_data():
         unit_list_csv="KGS,BARRELS",
         exp_cert_upload_flag=False,
         supporting_docs_upload_flag=True,
-        multiple_commodities_flag=False,
+        multiple_commodities_flag=True,
         guidance_file_url="/docs/ApplyingForSanctionsLicence.pdf",
         usage_auto_category_desc_flag=False,
         case_checklist_flag=True,
@@ -181,6 +184,35 @@ def add_import_application_type_data():
         case_checklist_flag=True,
         importer_printable=False,
         declaration_template=wd_dec,
+    )
+
+    #
+    # Inactive applications
+    #
+    ImportApplicationType.objects.create(
+        is_active=False,
+        type="SAN",
+        sub_type="SAN1",
+        name="Derogation from Sanctions Import Ban",
+        licence_type_code="SANCTIONS",
+        sigl_flag=False,
+        chief_flag=True,
+        chief_licence_prefix="GBSAN",
+        paper_licence_flag=False,
+        electronic_licence_flag=True,
+        cover_letter_flag=False,
+        cover_letter_schedule_flag=False,
+        category_flag=True,
+        quantity_unlimited_flag=False,
+        unit_list_csv="KGS,BARRELS",
+        exp_cert_upload_flag=False,
+        supporting_docs_upload_flag=True,
+        multiple_commodities_flag=False,
+        guidance_file_url="/docs/ApplyingForSanctionsLicence.pdf",
+        usage_auto_category_desc_flag=False,
+        case_checklist_flag=True,
+        importer_printable=False,
+        declaration_template=gen_dec,
     )
 
     ImportApplicationType.objects.create(
@@ -266,7 +298,7 @@ def add_import_application_type_data():
     )
 
     ImportApplicationType.objects.create(
-        is_active=True,
+        is_active=False,
         type="SPS",
         sub_type="SPS1",
         name="Prior Surveillance",
@@ -290,32 +322,6 @@ def add_import_application_type_data():
         case_checklist_flag=False,
         importer_printable=True,
         declaration_template=sps_dec,
-    )
-
-    ImportApplicationType.objects.create(
-        is_active=True,
-        type="ADHOC",
-        sub_type="ADHOC1",
-        name="Sanctions and Adhoc Licence Application",
-        licence_type_code="ADHOC",
-        sigl_flag=False,
-        chief_flag=True,
-        chief_licence_prefix="GBSAN",
-        paper_licence_flag=False,
-        electronic_licence_flag=True,
-        cover_letter_flag=False,
-        cover_letter_schedule_flag=False,
-        category_flag=True,
-        quantity_unlimited_flag=False,
-        unit_list_csv="KGS,BARRELS",
-        exp_cert_upload_flag=False,
-        supporting_docs_upload_flag=True,
-        multiple_commodities_flag=True,
-        guidance_file_url="/docs/ApplyingForSanctionsLicence.pdf",
-        usage_auto_category_desc_flag=False,
-        case_checklist_flag=True,
-        importer_printable=False,
-        declaration_template=gen_dec,
     )
 
 

--- a/web/menu/menu.py
+++ b/web/menu/menu.py
@@ -183,7 +183,6 @@ if settings.DEBUG:
 class Menu:
     items = [
         MenuLink(label="Workbasket", view="workbasket"),
-        MenuLink(label="Dashboard"),
         MenuLink(label="Importer Details", view="user-importer-list"),
         MenuLink(label="Exporter Details", view="user-exporter-list"),
         MenuDropDown(

--- a/web/templates/partial/case/export/sidebar-create.html
+++ b/web/templates/partial/case/export/sidebar-create.html
@@ -1,7 +1,5 @@
 <ul class="menu-out">
-  {{ icms_link(request, icms_url('export:create-application', kwargs={'type_code': "cfs" }), 'Certificate of Free Sale') }}
-
-  {{ icms_link(request, icms_url('export:create-application', kwargs={'type_code': "com" }), 'Certificate of Manufacture') }}
-
-  {{ icms_link(request, icms_url('export:create-application', kwargs={'type_code': "gmp" }), 'Certificate of Good Manufacturing Practice') }}
+  {% for application_type in application_types %}
+    {{ icms_link(request, application_type.create_application_url, application_type.get_type_code_display() ) }}
+  {% endfor %}
 </ul>

--- a/web/templates/web/domains/workbasket/workbasket.html
+++ b/web/templates/web/domains/workbasket/workbasket.html
@@ -1,7 +1,5 @@
 {% extends "layout/sidebar.html" %}
 
-{% block page_title %}Workbasket{% endblock %}
-
 {% block sidebar %}
     <h4>
         Filter


### PR DESCRIPTION
The organisation contact groups have feature parity with V1 users.
V2 users have extra features that V1 users do not since upgrading ILBTEST.

All differences found are going to be discussed with ILB, the stories are listed below:
  - ICMSLST-2082
  - ICMSLST-2087
  - ICMSLST-2088

Other changes:
  - Update application types shown when developing ICMS.
    - Set is_active to correct value for all application types
    - Add setting to enable all application types if needed.
  - Update page_title for workbasket view.
  - Fix export application sidebar to only show active application types.