### PR TITLE
ICMSLST-2063 - Import and refactor of import files to s3 code

### DIFF
--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -51,3 +51,7 @@ LOGGING = {
         },
     },
 }
+
+ICMS_V1_REPLICA_USER = ""
+ICMS_V1_REPLICA_PASSWORD = ""
+ICMS_V1_REPLICA_DSN = ""

--- a/data_migration/management/commands/import_v1_files_to_s3.py
+++ b/data_migration/management/commands/import_v1_files_to_s3.py
@@ -1,0 +1,173 @@
+import datetime
+import json
+from typing import IO, Any
+
+from botocore.exceptions import ClientError
+from django.core.management.base import BaseCommand
+from tqdm import tqdm
+
+from data_migration.management.commands.utils.db_processor import OracleDBProcessor
+from data_migration.queries.files_v1 import AVAILABLE_QUERIES
+from web.utils import s3 as s3_web
+
+DEFAULT_CREATED_DATE_TIME = "1900-12-13 09:39:21"
+DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+def get_default_last_run_data(query_name: str) -> dict:
+    return dict(query_name=query_name, created_datetime=DEFAULT_CREATED_DATE_TIME)
+
+
+def get_query_last_run_key(query_name: str) -> str:
+    return f"{query_name}-last-run.json"
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--limit",
+            help="Limit queries to only return a set number of rows",
+            type=int,
+            default=None,
+        )
+        parser.add_argument(
+            "--ignore-last-run",
+            help="Ignore the data in the last run json file",
+            action="store_true",
+            default=False,
+        )
+        parser.add_argument(
+            "--queries",
+            help="Specify which queries to run, defaults to all available queries",
+            nargs="+",
+            choices=AVAILABLE_QUERIES,
+            type=str,
+            default=None,
+        )
+        parser.add_argument(
+            "--s3-file-prefix",
+            help="Prefix for all files when adding to s3 ie. a folder",
+            type=str,
+            default="",
+        )
+        parser.add_argument(
+            "--number-of-rows",
+            help="Number of rows to select in each batch default (10000)",
+            type=int,
+            default=10000,
+        )
+        parser.add_argument(
+            "--count-only",
+            help="Retrieves a count of number of files that will be processed per query",
+            action="store_true",
+            default=False,
+        )
+
+    def get_db(self, options: dict) -> OracleDBProcessor:
+        """Returns a DB processor that facilitates executing database queries on the v1 oracle database."""
+        return OracleDBProcessor(options["limit"], options["queries"], options["number_of_rows"])
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        self.db = self.get_db(options)
+        self.file_prefix = options["s3_file_prefix"]
+        self.process_queries(options["ignore_last_run"], options["count_only"])
+
+    def upload_file_obj_to_s3(self, _file_obj: IO[Any], _key: str) -> None:
+        """Uploads a file to s3 adding a prefix to the file name (key) if required."""
+        if self.file_prefix:
+            _key = f"{self.file_prefix}/{_key}"
+        s3_web.upload_file_obj_to_s3(_file_obj, _key)
+
+    def get_initial_run_data_dict(
+        self, query_name: str, number_of_files_to_be_processed: int, start_from_datetime: str
+    ) -> dict:
+        """Returns a dictionary containing summary details of the current run for the given query."""
+        return {
+            "number_of_files_to_be_processed": number_of_files_to_be_processed,
+            "number_of_files_processed": 0,
+            "query_name": query_name,
+            "file_prefix": self.file_prefix,
+            "created_datetime": start_from_datetime,
+            "started_at": datetime.datetime.now().strftime(DATETIME_FORMAT),
+        }
+
+    def process_query_and_upload(
+        self, query_dict: dict[str, str], start_from_datetime: str, row_count: int
+    ) -> dict[str, Any]:
+        """Returns summary details of the last time the query was run including date time of
+        last file processed (created_datetime) and parameters provided at runtime.
+
+        For a given query
+         - Selects all files to be added to s3
+         - Uploads blob file data to s3
+        """
+        query_name = query_dict["query_name"]
+        number_of_files_to_be_processed = min(row_count, self.db.limit or row_count)
+        data_dict = self.get_initial_run_data_dict(
+            query_name, number_of_files_to_be_processed, start_from_datetime
+        )
+
+        pbar = tqdm(total=number_of_files_to_be_processed, desc=query_name)
+
+        sql = self.db.get_sql(query_dict, start_from_datetime)
+        with self.db.execute_query(sql) as rows:
+            try:
+                while True:
+                    obj = next(rows)
+                    self.upload_file_obj_to_s3(obj["BLOB_DATA"], obj["PATH"])
+                    pbar.update(1)
+                    data_dict["number_of_files_processed"] = pbar.n
+                    data_dict["created_datetime"] = obj["CREATED_DATETIME"].strftime(
+                        DATETIME_FORMAT
+                    )
+            except StopIteration:
+                pass
+        pbar.close()
+        data_dict["finished_at"] = datetime.datetime.now().strftime(DATETIME_FORMAT)
+        return data_dict
+
+    def process_queries(self, ignore_last_run: bool, count_only: bool) -> None:
+        """For each of the specified queries in turn
+        - Retrieves the summary details of last time the query was run
+        - Retrieves and prints the count of the remaining files to be processed
+        - Selects all files to be added to s3
+        - Uploads blob file data to s3
+        - Writes summary details of files processed (last run data) to s3
+        """
+        for query_dict in self.db.get_query_list():
+            query_name = query_dict["query_name"]
+            start_from_datetime = self.get_start_from_datetime(ignore_last_run, query_name)
+            row_count = self.db.execute_count_query(query_dict, start_from_datetime)
+            self.stdout.write(f"Files to be processed for {query_name} query: {row_count}")
+            if not count_only and row_count > 0:
+                last_file_processed = self.process_query_and_upload(
+                    query_dict, start_from_datetime, row_count
+                )
+                self.write_run_data_to_s3(last_file_processed)
+
+    def get_start_from_datetime(self, ignore_last_run: bool, query_name: str) -> str:
+        """Returns the date time the given query should be filtered from."""
+        if ignore_last_run:
+            return DEFAULT_CREATED_DATE_TIME
+        last_run_dict = self.get_last_run_data(query_name)
+        return last_run_dict["created_datetime"]
+
+    def write_run_data_to_s3(self, result: dict[str, Any]) -> None:
+        """Writes a (json) file to s3, which contains the details of the completed or partial run."""
+        data = json.dumps(result)
+        s3_web.put_object_in_s3(data, get_query_last_run_key(result["query_name"]))
+        self.stdout.write(data)
+
+    def get_last_run_data(self, query_name: str) -> dict:
+        """Returns a dictionary of details of the last time the query was run.
+
+        Attempts to retrieve a (json) file from s3 for a given query that contains summary details from
+        the last time the query was run. If the file is not present default data is returned.
+        """
+        file_name = get_query_last_run_key(query_name)
+        try:
+            file_blob = s3_web.get_file_from_s3(file_name)
+            _data = json.loads(file_blob.decode())
+        except ClientError:
+            _data = get_default_last_run_data(query_name)
+        return _data

