### PR TITLE
ICMSLST-1895 Add NCA Case Officer group.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Go to http://localhost:8080, login with the one of the test accounts:
   - exporter_user
   - importer_agent
   - exporter_agent
+  - nca_admin
 
 The password is the same for each user: `admin`
 

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -3001,3 +3001,7 @@ type="radio">/ Topic
 # Actions
 Marie
 Jacobs
+NCA Case Officer
+Clara
+Boone (NCA Case Officer
+ILB & NCA

--- a/web/management/commands/add_dummy_data.py
+++ b/web/management/commands/add_dummy_data.py
@@ -49,6 +49,7 @@ class Command(BaseCommand):
         ilb_admin_group = Group.objects.get(name="ILB Case Officer")
         importer_user_group = Group.objects.get(name="Importer User")
         exporter_user_group = Group.objects.get(name="Exporter User")
+        nca_case_officer = Group.objects.get(name="NCA Case Officer")
 
         # Enable disabled application types to test / develop them
         if settings.SET_INACTIVE_APP_TYPES_ACTIVE:
@@ -205,6 +206,14 @@ class Command(BaseCommand):
             last_name="Jacobs (agent)",
             groups=[exporter_user_group],
             linked_exporter_agents=[agent_exporter],
+        )
+
+        self.create_user(
+            username="nca_admin",
+            password=options["password"],
+            first_name="Clara",
+            last_name="Boone (NCA Case Officer)",
+            groups=[nca_case_officer],
         )
 
         self.create_superuser("admin", options["password"])

--- a/web/management/commands/add_test_data.py
+++ b/web/management/commands/add_test_data.py
@@ -7,6 +7,7 @@ from guardian.shortcuts import assign_perm
 
 from web.management.commands.utils.load_data import load_app_test_data
 from web.models import (
+    ExportApplicationType,
     Exporter,
     ExporterAccessRequest,
     ImportApplicationType,
@@ -63,19 +64,14 @@ class Command(BaseCommand):
         self.create_test_importers()
         self.create_test_exporters()
 
-        # ILB Admin/Caseworker
+        # ICMS Caseworkers (ILB & NCA)
         self.create_icms_admin_user("ilb_admin_user")
         self.create_icms_admin_user("ilb_admin_two")
+        self.create_nca_admin_user("nca_admin_user")
 
         # enable disabled application types
-        ImportApplicationType.objects.filter(
-            type__in=[
-                ImportApplicationType.Types.DEROGATION,
-                ImportApplicationType.Types.OPT,
-                ImportApplicationType.Types.SPS,
-                ImportApplicationType.Types.TEXTILES,
-            ]
-        ).update(is_active=True)
+        ImportApplicationType.objects.update(is_active=True)
+        ExportApplicationType.objects.update(is_active=True)
 
         group = ObsoleteCalibreGroup.objects.create(name="Group 1", order=1)
         ObsoleteCalibre.objects.create(calibre_group=group, name="9mm", order=1)
@@ -232,6 +228,14 @@ class Command(BaseCommand):
         user = self.create_user(username)
         PersonalEmail.objects.create(user=user, email=user.email, portal_notifications=True)
         group = Group.objects.get(name="ILB Case Officer")
+        user.groups.add(group)
+
+        return user
+
+    def create_nca_admin_user(self, username):
+        user = self.create_user(username)
+        PersonalEmail.objects.create(user=user, email=user.email, portal_notifications=True)
+        group = Group.objects.get(name="NCA Case Officer")
         user.groups.add(group)
 
         return user

--- a/web/management/commands/create_icms_groups.py
+++ b/web/management/commands/create_icms_groups.py
@@ -61,4 +61,10 @@ def get_groups():
             # Sys permissions
             Perms.sys.exporter_access.codename,
         ],
+        "NCA Case Officer": [
+            # Page permissions
+            Perms.page.view_import_case_search.codename,
+            # Sys permissions
+            Perms.sys.search_all_cases.codename,
+        ],
     }

--- a/web/permissions/context_processors.py
+++ b/web/permissions/context_processors.py
@@ -26,6 +26,11 @@ class UserObjectPerms(ObjectPermissionChecker):
 
         return checker.can_view()
 
+    def can_edit_application(self, application):
+        checker = AppChecker(self.user, application)
+
+        return checker.can_edit()
+
 
 class UserObjectPermissionsContext(TypedDict):
     user_obj_perms: UserObjectPerms

--- a/web/permissions/service.py
+++ b/web/permissions/service.py
@@ -75,9 +75,14 @@ class AppChecker:
         agent organisation applications if defined.
 
         ILB_ADMIN's can always view an application.
