### PR TITLE
ICMSLST-2077 Data Migration Importer and Exporter Object Permissions

### DIFF
--- a/data_migration/management/commands/post_migration.py
+++ b/data_migration/management/commands/post_migration.py
@@ -1,27 +1,34 @@
 import oracledb
 from django.contrib.auth.models import Group
 from django.core.management.base import BaseCommand
+from guardian.shortcuts import remove_perm
 
-from web.models import User
+from web.models import Exporter, Importer, User
+from web.permissions import get_org_obj_permissions, organisation_add_contact
 
 from .config.post_migrate import GROUPS_TO_ROLES
 from .utils.db import CONNECTION_CONFIG
 
 
 class Command(BaseCommand):
-    def handle(self, *args, **options):
+    def handle(self, *args, **options) -> None:
         self.apply_user_permissions()
 
-    def apply_user_permissions(self):
+    def apply_user_permissions(self) -> None:
+        """Fetch user teams and roles from V1 and apply groups and object permissions in V2"""
         with oracledb.connect(**CONNECTION_CONFIG) as connection:
             self.fetch_data(connection, "ILB Case Officer")
             self.fetch_data(connection, "Home Office Case Officer")
             self.fetch_data(connection, "NCA Case Officer")
+            self.fetch_data(connection, "Importer User")
+            self.fetch_data(connection, "Exporter User")
 
-    def fetch_data(self, connection: oracledb.Connection, group_name: str):
+    def fetch_data(self, connection: oracledb.Connection, group_name: str) -> None:
+        """Fetch user teams and roles from V1 and call methods to assign groups and permissions
+        to the returned users"""
+
         self.stdout.write(f"Adding users to {group_name} group")
         query = GROUPS_TO_ROLES[group_name]
-        group = Group.objects.get(name=group_name)
 
         with connection.cursor() as cursor:
             cursor.execute(query)
@@ -32,9 +39,48 @@ class Command(BaseCommand):
                 if not rows:
                     break
 
-                self.assign_user_groups(group, rows)
+                if group_name in ("Importer User", "Exporter User"):
+                    self.assign_object_permissions(group_name, rows)
+                else:
+                    self.assign_user_groups(group_name, rows)
 
-    def assign_user_groups(self, group: Group, rows: list[tuple[str, str]]):
+    def assign_object_permissions(self, group_name: str, rows: list[tuple[str, str, int]]) -> None:
+        """Assign object permissions to the usernames provided in the data
+
+        :param group_name: the name of the group used to determine the object type to apply the permissions to
+        :param rows: each row of data should contain (username, roles, object_id)
+        """
         for row in rows:
             user = User.objects.get(username=row[0])
+            roles = row[1]
+            org_id = row[2]
+
+            if group_name == "Importer User":
+                org = Importer.objects.get(pk=org_id)
+            else:
+                org = Exporter.objects.get(pk=org_id)
+
+            assign_manage = ":AGENT_APPROVER" in roles
+
+            organisation_add_contact(org, user, assign_manage)
+
+            # Check user should have view permissions
+            if ":VIEW" not in roles:
+                obj_perms = get_org_obj_permissions(org)
+                remove_perm(obj_perms.view, user, org)
+
+            # Check user should have edit permissions
+            if ":EDIT_APP" not in roles and ":VARY_APP" not in roles:
+                obj_perms = get_org_obj_permissions(org)
+                remove_perm(obj_perms.edit, user, org)
+
+    def assign_user_groups(self, group_name: str, rows: list[tuple[str, str]]) -> None:
+        """Assign groups to the usernames provided in the data
+
+        :param group_name: the name of the group to be added to the user
+        :param rows: each row of data should contain (username, roles)
+        """
+        for row in rows:
+            user = User.objects.get(username=row[0])
+            group = Group.objects.get(name=group_name)
             user.groups.add(group)