--- a/data_migration/management/commands/utils/db_processor.py
+++ b/data_migration/management/commands/utils/db_processor.py
@@ -1,0 +1,69 @@
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import oracledb
+
+from data_migration.management.commands.utils.db import CONNECTION_CONFIG
+from data_migration.queries.files_v1 import QUERY_LIST
+
+
+class OracleDBProcessor:
+    QUERIES: list[dict] = QUERY_LIST
+
+    def __init__(self, limit: int, selected_queries: list[str], number_of_rows: int):
+        self.limit = limit
+        self.selected_queries = selected_queries
+        self.number_of_rows = number_of_rows
+
+    def get_query_list(self) -> Iterator[dict]:
+        for query in self.QUERIES:
+            if not self.selected_queries or (query["query_name"] in self.selected_queries):
+                yield query
+
+    def add_select_to_sql(self, sql: str) -> str:
+        return f"WITH DOC_QUERY AS ({sql}) SELECT * FROM DOC_QUERY"
+
+    def add_count_to_sql(self, sql: str) -> str:
+        return f"WITH DOC_QUERY AS ({sql}) SELECT count(1) FROM DOC_QUERY"
+
+    def add_limit_to_sql(self, sql: str) -> str:
+        if not self.limit:
+            return sql
+        return f"{sql} FETCH FIRST {self.limit} ROWS ONLY"
+
+    def get_basic_sql(self, query_dict: dict[str, str], start_from_datetime: str) -> str:
+        return query_dict["query"].format(created_datetime_from=start_from_datetime)
+
+    def get_count_sql(self, query_dict: dict[str, str], start_from_datetime: str) -> str:
+        sql = self.get_basic_sql(query_dict, start_from_datetime)
+        return self.add_count_to_sql(sql)
+
+    def get_sql(self, query_dict: dict[str, str], start_from_datetime: str) -> str:
+        sql = self.get_basic_sql(query_dict, start_from_datetime)
+        sql = self.add_limit_to_sql(sql)
+        return self.add_select_to_sql(sql)
+
+    def get_db_connection(self) -> oracledb.Connection:
+        return oracledb.connect(**CONNECTION_CONFIG)
+
+    @contextmanager
+    def execute_query(self, sql: str) -> Iterator:
+        with self.get_db_connection().cursor() as cursor:
+            cursor.execute(sql)
+            columns = [col[0].upper() for col in cursor.description]
+            cursor.rowfactory = lambda *args: dict(zip(columns, args))
+
+            def _rows():
+                while True:
+                    rows = cursor.fetchmany(self.number_of_rows)
+                    if not rows:
+                        break
+                    yield from rows
+
+            yield _rows()
+
+    def execute_count_query(self, query_dict: dict[str, str], start_from_datetime: str) -> int:
+        sql = self.get_count_sql(query_dict, start_from_datetime)
+        with self.get_db_connection().cursor() as cursor:
+            cursor.execute(sql)
+            return cursor.fetchone()[0]