+        Users who can view all cases can always view an application (e.g. NCA Case Officers)
         """
 
         if self.is_ilb_admin:
+            return True
+
+        # NCA Case Officers can search all import applications
+        if self.app.is_import_application() and self.user.has_perm(Perms.sys.search_all_cases):
             return True
 
         if not self.has_org_access:

--- a/web/templates/web/domains/case/view_case.html
+++ b/web/templates/web/domains/case/view_case.html
@@ -26,7 +26,7 @@
       {% endif %}
 
       {% if process.status in ["COMPLETED", "REVOKED"] %}
-        {% if process.application_type.type == "FA" and process.decision == process.APPROVE %}
+        {% if process.application_type.type == "FA" and process.decision == process.APPROVE and user_obj_perms.can_edit_application(process) %}
           {{ icms_link(request, icms_url('import:fa:provide-report', kwargs={'application_pk': process.pk}), 'Firearms Supplementary Information') }}
         {% endif %}
       {% endif %}

--- a/web/tests/conftest.py
+++ b/web/tests/conftest.py
@@ -89,6 +89,12 @@ def ilb_admin_user(django_user_model):
 
 
 @pytest.fixture
+def nca_admin_user(django_user_model):
+    """Fixture to get an NCA Case Officer user."""
+    return django_user_model.objects.get(username="nca_admin_user")
+
+
+@pytest.fixture
 def ilb_admin_two(django_user_model):
     return django_user_model.objects.get(username="ilb_admin_two")
 

--- a/web/tests/domains/user/test_forms.py
+++ b/web/tests/domains/user/test_forms.py
@@ -17,7 +17,7 @@ class TestUserListFilter(TestCase):
 
     def test_email_filter(self):
         results = self.run_filter({"email_address": "example.com"})
-        assert results.count() == 13
+        assert results.count() == 14
 
     def test_username_filter(self):
         results = self.run_filter({"username": "I1_main_contact"})
@@ -54,7 +54,7 @@ class TestPeopleFilter(TestCase):
 
     def test_email_filter(self):
         results = self.run_filter({"email_address": "example.com"})
-        assert results.count() == 13
+        assert results.count() == 14
 
     def test_first_name_filter(self):
         results = self.run_filter({"forename": "E1"})
@@ -74,11 +74,11 @@ class TestPeopleFilter(TestCase):
 
     def test_job_title_filter(self):
         results = self.run_filter({"job": "job"})
-        assert results.count() == 13
+        assert results.count() == 14
 
     def test_filter_order(self):
         results = self.run_filter({"email_address": "example"})
-        assert results.count() == 13
+        assert results.count() == 14
         first = results.first()
         last = results.last()
         assert first.username == "access_request_user"

--- a/web/tests/permissions/test_context_processors.py
+++ b/web/tests/permissions/test_context_processors.py
@@ -35,19 +35,23 @@ class TestUserObjectPerms:
         assert importer_uop.can_manage_org_contacts(self.importer)
         assert importer_uop.can_user_view_org(self.importer)
         assert importer_uop.can_view_application(self.fa_sil_app)
+        assert importer_uop.can_edit_application(self.fa_sil_app)
         assert not exporter_uop.can_edit_org(self.importer)
         assert not exporter_uop.can_manage_org_contacts(self.importer)
         assert not exporter_uop.can_user_view_org(self.importer)
         assert not exporter_uop.can_view_application(self.fa_sil_app)
+        assert not exporter_uop.can_edit_application(self.fa_sil_app)
 
         assert exporter_uop.can_edit_org(self.exporter)
         assert exporter_uop.can_manage_org_contacts(self.exporter)
         assert exporter_uop.can_user_view_org(self.exporter)
         assert exporter_uop.can_view_application(self.com_app)
+        assert exporter_uop.can_edit_application(self.com_app)
         assert not importer_uop.can_edit_org(self.exporter)
         assert not importer_uop.can_manage_org_contacts(self.exporter)
         assert not importer_uop.can_user_view_org(self.exporter)
         assert not importer_uop.can_view_application(self.com_app)
+        assert not importer_uop.can_edit_application(self.com_app)
 
 
 def test_request_user_object_permissions(importer_one_contact):

--- a/web/tests/permissions/test_service.py
+++ b/web/tests/permissions/test_service.py
@@ -36,6 +36,7 @@ class TestPermissionsService:
         exporter_one_contact,
         exporter_one_agent_one_contact,
         ilb_admin_user,
+        nca_admin_user,
         fa_sil_app,
         fa_sil_agent_app,
         com_app,
@@ -50,6 +51,7 @@ class TestPermissionsService:
         self.exporter_contact = exporter_one_contact
         self.exporter_agent_contact = exporter_one_agent_one_contact
         self.ilb_admin = ilb_admin_user
+        self.nca_admin = nca_admin_user
 
         self.fa_sil_app = fa_sil_app
         self.fa_sil_agent_app = fa_sil_agent_app
@@ -63,6 +65,8 @@ class TestPermissionsService:
         export_agent_checker = AppChecker(self.exporter_agent_contact, self.com_agent_app)
         ilb_admin_import_checker = AppChecker(self.ilb_admin, self.fa_sil_app)
         ilb_admin_export_checker = AppChecker(self.ilb_admin, self.com_app)
+        nca_admin_import_checker = AppChecker(self.nca_admin, self.fa_sil_app)
+        nca_admin_export_checker = AppChecker(self.nca_admin, self.com_app)
 
         #
         # Check importer, exporter and agent apps have correct access
@@ -107,6 +111,17 @@ class TestPermissionsService:
         assert not export_checker.can_edit()
         assert not export_checker.can_view()
         assert not export_checker.can_vary()
+
+        #
+        # Test NCA admin access (They can only view import applications)
+        #
+        assert not nca_admin_import_checker.can_edit()
+        assert nca_admin_import_checker.can_view()
+        assert not nca_admin_import_checker.can_vary()
+
+        assert not nca_admin_export_checker.can_edit()
+        assert not nca_admin_export_checker.can_view()
+        assert not nca_admin_export_checker.can_vary()
 
     def test_can_user_edit_firearm_authorities(self):
         #


### PR DESCRIPTION
Changes:
  - Add new "NCA Case Officer" group.
  - Add new nca_admin test user.
  - Add can_edit_application to user_obj_perms template object.
  - Update AppChecker.can_view to check search_all_cases permission.