### PR TITLE
ICMSLST-2098 Refactor Import to s3 script options

### DIFF
--- a/data_migration/README.md
+++ b/data_migration/README.md
@@ -46,6 +46,31 @@ The following data_types are valid in the `--start` parameter
 * `f` or `file` for the file data type
 * `ia` or `import_application` for the import_application data type
 
+## File Import
+
+The following script is used to pull the file data from V1 and export into S3
+
+```
+./manage.py import_v1_files_to_s3
+```
+The command can be run with options
+* `--batchsize` to modify the size of the batches when running the migration (default: 500)
+* `--run-data-batchsize` to modify the size of the batches when periodically saving the run data to s3 (default: 100)
+* `--limit` to limit the database queries to only return a set number of rows (default: None)
+* `--ignore-last-run` to ignore the data in the last run json file (if present) in s3 (default: False)
+* `--queries` to specify which queries to run (default: All available queries)
+* `--count-only` to retrieve just the total count (and file size) of the number of files that be processed per query (default: False)
+
+Some of the queries are smaller than others, so it is recommended the script is run as follows
+```
+./manage.py import_v1_files_to_s3 --queries small
+./manage.py import_v1_files_to_s3 --queries sil_application_files
+./manage.py import_v1_files_to_s3 --queries sps_application_files
+./manage.py import_v1_files_to_s3 --queries sps_docs --limit 11000 (Run 8 times)
+./manage.py import_v1_files_to_s3
+```
+
+
 
 ## Deployment
 

--- a/data_migration/management/commands/export_from_v1.py
+++ b/data_migration/management/commands/export_from_v1.py
@@ -33,7 +33,7 @@ class Command(MigrationBaseCommand):
 
         parser.add_argument(
             "--skip_post",
-            help="Skip post exoprt tasks",
+            help="Skip post export tasks",
             action="store_true",
         )
 