--- a/data_migration/queries/files_v1.py
+++ b/data_migration/queries/files_v1.py
@@ -1,0 +1,224 @@
+# TODO: ICMSLST-2116 Remove this file and use the queries found in files.py
+
+QUERY_1 = f"""
+    SELECT
+    sld.blob_data
+    , fv.path
+    , fv.created_by_id
+    , fv.created_datetime
+    FROM mailshotmgr.xview_mailshot_details xmd
+    INNER JOIN decmgr.file_folders ff ON ff.id = xmd.documents_ff_id
+    INNER JOIN decmgr.file_folder_targets fft ON fft.ff_id = ff.id
+    INNER JOIN (
+    SELECT
+        fft_id target_id
+        , fv.id version_id
+        , create_start_datetime created_datetime
+        , create_by_wua_id created_by_id
+        , CONCAT(id, CONCAT('-', x.filename)) PATH
+        , secure_lob_ref
+        , x.*
+    FROM decmgr.file_versions fv
+    CROSS JOIN XMLTABLE('/*'
+        PASSING metadata_xml
+        COLUMNS
+        filename VARCHAR2(4000) PATH '/file-metadata/filename/text()'
+        , content_type VARCHAR2(4000) PATH '/file-metadata/content-type/text()'
+        , file_size NUMBER PATH '/file-metadata/size/text()'
+        ) x
+    WHERE status_control = 'C'
+    ) fv ON fv.target_id = fft.ID
+    INNER JOIN securemgr.secure_lob_data sld ON sld.id = DEREF(fv.secure_lob_ref).id
+    WHERE xmd.status_control = 'C' AND created_datetime > TO_DATE('{{created_datetime_from}}', 'YYYY/MM/DD HH24:MI:SS`')
+    ORDER BY fv.created_datetime ASC, fft.id
+"""  # noqa: F541
+
+QUERY_2 = f"""
+    SELECT
+    sld.blob_data
+    , fv.path
+    , fv.created_by_id
+    , fv.created_datetime
+    FROM impmgr.xview_ima_rfis xir
+    INNER JOIN decmgr.file_folders ff ON ff.id = xir.file_folder_id
+    INNER JOIN decmgr.file_folder_targets fft ON fft.ff_id = ff.id
+    INNER JOIN (
+    SELECT
+        fft_id target_id
+        , fv.id version_id
+        , create_start_datetime created_datetime
+        , create_by_wua_id created_by_id
+        , CONCAT(id, CONCAT('-', x.filename)) PATH
+        , secure_lob_ref
+        , x.*
+    FROM decmgr.file_versions fv
+    CROSS JOIN XMLTABLE('/*'
+        PASSING metadata_xml
+        COLUMNS
+        filename VARCHAR2(4000) PATH '/file-metadata/filename/text()'
+        , content_type VARCHAR2(4000) PATH '/file-metadata/content-type/text()'
+        , file_size NUMBER PATH '/file-metadata/size/text()'
+        ) x
+    WHERE status_control = 'C'
+    ) fv ON fv.target_id = fft.ID
+    INNER JOIN securemgr.secure_lob_data sld ON sld.id = DEREF(fv.secure_lob_ref).id
+    WHERE created_datetime > TO_DATE('{{created_datetime_from}}', 'YYYY/MM/DD HH24:MI:SS`')
+    ORDER by created_datetime ASC, fft.id
+"""  # noqa: F541
+
+QUERY_3 = f"""
+    SELECT
+    sld.blob_data
+    , fv.path
+    , fv.created_by_id
+    , fv.created_datetime
+    FROM decmgr.file_folder_targets fft
+    INNER JOIN decmgr.file_folders ff ON fft.ff_id = ff.id
+    INNER JOIN (
+    SELECT
+        fft_id target_id
+        , fv.id version_id
+        , create_start_datetime created_datetime
+        , create_by_wua_id created_by_id
+        , CONCAT(id, CONCAT('-', x.filename)) PATH
+        , secure_lob_ref
+        , x.*
+    FROM decmgr.file_versions fv
+    CROSS JOIN XMLTABLE('/*'
+        PASSING metadata_xml
+        COLUMNS
+        filename VARCHAR2(4000) PATH '/file-metadata/filename/text()'
+        , content_type VARCHAR2(4000) PATH '/file-metadata/content-type/text()'
+        , file_size NUMBER PATH '/file-metadata/size/text()'
+        ) x
+    WHERE status_control = 'C'
+    ) fv ON fv.target_id = fft.ID
+    INNER JOIN securemgr.secure_lob_data sld ON sld.id = DEREF(fv.secure_lob_ref).id
+    WHERE ff.file_folder_type IN ('IMP_CASE_NOTE_DOCUMENTS', 'GMP_SUPPORTING_DOCUMENTS')
+    AND created_datetime > TO_DATE('{{created_datetime_from}}', 'YYYY/MM/DD HH24:MI:SS`')
+    ORDER by created_datetime ASC, fft.id
+"""  # noqa: F541
+
+
+QUERY_4 = f"""
+    SELECT
+    sld.blob_data
+    , fv.path
+    , fv.created_by_id
+    , fv.created_datetime
+    FROM impmgr.xview_ima_details xid
+    INNER JOIN impmgr.import_application_types iat
+    ON iat.ima_type = xid.ima_type AND iat.ima_sub_type = xid.ima_sub_type
+    INNER JOIN decmgr.file_folders ff ON ff.id = xid.app_docs_ff_id
+    INNER JOIN decmgr.file_folder_targets fft ON fft.ff_id = ff.id
+    INNER JOIN (
+    SELECT
+        fft_id
+        , fv.id version_id
+        , create_start_datetime created_datetime
+        , create_by_wua_id created_by_id
+        , CONCAT(id, CONCAT('-', x.filename)) path
+        , secure_lob_ref
+        , x.*
+    FROM decmgr.file_versions fv
+    CROSS JOIN XMLTABLE('/*'
+        PASSING fv.metadata_xml
+        COLUMNS
+        filename VARCHAR2(4000) PATH '/file-metadata/filename/text()'
+        , content_type VARCHAR2(4000) PATH '/file-metadata/content-type/text()'
+        , file_size NUMBER PATH '/file-metadata/size/text()'
+    ) x
+    WHERE status_control = 'C'
+    ) fv ON fv.fft_id = fft.id
+    INNER JOIN securemgr.secure_lob_data sld ON sld.id = DEREF(fv.secure_lob_ref).id
+    WHERE xid.status_control = 'C' AND created_datetime > TO_DATE('{{created_datetime_from}}', 'YYYY/MM/DD HH24:MI:SS`')
+    AND xid.status <> 'DELETED'
+    AND (
+    (iat.status = 'ARCHIVED' AND xid.submitted_datetime IS NOT NULL)
+    OR iat.status = 'CURRENT'
+    )
+    order by created_datetime ASC, version_id asc
+"""  # noqa: F541
+
+
+QUERY_5 = f"""
+    SELECT
+    sld.blob_data
+    , vf.file_id || '-' || vf.filename PATH
+    , vf.created_by_wua_id created_by_id
+    , vf.created_datetime
+    FROM doclibmgr.folder_details fd
+    INNER JOIN doclibmgr.vw_file_folders vff ON vff.f_id = fd.f_id
+    INNER JOIN doclibmgr.vw_files vf ON vf.file_id = vff.file_id
+    INNER JOIN DOCLIBMGR.FILE_versions fv ON fv.id = vf.file_id
+    INNER JOIN securemgr.secure_lob_data sld ON sld.id = fv.secure_lob_id
+    WHERE fd.folder_title LIKE 'Case Note %' AND vf.created_datetime > TO_DATE('{{created_datetime_from}}', 'YYYY/MM/DD HH24:MI:SS`')
+    ORDER BY fv.created_datetime ASC, vf.file_id
+"""  # noqa: F541
+
+QUERY_6 = f"""
+    SELECT
+    glf.file_content as blob_data
+    , CONCAT(glf.id, CONCAT('/', x.filename)) path
+    , x.created_by_id
+    , TO_DATE(x.created_datetime, 'YYYY-MM-DD"T"HH24:MI:SS') AS created_datetime
+    FROM impmgr.import_application_details ad
+    INNER JOIN impmgr.xview_ima_details xid ON ad.id = xid.imad_id AND ima_type = 'FA'
+    CROSS JOIN XMLTABLE('
+    for $g1 in /IMA/FA_REPORTS/FA_SUPPLEMENTARY_REPORT_LIST/FA_SUPPLEMENTARY_REPORT | <null/>
+    where /IMA/FA_REPORTS/FA_SUPPLEMENTARY_REPORT_LIST/FA_SUPPLEMENTARY_REPORT and not($g1/self::null)
+    return
+    for $g2 in $g1/FA_SUPPLEMENTARY_REPORT_DETAILS/GOODS_LINE_LIST/GOODS_LINE | <null/>
+    where $g1/FA_SUPPLEMENTARY_REPORT_DETAILS/GOODS_LINE_LIST/GOODS_LINE and not($g2/self::null)
+    return
+    for $g3 in $g2/FILE_UPLOAD_LIST/FILE_UPLOAD | <null/>
+    where $g2/FILE_UPLOAD_LIST/FILE_UPLOAD and not ($g3/self::null)
+    return
+    <uploads>
+    <created_by_id>{{{{$g1/FA_SUPPLEMENTARY_REPORT_DETAILS/SUBMITTED_BY_WUA_ID/text()}}}}</created_by_id>
+    <file_id>{{{{$g3/FILE_CONTENT/file-id/text()}}}}</file_id>
+    <filename>{{{{$g3/FILE_CONTENT/filename/text()}}}}</filename>
+    <created_datetime>{{{{$g3/FILE_CONTENT/upload-date-time/text()}}}}</created_datetime>
+    </uploads>
+    '
+    PASSING ad.xml_data
+    COLUMNS
+    created_by_id INTEGER PATH '/uploads/created_by_id/text()'
+    , created_datetime VARCHAR(4000) PATH '/uploads/created_datetime/text()'
+    , sr_goods_file_id VARCHAR(4000) PATH '/uploads/file_id/text()'
+    , filename VARCHAR(4000) PATH '/uploads/filename/text()'
+    ) x
+    INNER JOIN impmgr.goods_line_files glf ON glf.id = x.sr_goods_file_id
+    WHERE ad.status_control = 'C' AND created_datetime > '{{created_datetime_from}}'
+    ORDER BY created_datetime
+"""  # noqa: F541
+
+
+QUERY_LIST = [
+    {
+        "query": QUERY_1,
+        "query_name": "V1_QUERY_1",
+    },
+    {
+        "query": QUERY_2,
+        "query_name": "V1_QUERY_2",
+    },
+    {
+        "query": QUERY_3,
+        "query_name": "V1_QUERY_3",
+    },
+    {
+        "query": QUERY_4,
+        "query_name": "V1_QUERY_4",
+    },
+    {
+        "query": QUERY_5,
+        "query_name": "V1_QUERY_5",
+    },
+    {
+        "query": QUERY_6,
+        "query_name": "V1_QUERY_6",
+    },
+]
+
+AVAILABLE_QUERIES = [query["query_name"] for query in QUERY_LIST]