--- a/data_migration/tests/test_e2e_users.py
+++ b/data_migration/tests/test_e2e_users.py
@@ -1,0 +1,305 @@
+import datetime as dt
+from unittest import mock
+
+import oracledb
+import pytest
+from django.core.management import call_command
+from django.test import override_settings
+
+from data_migration import models as dm
+from data_migration import queries
+from data_migration.management.commands.config.run_order import (
+    DATA_TYPE_M2M,
+    DATA_TYPE_QUERY_MODEL,
+    DATA_TYPE_SOURCE_TARGET,
+    DATA_TYPE_XML,
+)
+from data_migration.utils import xml_parser
+from web import models as web
+from web.permissions import ExporterObjectPermissions, ImporterObjectPermissions
+
+from . import utils
+
+sil_data_source_target = {
+    "user": [
+        (dm.User, web.User),
+        (dm.PhoneNumber, web.PhoneNumber),
+        (dm.AlternativeEmail, web.AlternativeEmail),
+        (dm.PersonalEmail, web.PersonalEmail),
+        (dm.Importer, web.Importer),
+        (dm.Exporter, web.Exporter),
+        (dm.Office, web.Office),
+        (dm.Process, web.Process),
+        (dm.AccessRequest, web.AccessRequest),
+        (dm.ImporterAccessRequest, web.ImporterAccessRequest),
+        (dm.ExporterAccessRequest, web.ExporterAccessRequest),
+        (dm.FurtherInformationRequest, web.FurtherInformationRequest),
+        (dm.ApprovalRequest, web.ApprovalRequest),
+        (dm.ImporterApprovalRequest, web.ImporterApprovalRequest),
+        (dm.ExporterApprovalRequest, web.ExporterApprovalRequest),
+    ],
+}
+
+
+@pytest.mark.django_db
+@mock.patch.dict(
+    DATA_TYPE_QUERY_MODEL,
+    {
+        "reference": [],
+        "user": [
+            (queries.users, "users", dm.User),
+            (queries.importers, "importers", dm.Importer),
+            (queries.importer_offices, "importer_offices", dm.Office),
+            (queries.exporters, "exporters", dm.Exporter),
+            (queries.exporter_offices, "exporter_offices", dm.Office),
+            (queries.access_requests, "access_requests", dm.AccessRequest),
+        ],
+    },
+)
+@mock.patch.dict(DATA_TYPE_SOURCE_TARGET, sil_data_source_target)
+@mock.patch.dict(
+    DATA_TYPE_M2M,
+    {
+        "user": [
+            (dm.Office, web.Importer, "offices"),
+            (dm.Office, web.Exporter, "offices"),
+            (dm.FurtherInformationRequest, web.AccessRequest, "further_information_requests"),
+        ],
+    },
+)
+@mock.patch.dict(
+    DATA_TYPE_XML,
+    {
+        "user": [
+            xml_parser.EmailAddressParser,
+            xml_parser.PhoneNumberParser,
+            xml_parser.ApprovalRequestParser,
+            xml_parser.AccessFIRParser,
+        ],
+    },
+)
+@mock.patch.object(oracledb, "connect")
+@override_settings(
+    PASSWORD_HASHERS=[
+        "django.contrib.auth.hashers.MD5PasswordHasher",
+        "web.auth.fox_hasher.FOXPBKDF2SHA1Hasher",
+    ]
+)
+def test_import_user_data(mock_connect, dummy_dm_settings):
+    mock_connect.return_value = utils.MockConnect()
+
+    call_command("export_from_v1", "--skip_ia", "--skip_export", "--skip_ref", "--skip_file")
+    call_command("extract_v1_xml", "--skip_ia", "--skip_export", "--skip_ref", "--skip_file")
+    call_command("import_v1_data", "--skip_ia", "--skip_export", "--skip_ref", "--skip_file")
+
+    assert web.User.objects.filter(groups__isnull=False).count() == 0
+
+    call_command("create_icms_groups")
+    call_command("post_migration")
+
+    assert web.User.objects.count() == 12
+
+    # Check User Data
+
+    users = web.User.objects.filter(pk__in=[2, 3]).order_by("pk")
+    u1: web.User = users[0]
+    u2: web.User = users[1]
+
+    assert u1.username == "ilb_case_officer@example.com"  # /PS-IGNORE
+    assert u1.first_name == "ILB"
+    assert u1.last_name == "Case-Officer"
+    assert u1.email == "ilb_case_officer@example.com"  # /PS-IGNORE
+    assert u1.check_password("password") is True
+    assert u1.title == "Mr"
+    assert u1.organisation == "Org"
+    assert u1.department == "Dept"
+    assert u1.job_title == "IT"
+    assert u1.phone_numbers.count() == 2
+    assert u1.alternative_emails.count() == 1
+    assert u1.personal_emails.count() == 2
+
+    pn1, pn2 = u1.phone_numbers.order_by("pk")
+    assert pn1.phone == "12345678"
+    assert pn1.type == "HOME"
+    assert pn1.comment == "My Home"
+    assert pn2.phone == "+212345678"
+    assert pn2.type == "MOBILE"
+    assert pn2.comment is None
+
+    ae1 = u1.alternative_emails.first()
+    assert ae1.email == "test_b"
+    assert ae1.type == "WORK"
+    assert ae1.portal_notifications is True
+    assert ae1.comment is None
+
+    pe1, pe2 = u1.personal_emails.order_by("pk")
+    assert pe1.email == "test_a"
+    assert pe1.type == "HOME"
+    assert pe1.portal_notifications is True
+    assert pe1.is_primary is True
+    assert pe1.comment == "A COMMENT"
+    assert pe2.email == "test_c"
+    assert pe2.type == "HOME"
+    assert pe2.portal_notifications is False
+    assert pe2.is_primary is False
+    assert pe2.comment is None
+
+    assert u2.check_password("password123") is True
+    assert u2.phone_numbers.count() == 0
+    assert u2.alternative_emails.count() == 0
+    assert u2.personal_emails.count() == 0
+
+    # Check Access Request / Approval Request
+
+    ar1, ar2, ar3, ar4 = web.AccessRequest.objects.order_by("pk")
+
+    assert ar1.process_ptr.process_type == "ImporterAccessRequest"
+    assert ar1.process_ptr.tasks.count() == 1
+    assert ar1.reference == "IAR/0001"
+    assert ar1.status == "SUBMITTED"
+    assert ar1.organisation_name == "Test Org"
+    assert ar1.organisation_address == "Test Address"
+    assert ar1.agent_name is None
+    assert ar1.agent_address == ""
+    assert ar1.response is None
+    assert ar1.response_reason == ""
+    assert ar1.importeraccessrequest.request_type == "MAIN_IMPORTER_ACCESS"
+    assert ar1.importeraccessrequest.link_id == 2
+    assert ar1.further_information_requests.count() == 0
+    assert ar1.approval_requests.count() == 0
+    assert ar1.created == dt.datetime(2022, 11, 14, 8, 24, tzinfo=dt.timezone.utc)
+
+    assert ar2.process_ptr.process_type == "ImporterAccessRequest"
+    assert ar2.process_ptr.tasks.count() == 0
+    assert ar2.reference == "IAR/0002"
+    assert ar2.status == "CLOSED"
+    assert ar2.agent_name == "Test Name"
+    assert ar2.agent_address == "Test Address"
+    assert ar2.request_reason == "Test Reason"
+    assert ar2.response == "APPROVED"
+    assert ar2.response_reason == "Test Reason"
+    assert ar2.importeraccessrequest.request_type == "AGENT_IMPORTER_ACCESS"
+    assert ar2.importeraccessrequest.link_id == 3
+    assert ar2.further_information_requests.count() == 0
+    assert ar2.approval_requests.count() == 1
+    assert ar2.created == dt.datetime(2022, 11, 14, 8, 47, tzinfo=dt.timezone.utc)
+
+    ar2_ar = ar2.approval_requests.first()
+    assert ar2_ar.process_ptr.process_type == "ImporterApprovalRequest"
+    assert ar2_ar.status == "COMPLETED"
+    assert ar2_ar.response == "APPROVE"
+    assert ar2_ar.response_reason == "Test Reason"
+    assert ar2_ar.importerapprovalrequest.pk == ar2_ar.pk
+    assert ar2_ar.request_date == dt.datetime(2022, 11, 14, 14, 55, 14, tzinfo=dt.timezone.utc)
+
+    assert ar3.process_ptr.process_type == "ExporterAccessRequest"
+    assert ar3.process_ptr.tasks.count() == 0
+    assert ar3.reference == "EAR/0003"
+    assert ar3.exporteraccessrequest.request_type == "MAIN_EXPORTER_ACCESS"
+    assert ar3.exporteraccessrequest.link_id == 2
+    assert ar3.further_information_requests.count() == 1
+    assert ar3.approval_requests.count() == 0
+    assert ar3.created == dt.datetime(2022, 11, 14, 10, 52, tzinfo=dt.timezone.utc)
+
+    assert ar4.process_ptr.process_type == "ExporterAccessRequest"
+    assert ar4.process_ptr.tasks.count() == 0
+    assert ar4.reference == "EAR/0004"
+    assert ar4.exporteraccessrequest.request_type == "AGENT_EXPORTER_ACCESS"
+    assert ar4.exporteraccessrequest.link_id == 3
+    assert ar4.further_information_requests.count() == 0
+    assert ar4.approval_requests.count() == 1
+    assert ar4.created == dt.datetime(2022, 11, 14, 10, 52, tzinfo=dt.timezone.utc)
+
+    ar4_ar = ar4.approval_requests.first()
+    assert ar4_ar.process_ptr.process_type == "ExporterApprovalRequest"
+    assert ar4_ar.status == "COMPLETED"
+    assert ar4_ar.response == "APPROVE"
+    assert ar4_ar.response_reason == "Test Reason"
+    assert ar4_ar.exporterapprovalrequest.pk == ar4_ar.pk
+
+    # Check Groups / Permissions
+
+    assert web.User.objects.filter(groups__isnull=False).count() == 11
+    assert (
+        web.User.objects.get(groups__name="ILB Case Officer").username
+        == "ilb_case_officer@example.com"  # /PS-IGNORE
+    )
+    assert (
+        web.User.objects.get(groups__name="Home Office Case Officer").username
+        == "home_office@example.com"  # /PS-IGNORE
+    )
+    assert (
+        web.User.objects.get(groups__name="NCA Case Officer").username
+        == "nca@example.com"  # /PS-IGNORE
+    )
+    assert web.User.objects.filter(groups__name="Importer User").count() == 4
+
+    IOP = ImporterObjectPermissions
+    importer_org = web.Importer.objects.get(id=2)
+    importer_agent_org = web.Importer.objects.get(id=3)
+
+    user = web.User.objects.get(username="importer_viewer@example.com")  # /PS-IGNORE
+    assert user.has_perm(IOP.view, importer_org) is True
+    assert user.has_perm(IOP.edit, importer_org) is False
+    assert user.has_perm(IOP.manage_contacts_and_agents, importer_org) is False
+    assert user.has_perm(IOP.is_agent, importer_org) is False
+
+    user = web.User.objects.get(username="importer_editor@example.com")  # /PS-IGNORE
+    assert user.has_perm(IOP.view, importer_org) is False
+    assert user.has_perm(IOP.edit, importer_org) is True
+    assert user.has_perm(IOP.manage_contacts_and_agents, importer_org) is True
+    assert user.has_perm(IOP.is_agent, importer_org) is False
+
+    user = web.User.objects.get(username="importer_agent_viewer@example.com")  # /PS-IGNORE
+    assert user.has_perm(IOP.view, importer_org) is False
+    assert user.has_perm(IOP.edit, importer_org) is False
+    assert user.has_perm(IOP.manage_contacts_and_agents, importer_org) is False
+    assert user.has_perm(IOP.is_agent, importer_org) is True
+    assert user.has_perm(IOP.view, importer_agent_org) is True
+    assert user.has_perm(IOP.edit, importer_agent_org) is False
+    assert user.has_perm(IOP.manage_contacts_and_agents, importer_agent_org) is False
+
+    user = web.User.objects.get(username="importer_agent_editor@example.com")  # /PS-IGNORE
+    assert user.has_perm(IOP.view, importer_org) is False
+    assert user.has_perm(IOP.edit, importer_org) is False
+    assert user.has_perm(IOP.manage_contacts_and_agents, importer_org) is False
+    assert user.has_perm(IOP.is_agent, importer_org) is True
+    assert user.has_perm(IOP.view, importer_agent_org) is True
+    assert user.has_perm(IOP.edit, importer_agent_org) is True
+    assert user.has_perm(IOP.manage_contacts_and_agents, importer_agent_org) is False
+
+    assert web.User.objects.filter(groups__name="Exporter User").count() == 4
+
+    EOP = ExporterObjectPermissions
+    exporter_org = web.Exporter.objects.get(id=1)
+    exporter_agent_org = web.Exporter.objects.get(id=2)
+
+    user = web.User.objects.get(username="exporter_viewer@example.com")  # /PS-IGNORE
+    assert user.has_perm(EOP.view, exporter_org) is True
+    assert user.has_perm(EOP.edit, exporter_org) is False
+    assert user.has_perm(EOP.manage_contacts_and_agents, exporter_org) is False
+    assert user.has_perm(EOP.is_agent, exporter_org) is False
+
+    user = web.User.objects.get(username="exporter_editor@example.com")  # /PS-IGNORE
+    assert user.has_perm(EOP.view, exporter_org) is False
+    assert user.has_perm(EOP.edit, exporter_org) is True
+    assert user.has_perm(EOP.manage_contacts_and_agents, exporter_org) is True
+    assert user.has_perm(EOP.is_agent, exporter_org) is False
+
+    user = web.User.objects.get(username="exporter_agent_viewer@example.com")  # /PS-IGNORE
+    assert user.has_perm(EOP.view, exporter_org) is False
+    assert user.has_perm(EOP.edit, exporter_org) is False
+    assert user.has_perm(EOP.manage_contacts_and_agents, exporter_org) is False
+    assert user.has_perm(EOP.is_agent, exporter_org) is True
+    assert user.has_perm(EOP.view, exporter_agent_org) is True
+    assert user.has_perm(EOP.edit, exporter_agent_org) is False
+    assert user.has_perm(EOP.manage_contacts_and_agents, exporter_agent_org) is False
+
+    user = web.User.objects.get(username="exporter_agent_editor@example.com")  # /PS-IGNORE
+    assert user.has_perm(EOP.view, exporter_org) is False
+    assert user.has_perm(EOP.edit, exporter_org) is False
+    assert user.has_perm(EOP.manage_contacts_and_agents, exporter_org) is False
+    assert user.has_perm(EOP.is_agent, exporter_org) is True
+    assert user.has_perm(EOP.view, exporter_agent_org) is True
+    assert user.has_perm(EOP.edit, exporter_agent_org) is True
+    assert user.has_perm(EOP.manage_contacts_and_agents, exporter_agent_org) is False

