### PR TITLE
ICMSLST-2315 Remove PDF_DEFAULT_DOMAIN setting.

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -281,9 +281,6 @@ CSRF_COOKIE_SECURE = True
 # Default domain is used in email templates to point users to ICMS from emails
 DEFAULT_DOMAIN = env.str("ICMS_DEFAULT_DOMAIN", default="http://localhost:8080/")
 
-# Used to access static files when generating pdfs
-PDF_DEFAULT_DOMAIN = env.str("ICMS_DEFAULT_DOMAIN", default="http://localhost:8080/")
-
 SELECT2_CACHE_BACKEND = "default"
 SELECT2_CSS = os.path.join(STATIC_URL, "3rdparty/select2/select2.min.css")
 SELECT2_JS = os.path.join(STATIC_URL, "3rdparty/select2/select2.min.js")

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -83,10 +83,6 @@ HTML_MINIFY = False
 # Django Compressor (also set ICMS_DEBUG to False, to trigger compression of js on system start)
 COMPRESS_OFFLINE = False
 
-
-# Need to use the local docker-compose network name to access the static files.
-PDF_DEFAULT_DOMAIN = "http://web:8080/"
-
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,7 @@ services:
             - GOV_NOTIFY_API_KEY
             - EMAIL_BACKEND
             - SEND_ALL_EMAILS_TO
+            - APP_ENV
         depends_on:
             - redis
         volumes:

--- a/web/tests/utils/pdf/test_generator.py
+++ b/web/tests/utils/pdf/test_generator.py
@@ -317,7 +317,7 @@ def test_get_document_context_raises_error_if_doc_type_unsupported(licence):
         generator.get_document_context()
 
 
-def test_get_pdf(oil_app, licence):
+def test_get_pdf(db, oil_app, licence):
     generator = PdfGenerator(oil_app, licence, DocumentTypes.LICENCE_PREVIEW)
     pdf_file = generator.get_pdf()
 

--- a/web/utils/pdf/generator.py
+++ b/web/utils/pdf/generator.py
@@ -9,6 +9,7 @@ from django.template.loader import render_to_string
 from web.domains.case.types import DocumentPack, ImpOrExp
 from web.flow.models import ProcessTypes
 from web.models import Country
+from web.sites import get_caseworker_site_domain
 from web.types import DocumentTypes
 
 from . import utils
@@ -29,7 +30,7 @@ class PdfGenerator:
         """
 
         html_string = self.get_document_html()
-        html = weasyprint.HTML(string=html_string, base_url=settings.PDF_DEFAULT_DOMAIN)
+        html = weasyprint.HTML(string=html_string, base_url=get_icms_domain())
 
         return html.write_pdf(target=target)
 
@@ -150,3 +151,13 @@ class PdfGenerator:
                     raise ValueError(f"Unsupported process type: {self.application.process_type}")
         else:
             raise ValueError(f"Unsupported document type: {self.doc_type}")
+
+
+def get_icms_domain() -> str:
+    """Used to access static files when generating pdfs"""
+
+    # Need to use the local docker-compose network name to access the static files.
+    if settings.APP_ENV == "local":
+        return "http://web:8080/"
+
+    return get_caseworker_site_domain()


### PR DESCRIPTION
Move logic required to get static files domain to pdf/generator.py.