### PR TITLE
ICMSLST-2061 Fetch Email Attachments in Celery Task

### DIFF
--- a/web/templates/web/domains/case/manage/case-emails.html
+++ b/web/templates/web/domains/case/manage/case-emails.html
@@ -4,7 +4,7 @@
 
 
 {% block content_actions_link %}
-  <a href="{{ icms_url('case:manage', kwargs={'application_pk': process.pk, 'case_type': 'import'}) }}" class="prev-link">
+  <a href="{{ icms_url('case:manage', kwargs={'application_pk': process.pk, 'case_type': case_type}) }}" class="prev-link">
     Application
   </a>
 {% endblock %}


### PR DESCRIPTION
Pass attachment ids instead of attachment files to send_email so emails with attachments can be called as a celery task. Fetch the files from S3 within send_email task instead