--- a/data_migration/tests/utils/user_data.py
+++ b/data_migration/tests/utils/user_data.py
@@ -53,10 +53,10 @@ user_query_result = {
             ),
             (
                 2,  # id
-                "test_user",  # username
-                "Test",  # first_name
-                "User",  # last_name
-                "test_a",  # email
+                "ilb_case_officer@example.com",  # username /PS-IGNORE
+                "ILB",  # first_name
+                "Case-Officer",  # last_name
+                "ilb_case_officer@example.com",  # email /PS-IGNORE
                 1,  # is_active
                 "31323334",  # salt 1234
                 "FB8C301A3EBDA623029E0AACC9D3B21B",  # encrypted_password /PS-IGNORE
@@ -75,10 +75,10 @@ user_query_result = {
             ),
             (
                 3,  # id
-                "test_user_two",  # username
-                "Testtwo",  # first_name
-                "Usertwo",  # last_name
-                "test.usertwo",  # email
+                "home_office@example.com",  # username /PS-IGNORE
+                "Home",  # first_name
+                "Office",  # last_name
+                "home_office@example.com",  # email  /PS-IGNORE
                 1,  # is_active
                 "35363738",  # salt 5678
                 "9E764661E6C292D49006E4AF99FB1793",  # encrypted_password /PS-IGNORE
@@ -87,7 +87,205 @@ user_query_result = {
                 "Dept",  # Department
                 "IT",  # job_title
                 "ACTIVE",  # account_status
-                "test_user(WUA_ID=3, WUAH_ID=4)",  # account_status_by
+                3,  # account_status_by
+                dt.date.today(),  # account_status_date
+                dt.datetime(2022, 11, 1, 12, 32),  # last_login_datetime
+                "FULL",  # password_disposition
+                None,  # email_address_xml
+                None,  # telephone_xml
+                0,  # share_contact_details
+            ),
+            (
+                4,  # id
+                "nca@example.com",  # username /PS-IGNORE
+                "NCA",  # first_name
+                "User",  # last_name
+                "nca@example.com",  # email  /PS-IGNORE
+                1,  # is_active
+                "35363738",  # salt 5678
+                "9E764661E6C292D49006E4AF99FB1793",  # encrypted_password /PS-IGNORE
+                "Ms",  # title
+                "Org",  # Oranisation
+                "Dept",  # Department
+                "IT",  # job_title
+                "ACTIVE",  # account_status
+                4,  # account_status_by
+                dt.date.today(),  # account_status_date
+                dt.datetime(2022, 11, 1, 12, 32),  # last_login_datetime
+                "FULL",  # password_disposition
+                None,  # email_address_xml
+                None,  # telephone_xml
+                0,  # share_contact_details
+            ),
+            (
+                5,  # id
+                "importer_editor@example.com",  # username /PS-IGNORE
+                "Importer",  # first_name
+                "Editor",  # last_name
+                "importer_editor@example.com",  # email  /PS-IGNORE
+                1,  # is_active
+                "35363738",  # salt 5678
+                "9E764661E6C292D49006E4AF99FB1793",  # encrypted_password /PS-IGNORE
+                "Ms",  # title
+                "Org",  # Oranisation
+                "Dept",  # Department
+                "IT",  # job_title
+                "ACTIVE",  # account_status
+                5,  # account_status_by
+                dt.date.today(),  # account_status_date
+                dt.datetime(2022, 11, 1, 12, 32),  # last_login_datetime
+                "FULL",  # password_disposition
+                None,  # email_address_xml
+                None,  # telephone_xml
+                0,  # share_contact_details
+            ),
+            (
+                6,  # id
+                "importer_viewer@example.com",  # username /PS-IGNORE
+                "Importer",  # first_name
+                "Viewer",  # last_name
+                "importer_viwer@example.com",  # email  /PS-IGNORE
+                1,  # is_active
+                "35363738",  # salt 5678
+                "9E764661E6C292D49006E4AF99FB1793",  # encrypted_password /PS-IGNORE
+                "Ms",  # title
+                "Org",  # Oranisation
+                "Dept",  # Department
+                "IT",  # job_title
+                "ACTIVE",  # account_status
+                6,  # account_status_by
+                dt.date.today(),  # account_status_date
+                dt.datetime(2022, 11, 1, 12, 32),  # last_login_datetime
+                "FULL",  # password_disposition
+                None,  # email_address_xml
+                None,  # telephone_xml
+                0,  # share_contact_details
+            ),
+            (
+                7,  # id
+                "importer_agent_editor@example.com",  # username /PS-IGNORE
+                "Importer Agent",  # first_name
+                "Editor",  # last_name
+                "importer_agent_editor@example.com",  # email  /PS-IGNORE
+                1,  # is_active
+                "35363738",  # salt 5678
+                "9E764661E6C292D49006E4AF99FB1793",  # encrypted_password /PS-IGNORE
+                "Ms",  # title
+                "Org",  # Oranisation
+                "Dept",  # Department
+                "IT",  # job_title
+                "ACTIVE",  # account_status
+                7,  # account_status_by
+                dt.date.today(),  # account_status_date
+                dt.datetime(2022, 11, 1, 12, 32),  # last_login_datetime
+                "FULL",  # password_disposition
+                None,  # email_address_xml
+                None,  # telephone_xml
+                0,  # share_contact_details
+            ),
+            (
+                8,  # id
+                "importer_agent_viewer@example.com",  # username /PS-IGNORE
+                "Importer Agent",  # first_name
+                "Viewer",  # last_name
+                "importer_agent_viwer@example.com",  # email  /PS-IGNORE
+                1,  # is_active
+                "35363738",  # salt 5678
+                "9E764661E6C292D49006E4AF99FB1793",  # encrypted_password /PS-IGNORE
+                "Ms",  # title
+                "Org",  # Oranisation
+                "Dept",  # Department
+                "IT",  # job_title
+                "ACTIVE",  # account_status
+                8,  # account_status_by
+                dt.date.today(),  # account_status_date
+                dt.datetime(2022, 11, 1, 12, 32),  # last_login_datetime
+                "FULL",  # password_disposition
+                None,  # email_address_xml
+                None,  # telephone_xml
+                0,  # share_contact_details
+            ),
+            (
+                9,  # id
+                "exporter_editor@example.com",  # username /PS-IGNORE
+                "Exporter",  # first_name
+                "Editor",  # last_name
+                "Exporter_editor@example.com",  # email  /PS-IGNORE
+                1,  # is_active
+                "35363738",  # salt 5678
+                "9E764661E6C292D49006E4AF99FB1793",  # encrypted_password /PS-IGNORE
+                "Ms",  # title
+                "Org",  # Oranisation
+                "Dept",  # Department
+                "IT",  # job_title
+                "ACTIVE",  # account_status
+                9,  # account_status_by
+                dt.date.today(),  # account_status_date
+                dt.datetime(2022, 11, 1, 12, 32),  # last_login_datetime
+                "FULL",  # password_disposition
+                None,  # email_address_xml
+                None,  # telephone_xml
+                0,  # share_contact_details
+            ),
+            (
+                10,  # id
+                "exporter_viewer@example.com",  # username /PS-IGNORE
+                "Exporter",  # first_name
+                "Viewer",  # last_name
+                "exporter_viwer@example.com",  # email  /PS-IGNORE
+                1,  # is_active
+                "35363738",  # salt 5678
+                "9E764661E6C292D49006E4AF99FB1793",  # encrypted_password /PS-IGNORE
+                "Ms",  # title
+                "Org",  # Oranisation
+                "Dept",  # Department
+                "IT",  # job_title
+                "ACTIVE",  # account_status
+                10,  # account_status_by
+                dt.date.today(),  # account_status_date
+                dt.datetime(2022, 11, 1, 12, 32),  # last_login_datetime
+                "FULL",  # password_disposition
+                None,  # email_address_xml
+                None,  # telephone_xml
+                0,  # share_contact_details
+            ),
+            (
+                11,  # id
+                "exporter_agent_editor@example.com",  # username /PS-IGNORE
+                "Exporter Agent",  # first_name
+                "Editor",  # last_name
+                "exporter_agent_editor@example.com",  # email  /PS-IGNORE
+                1,  # is_active
+                "35363738",  # salt 5678
+                "9E764661E6C292D49006E4AF99FB1793",  # encrypted_password /PS-IGNORE
+                "Ms",  # title
+                "Org",  # Oranisation
+                "Dept",  # Department
+                "IT",  # job_title
+                "ACTIVE",  # account_status
+                11,  # account_status_by
+                dt.date.today(),  # account_status_date
+                dt.datetime(2022, 11, 1, 12, 32),  # last_login_datetime
+                "FULL",  # password_disposition
+                None,  # email_address_xml
+                None,  # telephone_xml
+                0,  # share_contact_details
+            ),
+            (
+                12,  # id
+                "exporter_agent_viewer@example.com",  # username /PS-IGNORE
+                "Exporter Agent",  # first_name
+                "Viewer",  # last_name
+                "exporter_agent_viwer@example.com",  # email  /PS-IGNORE
+                1,  # is_active
+                "35363738",  # salt 5678
+                "9E764661E6C292D49006E4AF99FB1793",  # encrypted_password /PS-IGNORE
+                "Ms",  # title
+                "Org",  # Oranisation
+                "Dept",  # Department
+                "IT",  # job_title
+                "ACTIVE",  # account_status
+                12,  # account_status_by
                 dt.date.today(),  # account_status_date
                 dt.datetime(2022, 11, 1, 12, 32),  # last_login_datetime
                 "FULL",  # password_disposition
@@ -145,12 +343,12 @@ user_query_result = {
             ("is_active",),
             ("name",),
             ("registered_number",),
-            ("main_importer_id",),
+            ("main_exporter_id",),
         ],
         [
-            (1, 1, "Test Org", 123, 2, None),
-            (2, 1, "Test Agent", 124, "GB123456789013", 2, 1),
-            (3, 0, "Test Inactive", 125, "GB123456789014", 2, None),
+            (1, 1, "Test Org", 123, None),
+            (2, 1, "Test Agent", 124, 1),
+            (3, 0, "Test Inactive", 125, None),
         ],
     ),
     queries.exporter_offices: (
@@ -305,24 +503,88 @@ user_query_result = {
         ],
     ),
     queries.ilb_user_roles: (
+        [("username",), ("roles")],
         [
-            ("username",),
-            ("roles"),
+            (
+                "ilb_case_officer@example.com",  # /PS-IGNORE
+                "IMP_CASE_OFFICERS:CASE_OFFICER, IMP_CASE_OFFICERS:CA_CASE_OFFICER",
+            )
         ],
-        [("test_user", "TEAM_1:ROLE_1,TEAM_1:ROLE_2")],
     ),
     queries.nca_user_roles: (
+        [("username",), ("roles")],
         [
-            ("username",),
-            ("roles"),
+            (
+                "nca@example.com",  # /PS-IGNORE
+                "IMP_ADMIN:DASHBOARD_USER, REPORTING_TEAM:REPORT_RUNNER_NOW, REPORTING_TEAM:REPORT_VIEWER",
+            )
         ],
-        [("test_user_two", "TEAM_1:ROLE_1,TEAM_1:ROLE_2")],
     ),
     queries.home_office_user_roles: (
+        [("username",), ("roles")],
+        [
+            (
+                "home_office@example.com",  # /PS-IGNORE
+                "IMP_EXTERNAL:SECTION5_AUTHORITY_EDITOR, IMP_ADMIN_SEARCH:SEARCH_CASES",
+            )
+        ],
+    ),
+    queries.importer_user_roles: (
         [
             ("username",),
             ("roles"),
+            ("importer_id",),
         ],
-        [("test_user_two", "TEAM_1:ROLE_1,TEAM_1:ROLE_2")],
+        [
+            (
+                "importer_viewer@example.com",  # /PS-IGNORE
+                "IMP_IMPORTER_CONTACTS:VIEW_APP",
+                2,
+            ),
+            (
+                "importer_editor@example.com",  # /PS-IGNORE
+                "IMP_IMPORTER_CONTACTS:AGENT_APPROVER, IMP_IMPORTER_CONTACTS:EDIT_APP",
+                2,
+            ),
+            (
+                "importer_agent_viewer@example.com",  # /PS-IGNORE
+                "IMP_IMPORTER_AGENT_CONTACTS:VIEW_APP",
+                3,
+            ),
+            (
+                "importer_agent_editor@example.com",  # /PS-IGNORE
+                "IMP_IMPORTER_AGENT_CONTACTS:VIEW_APP, IMP_IMPORTER_AGENT_CONTACTS:VARY_APP",
+                3,
+            ),
+        ],
+    ),
+    queries.exporter_user_roles: (
+        [
+            ("username",),
+            ("roles",),
+            ("exporter_id",),
+        ],
+        [
+            (
+                "exporter_viewer@example.com",  # /PS-IGNORE
+                "IMP_EXPORTER_CONTACTS:VIEW_APP",
+                1,
+            ),
+            (
+                "exporter_editor@example.com",  # /PS-IGNORE
+                "IMP_EXPORTER_CONTACTS:AGENT_APPROVER, IMP_EXPORTER_CONTACTS:EDIT_APP",
+                1,
+            ),
+            (
+                "exporter_agent_viewer@example.com",  # /PS-IGNORE
+                "IMP_EXPORTER_AGENT_CONTACTS:VIEW_APP",
+                2,
+            ),
+            (
+                "exporter_agent_editor@example.com",  # /PS-IGNORE
+                "IMP_EXPORTER_AGENT_CONTACTS:VIEW_APP, IMP_EXPORTER_AGENT_CONTACTS:VARY_APP",
+                2,
+            ),
+        ],
     ),
 }

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -3087,3 +3087,6 @@ Baker
 Nottingham
 can_edit_firearm_authorities
 v3.8.0
+LEFT JOIN decmgr.resource_usages_current
+ON ru.res_id =
+ru.uref


### PR DESCRIPTION
Apply importer and exporter object permissions after the post data migration. The queries to select the data narrow down the permissions to only select data for `IMP_EXPORTER_AGENT_CONTACTS` and  `IMP_EXPORTER_CONTACTS` for exporters and `IMP_IMPORTER_AGENT_CONTACTS` and  `IMP_IMPORTER_CONTACTS` for importers along with returning the organisation id the user's permissions are for. The user permissions are then applied based on their roles in the organisation `VIEW` to view, `EDIT` or `VARY` to edit, `AGENT_APPROVER` to manage contacts.