--- a/data_migration/tests/test_db_processor.py
+++ b/data_migration/tests/test_db_processor.py
@@ -1,0 +1,55 @@
+from django.test import TestCase
+
+from data_migration.management.commands.utils.db_processor import OracleDBProcessor
+
+TEST_QUERY = f"""
+select file_contents as blob_data, path, created_by_id, created_datetime  from data_migration_document
+where  created_datetime > '{{created_datetime_from}}'
+ORDER BY created_datetime
+"""  # noqa: F541
+
+CREATED_DATETIME_ALT = "2023-01-01 01:00:00"
+
+
+class TestOracleDBProcessor(TestCase):
+    def setUp(self):
+        self.db = OracleDBProcessor(100, ["test_query"], 1)
+
+    def test_add_limit_to_sql(self):
+        assert (
+            self.db.add_limit_to_sql("select * from table")
+            == "select * from table FETCH FIRST 100 ROWS ONLY"
+        )
+
+    def test_get_sql(self):
+        query_dict = {"query_name": "test_query", "query": TEST_QUERY}
+        expected_sql = """WITH DOC_QUERY AS (
+select file_contents as blob_data, path, created_by_id, created_datetime  from data_migration_document
+where  created_datetime > '2023-01-01 01:00:00'
+ORDER BY created_datetime
+ FETCH FIRST 100 ROWS ONLY) SELECT * FROM DOC_QUERY"""
+
+        result = self.db.get_sql(query_dict, CREATED_DATETIME_ALT)
+        assert result == expected_sql
+
+    def test_get_count_sql(self):
+        query_dict = {"query_name": "test_query", "query": TEST_QUERY}
+        expected_sql = """WITH DOC_QUERY AS (
+select file_contents as blob_data, path, created_by_id, created_datetime  from data_migration_document
+where  created_datetime > '2023-01-01 01:00:00'
+ORDER BY created_datetime
+) SELECT count(1) FROM DOC_QUERY"""
+
+        result = self.db.get_count_sql(query_dict, CREATED_DATETIME_ALT)
+        assert result == expected_sql
+
+    def test_get_query_list(self):
+        db = OracleDBProcessor(100, None, 1)
+        result = [query_dict for query_dict in db.get_query_list()]
+        assert len(result) == 6
+        assert set(result[0].keys()) == {"query_name", "query"}
+
+    def test_get_filtered_query_list(self):
+        db = OracleDBProcessor(100, ["V1_QUERY_2", "V1_QUERY_5"], 1)
+        result = [query_dict["query_name"] for query_dict in db.get_query_list()]
+        assert set(result) == {"V1_QUERY_2", "V1_QUERY_5"}