--- a/data_migration/queries/files.py
+++ b/data_migration/queries/files.py
@@ -22,7 +22,7 @@ LEFT JOIN (
     , fv.id version_id
     , create_start_datetime created_datetime
     , create_by_wua_id created_by_id
-    , CONCAT(id, CONCAT('-', x.filename)) path
+    , 'derogations_application_files/' || id || '-' || x.filename path
     , secure_lob_ref
     , x.*
   FROM decmgr.file_versions fv
@@ -73,7 +73,7 @@ LEFT JOIN (
     , fv.id version_id
     , create_start_datetime created_datetime
     , create_by_wua_id created_by_id
-    , CONCAT(id, CONCAT('-', x.filename)) path
+    , 'sps_application_files/' || id || '-' || x.filename path
     , DEREF(secure_lob_ref).id  secure_lob_ref_id
     , x.*
   FROM decmgr.file_versions fv
@@ -124,7 +124,7 @@ LEFT JOIN (
     , fv.id version_id
     , create_start_datetime created_datetime
     , create_by_wua_id created_by_id
-    , CONCAT(id, CONCAT('-', x.filename)) path
+    , 'dfl_application_files/' || id || '-' || x.filename path
     , DEREF(secure_lob_ref).id  secure_lob_ref_id
     , x.*
   FROM decmgr.file_versions fv
@@ -176,7 +176,7 @@ LEFT JOIN (
     , fv.id version_id
     , create_start_datetime created_datetime
     , create_by_wua_id created_by_id
-    , CONCAT(id, CONCAT('-', x.filename)) path
+    , 'oil_application_files/' || id || '-' || x.filename path
     , DEREF(secure_lob_ref).id  secure_lob_ref_id
     , x.*
   FROM decmgr.file_versions fv
@@ -228,7 +228,7 @@ LEFT JOIN (
     , fv.id version_id
     , create_start_datetime created_datetime
     , create_by_wua_id created_by_id
-    , CONCAT(id, CONCAT('-', x.filename)) path
+    , 'sil_application_files/' || id || '-' || x.filename path
     , DEREF(secure_lob_ref).id  secure_lob_ref_id
     , x.*
   FROM decmgr.file_versions fv
@@ -280,7 +280,7 @@ LEFT JOIN (
     , fv.id version_id
     , create_start_datetime created_datetime
     , create_by_wua_id created_by_id
-    , CONCAT(id, CONCAT('-', x.filename)) path
+    , 'sanction_application_files/' || id || '-' || x.filename path
     , DEREF(secure_lob_ref).id  secure_lob_ref_id
     , x.*
   FROM decmgr.file_versions fv
@@ -332,7 +332,7 @@ LEFT JOIN (
     , fv.id version_id
     , create_start_datetime created_datetime
     , create_by_wua_id created_by_id
-    , CONCAT(id, CONCAT('-', x.filename)) path
+    , 'opt_application_files/' || id || '-' || x.filename path
     , DEREF(secure_lob_ref).id  secure_lob_ref_id
     , x.*
   FROM decmgr.file_versions fv
@@ -387,7 +387,7 @@ LEFT JOIN (
     , fv.id version_id
     , create_start_datetime created_datetime
     , create_by_wua_id created_by_id
-    , CONCAT(id, CONCAT('-', x.filename)) path
+    , 'wood_application_files/' || id || '-' || x.filename path
     , DEREF(secure_lob_ref).id  secure_lob_ref_id
     , x.*
   FROM decmgr.file_versions fv
@@ -439,7 +439,7 @@ LEFT JOIN (
     , fv.id version_id
     , create_start_datetime created_datetime
     , create_by_wua_id created_by_id
-    , CONCAT(id, CONCAT('-', x.filename)) path
+    , 'textiles_application_files/' || id || '-' || x.filename path
     , DEREF(secure_lob_ref).id  secure_lob_ref_id
     , x.*
   FROM decmgr.file_versions fv
@@ -503,7 +503,7 @@ LEFT JOIN (
     , fv.id version_id
     , create_start_datetime created_datetime
     , create_by_wua_id created_by_id
-    , CONCAT(id, CONCAT('-', x.filename)) path
+    , 'fa_certificate_files/' || id || '-' || x.filename path
     , DEREF(secure_lob_ref).id  secure_lob_ref_id
     , x.*
   FROM decmgr.file_versions fv
@@ -545,7 +545,7 @@ LEFT JOIN (
     , fv.id version_id
     , create_start_datetime created_datetime
     , create_by_wua_id created_by_id
-    , CONCAT(id, CONCAT('-', x.filename)) path
+    , 'sps_docs/' || id || '-' || x.filename path
     , DEREF(secure_lob_ref).id  secure_lob_ref_id
     , x.*
   FROM decmgr.file_versions fv,
@@ -587,7 +587,7 @@ LEFT JOIN (
     , fv.id version_id
     , create_start_datetime created_datetime
     , create_by_wua_id created_by_id
-    , CONCAT(id, CONCAT('-', x.filename)) path
+    , 'case_note_files/' || id || '-' || x.filename path
     , DEREF(secure_lob_ref).id  secure_lob_ref_id
     , x.*
   FROM decmgr.file_versions fv
@@ -630,7 +630,7 @@ LEFT JOIN (
     , fv.id version_id
     , create_start_datetime created_datetime
     , create_by_wua_id created_by_id
-    , CONCAT(id, CONCAT('-', x.filename)) path
+    , 'fir_files/' || id || '-' || x.filename path
     , DEREF(secure_lob_ref).id  secure_lob_ref_id
     , x.*
   FROM decmgr.file_versions fv
@@ -673,7 +673,7 @@ LEFT JOIN (
     , fv.id version_id
     , create_start_datetime created_datetime
     , create_by_wua_id created_by_id
-    , CONCAT(id, CONCAT('-', x.filename)) path
+    , 'mailshot_files/' || id || '-' || x.filename path
     , DEREF(secure_lob_ref).id  secure_lob_ref_id
     , x.*
   FROM decmgr.file_versions fv
@@ -715,7 +715,7 @@ LEFT JOIN (
     , fv.id version_id
     , create_start_datetime created_datetime
     , create_by_wua_id created_by_id
-    , CONCAT(id, CONCAT('-', x.filename)) path
+    , 'gmp_files/' || id || '-' || x.filename path
     , DEREF(secure_lob_ref).id  secure_lob_ref_id
     , x.*
   FROM decmgr.file_versions fv
@@ -743,7 +743,7 @@ SELECT
   , vf.created_datetime as created_datetime
   , vf.created_by_wua_id created_by_id
   , EXTRACTVALUE(vf.metadata_xml, '/file-metadata/size') file_size
-  , vf.file_id || '-' || vf.filename path
+  , 'export_case_note_docs/' || vf.file_id || '-' || vf.filename path
   , sld.blob_data
 FROM doclibmgr.folder_details fd
 LEFT JOIN doclibmgr.vw_file_folders vff ON vff.f_id = fd.f_id
@@ -759,7 +759,7 @@ fa_supplementary_report_upload_files = """
 SELECT
     ad.ima_id
   , ad.id imad_id
-  , CONCAT(x.sr_goods_file_id, CONCAT('/', x.filename)) PATH
+  , 'fa_supplementary_report_upload_files/' || x.sr_goods_file_id || '/' || x.filename PATH
   , glf.file_content as blob_data
   , to_date(replace(created_datetime_str, 'T', chr(10)), 'YYYY-MM-DD HH24:MI:SS') created_datetime
   , x.*

--- a/data_migration/tests/test_import_v1_files_to_s3.py
+++ b/data_migration/tests/test_import_v1_files_to_s3.py
@@ -44,8 +44,8 @@ class TestImportV1FilesToS3:
 
     def get_cmd_to_test(self):
         cmd = import_v1_files_to_s3.Command()
-        cmd.file_prefix = "test_query_prefix"
         cmd.db = OracleDBProcessor(100, ["test_query"], 1)
+        cmd.run_data_batchsize = 100
         return cmd
 
     def test_get_query_last_run_key(self):
@@ -97,7 +97,6 @@ class TestImportV1FilesToS3:
         mock_upload_last_run(
             {
                 "created_datetime": "2023-01-01 01:00:00",
-                "file_prefix": "test_query_prefix",
                 "finished_at": "2023-01-01 01:00:00",
                 "number_of_files_processed": len(FAKE_DB_RESPONSE),
                 "number_of_files_to_be_processed": len(FAKE_DB_RESPONSE),
@@ -163,7 +162,6 @@ class TestImportV1FilesToS3:
                     "number_of_files_to_be_processed": 2,
                     "number_of_files_processed": 2,
                     "query_name": "test_query",
-                    "file_prefix": "test_query_prefix",
                     "started_at": "2023-01-01 01:00:00",
                     "created_datetime": "2023-01-01 01:00:00",
                     "finished_at": "2023-01-01 01:00:00",
@@ -201,7 +199,6 @@ class TestImportV1FilesToS3:
         parameters = {"created_datetime": "2023-05-02 12:00:00"}
         result = self.cmd.get_initial_run_data_dict(self.test_query, parameters, 123)
         assert result == {
-            "file_prefix": "test_query_prefix",
             "number_of_files_processed": 0,
             "number_of_files_to_be_processed": 123,
             "query_name": "test_query",
@@ -222,7 +219,7 @@ class TestImportV1FilesToS3:
     def test_should_save_run_data(
         self, number_of_files_processed, number_of_files_to_be_processed, expected_result
     ):
-        self.cmd.SAVE_RUN_DATA = 5
+        self.cmd.run_data_batchsize = 5
         assert (
             self.cmd.should_save_run_data(
                 number_of_files_processed, number_of_files_to_be_processed

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -3109,3 +3109,8 @@ Test Inactive
 gmp2/ISO22716
 MB
 "Returns True
+ALLOW_DATA_MIGRATION` - True
+import_v1_data
+--skip_task
+ia.2
+./manage.py import_v1_files_to_s3 --queries


### PR DESCRIPTION
- Removed `--s3-file-prefix` option in favour of prefixing the query name to the file path within the queries themselves
- Renamed `--number-of-rows` to `--batchsize` to be more consistent with other data migration commands
- Created an option  `--run-data-batchsize` to replace `SAVE_RUN_DATA`
- Introduced query aliases `small` / `large` that groups queries based on total data (small below 1.5 GB)
- Updated Readme