--- a/data_migration/tests/test_import_v1_files_to_s3.py
+++ b/data_migration/tests/test_import_v1_files_to_s3.py
@@ -1,0 +1,208 @@
+import io
+import json
+from datetime import datetime
+from unittest import mock
+
+import freezegun
+from botocore.exceptions import ClientError
+
+from data_migration.management.commands import import_v1_files_to_s3
+from data_migration.management.commands.utils.db_processor import OracleDBProcessor
+
+CREATED_DATETIME_ALT = "2023-01-01 01:00:00"
+
+
+def test_get_query_last_run_key():
+    assert import_v1_files_to_s3.get_query_last_run_key("TEST") == "TEST-last-run.json"
+
+
+def test_get_default_last_run_data():
+    assert import_v1_files_to_s3.get_default_last_run_data("TEST") == {
+        "created_datetime": import_v1_files_to_s3.DEFAULT_CREATED_DATE_TIME,
+        "query_name": "TEST",
+    }
+
+
+def get_cmd_to_test():
+    query_dict = {"query_name": "test_query", "query": "select * from test_query_table"}
+    cmd = import_v1_files_to_s3.Command()
+    cmd.file_prefix = "test_query_prefix"
+    cmd.db = OracleDBProcessor(100, ["test_query"], 1)
+    cmd.db.QUERIES = [query_dict]
+    return cmd
+
+
+def test_get_start_from_datetime_ignore_true():
+    cmd = import_v1_files_to_s3.Command()
+    result = cmd.get_start_from_datetime(True, "test_query")
+    assert result == import_v1_files_to_s3.DEFAULT_CREATED_DATE_TIME
+
+
+@mock.patch("data_migration.management.commands.import_v1_files_to_s3.Command.get_last_run_data")
+def test_get_start_from_datetime_ignore_false(mock_get_last_run_file):
+    mock_get_last_run_file.return_value = {"created_datetime": CREATED_DATETIME_ALT}
+    cmd = import_v1_files_to_s3.Command()
+    result = cmd.get_start_from_datetime(False, "test_query")
+    assert result == CREATED_DATETIME_ALT
+
+
+@mock.patch("web.utils.s3.get_s3_client")
+def test_get_last_run_data(mock_get_client):
+    mock_get_client.return_value = FakeS3Client(b'{"text" : "hello"}')
+    cmd = import_v1_files_to_s3.Command()
+    result = cmd.get_last_run_data("test_query")
+    assert result == {"text": "hello"}
+
+
+@mock.patch("web.utils.s3.get_s3_client")
+def test_get_last_run_data_when_file_does_not_exist(mock_get_client):
+    mock_get_client.return_value = FakeS3Client(None, raise_exception=True)
+    cmd = import_v1_files_to_s3.Command()
+    result = cmd.get_last_run_data("test_query")
+    assert result == import_v1_files_to_s3.get_default_last_run_data("test_query")
+
+
+@freezegun.freeze_time(CREATED_DATETIME_ALT)
+@mock.patch("data_migration.management.commands.import_v1_files_to_s3.s3_web.upload_file_obj_to_s3")
+@mock.patch.object(OracleDBProcessor, "execute_query")
+def test_process_query_and_upload(mock_execute_query, mock_upload_file):
+    fake_db_rows = [
+        {
+            "BLOB_DATA": "blob",
+            "PATH": "testfile.txt",
+            "CREATED_DATETIME": datetime.strptime(CREATED_DATETIME_ALT, "%Y-%m-%d %H:%M:%S"),
+        },
+        {
+            "BLOB_DATA": "blob2",
+            "PATH": "testfile2.txt",
+            "CREATED_DATETIME": datetime.strptime(CREATED_DATETIME_ALT, "%Y-%m-%d %H:%M:%S"),
+        },
+    ]
+    mock_upload_file.return_value = None
+    mock_execute_query.return_value.__enter__.return_value = iter(fake_db_rows)
+
+    cmd = get_cmd_to_test()
+    result = cmd.process_query_and_upload(
+        cmd.db.QUERIES[0], import_v1_files_to_s3.DEFAULT_CREATED_DATE_TIME, len(fake_db_rows)
+    )
+    assert result == {
+        "created_datetime": "2023-01-01 01:00:00",
+        "file_prefix": "test_query_prefix",
+        "finished_at": "2023-01-01 01:00:00",
+        "number_of_files_processed": len(fake_db_rows),
+        "number_of_files_to_be_processed": len(fake_db_rows),
+        "query_name": "test_query",
+        "started_at": "2023-01-01 01:00:00",
+    }
+
+
+@freezegun.freeze_time(CREATED_DATETIME_ALT)
+@mock.patch("data_migration.management.commands.import_v1_files_to_s3.s3_web.upload_file_obj_to_s3")
+@mock.patch.object(OracleDBProcessor, "execute_query")
+def test_process_query_and_upload_no_data(mock_execute_query, mock_upload_file):
+    fake_db_rows = []
+    mock_upload_file.return_value = None
+    mock_execute_query.return_value.__enter__.return_value = iter(fake_db_rows)
+    cmd = get_cmd_to_test()
+    result = cmd.process_query_and_upload(
+        cmd.db.QUERIES[0], import_v1_files_to_s3.DEFAULT_CREATED_DATE_TIME, len(fake_db_rows)
+    )
+    assert result == {
+        "created_datetime": "1900-12-13 09:39:21",
+        "file_prefix": "test_query_prefix",
+        "finished_at": "2023-01-01 01:00:00",
+        "number_of_files_processed": len(fake_db_rows),
+        "number_of_files_to_be_processed": len(fake_db_rows),
+        "query_name": "test_query",
+        "started_at": "2023-01-01 01:00:00",
+    }
+
+
+@freezegun.freeze_time(CREATED_DATETIME_ALT)
+@mock.patch("data_migration.management.commands.import_v1_files_to_s3.s3_web.put_object_in_s3")
+@mock.patch("data_migration.management.commands.import_v1_files_to_s3.s3_web.get_file_from_s3")
+@mock.patch.object(OracleDBProcessor, "execute_query")
+@mock.patch.object(OracleDBProcessor, "execute_count_query")
+def test_process_queries(
+    mock_execute_count_query, mock_execute_query, mock_get_file_from_s3, mock_put_object_in_s3
+):
+    mock_get_file_from_s3.return_value = b'{"created_datetime": "2023-05-02 12:00:00"}'
+    mock_put_object_in_s3.return_value = None
+    mock_execute_count_query.return_value = 10
+    mock_execute_query.return_value.__enter__.return_value = iter([])
+
+    cmd = get_cmd_to_test()
+    cmd.process_queries(False, False)
+
+    assert mock_execute_count_query.called is True
+    assert mock_execute_query.called is True
+    assert mock_get_file_from_s3.called is True
+    assert mock_put_object_in_s3.called is True
+    mock_put_object_in_s3.assert_called_once_with(
+        json.dumps(
+            {
+                "number_of_files_to_be_processed": 10,
+                "number_of_files_processed": 0,
+                "query_name": "test_query",
+                "file_prefix": "test_query_prefix",
+                "created_datetime": "2023-05-02 12:00:00",
+                "started_at": "2023-01-01 01:00:00",
+                "finished_at": "2023-01-01 01:00:00",
+            }
+        ),
+        "test_query-last-run.json",
+    )
+
+
+@freezegun.freeze_time(CREATED_DATETIME_ALT)
+@mock.patch("data_migration.management.commands.import_v1_files_to_s3.s3_web.put_object_in_s3")
+@mock.patch("data_migration.management.commands.import_v1_files_to_s3.s3_web.get_file_from_s3")
+@mock.patch.object(OracleDBProcessor, "execute_query")
+@mock.patch.object(OracleDBProcessor, "execute_count_query")
+def test_process_queries_count_only(
+    mock_execute_count_query, mock_execute_query, mock_get_file_from_s3, mock_put_object_in_s3
+):
+    mock_get_file_from_s3.return_value = None
+    mock_put_object_in_s3.return_value = None
+    mock_execute_count_query.return_value = 10
+    mock_execute_query.return_value.__enter__.return_value = iter([])
+
+    cmd = get_cmd_to_test()
+    cmd.process_queries(True, True)
+
+    assert mock_get_file_from_s3.called is False
+    assert mock_execute_count_query.called is True
+    assert mock_execute_query.called is False
+    assert mock_put_object_in_s3.called is False
+
+
+@freezegun.freeze_time(CREATED_DATETIME_ALT)
+def test_get_initial_run_data_dict():
+    cmd = import_v1_files_to_s3.Command()
+    cmd.file_prefix = "test_query_prefix"
+    result = cmd.get_initial_run_data_dict("test_query", 123, "2023-05-02 12:00:00")
+    assert result == {
+        "created_datetime": "2023-05-02 12:00:00",
+        "file_prefix": "test_query_prefix",
+        "number_of_files_processed": 0,
+        "number_of_files_to_be_processed": 123,
+        "query_name": "test_query",
+        "started_at": "2023-01-01 01:00:00",
+    }
+
+
+class FakeS3Client:
+    def __init__(self, response, raise_exception=False):
+        self.response = response
+        self.raise_exception = raise_exception
+
+    def get_object(self, **kwargs):
+        if self.raise_exception:
+            raise ClientError({"Error": {"Code": "NoSuchKey"}}, "get_object")
+        return {"Body": self.wrap_response(self.response)}
+
+    def wrap_response(self, data):
+        _file = io.BytesIO()
+        _file.write(data)
+        _file.seek(0)
+        return _file

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -3030,3 +3030,26 @@ NCA & HO
 Sanctions Case Officer
 Bradley
 Mcgee
+created_by_id_pos
+icms_legacy_query_2
+Invalid Key
+%Y-%m-%d
+SS
+ASC
+ON fv.id
+ON sld.id = DEREF(fv.secure_lob_ref).id WHERE
+sld.blob_data
+SELECT sld.blob_data
+ON ff.id
+DummyFileUploadHandler
+SELENIUM
+SELECT glf.file_content , CONCAT(glf.id, CONCAT('/'
+x.created_datetime
+f"WITH DOC_QUERY AS
+Fetch
+DB Connection
+V1_QUERY_3
+"Returns a DB
+"Returns a dictionary
+"Returns the date time the given query should be filtered from
+"Returns a dictionary of details of the last time the query

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -32,6 +32,7 @@ python-dateutil==2.8.2
 requests==2.31.0
 sentry-sdk[django]==1.17.0
 structlog==20.1.0
+tqdm==4.65
 WeasyPrint==52.4
 whitenoise==5.2.0
 xlsxwriter==3.0.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,7 @@ django-extensions==3.2.1
 factory-boy==3.0.1
 faker==4.1.2
 flake8==6.0.0
+freezegun==1.2.2
 ipdb==0.13.3
 isort==5.12.0
 mypy==1.2.0
@@ -34,3 +35,4 @@ types-pytz==2021.1.0
 types-python-dateutil==2.8.19.4
 types-Pygments==2.14.0.6
 types-requests==2.25.0
+types-tqdm==4.65.0.1

--- a/web/utils/s3.py
+++ b/web/utils/s3.py
@@ -34,7 +34,6 @@ def get_file_from_s3(path: str, client: Optional["S3Client"] = None) -> bytes:
 
     s3_file = client.get_object(Bucket=settings.AWS_STORAGE_BUCKET_NAME, Key=path)
     contents = s3_file["Body"].read()
-
     return contents
 
 
@@ -55,6 +54,19 @@ def upload_file_obj_to_s3(file_obj: IO[Any], key: str, client: Optional["S3Clien
         client = get_s3_client()
 
     client.upload_fileobj(file_obj, Bucket=settings.AWS_STORAGE_BUCKET_NAME, Key=key)
+
+    object_meta = client.head_object(Bucket=settings.AWS_STORAGE_BUCKET_NAME, Key=key)
+
+    return object_meta["ContentLength"]
+
+
+def put_object_in_s3(file_data: str, key: str, client: Optional["S3Client"] = None) -> int:
+    """Uploads data as file to s3 and return the size of the file (bytes)."""
+
+    if not client:
+        client = get_s3_client()
+
+    client.put_object(Body=file_data, Bucket=settings.AWS_STORAGE_BUCKET_NAME, Key=key)
 
     object_meta = client.head_object(Bucket=settings.AWS_STORAGE_BUCKET_NAME, Key=key)
 


### PR DESCRIPTION
Command to import files into s3
 - Adds command
 - Adds tests for command
 - Supported options `--limit` `--ignore-last-run` `--queries` `--s3-file-prefix` `--number-of-rows` `--count-only` 

Known issues (other tasks still to do)
 - Command is using the wrong queries and should use the queries found in `files.py`
 - The last run data is only written to s3 on a successful run and not if an error occurs
