### PR TITLE
ICMSLST-2314 Remove invalid DEFAULT_DOMAIN setting.

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -278,9 +278,6 @@ SESSION_COOKIE_AGE = env.int("DJANGO_SESSION_COOKIE_AGE", default=60 * 30)
 SESSION_COOKIE_SECURE = True
 CSRF_COOKIE_SECURE = True
 
-# Default domain is used in email templates to point users to ICMS from emails
-DEFAULT_DOMAIN = env.str("ICMS_DEFAULT_DOMAIN", default="http://localhost:8080/")
-
 SELECT2_CACHE_BACKEND = "default"
 SELECT2_CSS = os.path.join(STATIC_URL, "3rdparty/select2/select2.min.css")
 SELECT2_JS = os.path.join(STATIC_URL, "3rdparty/select2/select2.min.js")

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -73,4 +73,3 @@ STAFF_SSO_ENABLED = False
 GOV_UK_ONE_LOGIN_ENABLED = False
 LOGIN_URL = "accounts:login"
 LOGOUT_REDIRECT_URL = "accounts:login"  # type: ignore[assignment]
-DEFAULT_DOMAIN = "http://localhost:8080/"

--- a/web/mail/messages.py
+++ b/web/mail/messages.py
@@ -6,6 +6,7 @@ from django.core.mail import EmailMessage, SafeMIMEMultipart
 
 from web.domains.case.types import ImpAccessOrExpAccess, ImpOrExp, ImpOrExpApproval
 from web.models import VariationRequest, WithdrawApplication
+from web.sites import get_caseworker_site_domain
 
 from .constants import EmailTypes
 from .models import EmailTemplate
@@ -31,7 +32,8 @@ class GOVNotifyEmailMessage(EmailMessage):
 
     def get_personalisation(self) -> dict:
         return {
-            "icms_url": settings.DEFAULT_DOMAIN,
+            # TODO: ICMSLST-2313 Revisit this as it will change depending on the email type.
+            "icms_url": get_caseworker_site_domain(),
             "icms_contact_email": settings.ILB_CONTACT_EMAIL,
             "icms_contact_phone": settings.ILB_CONTACT_PHONE,
             "subject": self.subject,

--- a/web/mail/url_helpers.py
+++ b/web/mail/url_helpers.py
@@ -1,15 +1,14 @@
 from urllib.parse import urljoin
 
-from django.conf import settings
 from django.shortcuts import reverse
 from django.templatetags.static import static
 
 from web.domains.case.types import ImpOrExp
-from web.sites import get_caseworker_site_domain
-
-
-def get_full_url(url: str) -> str:
-    return urljoin(settings.DEFAULT_DOMAIN, url)
+from web.sites import (
+    get_caseworker_site_domain,
+    get_exporter_site_domain,
+    get_importer_site_domain,
+)
 
 
 def get_validate_digital_signatures_url(full_url: bool = False) -> str:
@@ -24,11 +23,19 @@ def get_validate_digital_signatures_url(full_url: bool = False) -> str:
 
 def get_case_view_url(application: ImpOrExp, full_url: bool = False) -> str:
     url_kwargs = {"application_pk": application.pk}
+
     if application.is_import_application():
+        # TODO: ICMSLST-2313 Check if we ever need to send this to the caseworker domain
+        domain = get_importer_site_domain()
         url_kwargs["case_type"] = "import"
     else:
+        # TODO: ICMSLST-2313 Check if we ever need to send this to the caseworker domain
+        domain = get_exporter_site_domain()
         url_kwargs["case_type"] = "export"
+
     url = reverse("case:view", kwargs=url_kwargs)
+
     if full_url:
-        return get_full_url(url)
+        return urljoin(domain, url)
+
     return url

--- a/web/notify/utils.py
+++ b/web/notify/utils.py
@@ -7,6 +7,7 @@ from django.template.loader import render_to_string
 from web.domains.case.types import ImpOrExp
 from web.domains.template.utils import get_email_template_subject_body
 from web.models import CaseEmail, Email, File, User
+from web.sites import get_caseworker_site_domain
 from web.utils.s3 import get_file_from_s3, get_s3_client
 
 
@@ -52,7 +53,8 @@ def create_case_email(
 def render_email(template, context):
     """Adds shared variables into context and renders the email"""
     context = context or {}
-    context["url"] = settings.DEFAULT_DOMAIN
+    # TODO: ICMSLST-2313 Revisit (render_email used in 5 places)
+    context["url"] = get_caseworker_site_domain()
     context["contact_email"] = settings.ILB_CONTACT_EMAIL
     context["contact_phone"] = settings.ILB_CONTACT_PHONE
     return render_to_string(template, context)

--- a/web/tests/helpers.py
+++ b/web/tests/helpers.py
@@ -18,6 +18,7 @@ from web.models import (
     User,
     VariationRequest,
 )
+from web.sites import get_caseworker_site_domain
 from web.utils.validation import ApplicationErrors
 
 
@@ -106,7 +107,9 @@ def check_gov_notify_email_was_sent(
 def assert_common_email_personalisation(personalisation: dict, exp_subject: str, exp_in_body: str):
     assert personalisation.pop("icms_contact_email") == settings.ILB_CONTACT_EMAIL
     assert personalisation.pop("icms_contact_phone") == settings.ILB_CONTACT_PHONE
-    assert personalisation.pop("icms_url") == settings.DEFAULT_DOMAIN
+
+    # TODO: ICMSLST-2313 Revisit this as it will change depending on the email type.
+    assert personalisation.pop("icms_url") == get_caseworker_site_domain()
     assert personalisation.pop("subject") == exp_subject
     assert exp_in_body in personalisation.pop("body")
 

--- a/web/tests/mail/test_emails.py
+++ b/web/tests/mail/test_emails.py
@@ -12,6 +12,7 @@ from web.models import (
     VariationRequest,
     WithdrawApplication,
 )
+from web.sites import get_caseworker_site_domain
 from web.tests.auth.auth import AuthTestCase
 from web.tests.helpers import (
     add_approval_request,
@@ -22,7 +23,8 @@ from web.tests.helpers import (
 
 def default_personalisation() -> dict:
     return {
-        "icms_url": settings.DEFAULT_DOMAIN,
+        # TODO: ICMSLST-2313 Revisit this as it will change depending on the email type.
+        "icms_url": get_caseworker_site_domain(),
         "icms_contact_email": settings.ILB_CONTACT_EMAIL,
         "icms_contact_phone": settings.ILB_CONTACT_PHONE,
         "subject": "",

--- a/web/tests/mail/test_url_helpers.py
+++ b/web/tests/mail/test_url_helpers.py
@@ -18,9 +18,9 @@ def test_get_validate_digital_signatures_url(db, full_url, expected_url):
     "application,full_url,expected_url",
     [
         ("completed_cfs_app", False, "/case/export/{pk}/view/"),
-        ("completed_cfs_app", True, "http://localhost:8080/case/export/{pk}/view/"),
+        ("completed_cfs_app", True, "http://export-a-certificate/case/export/{pk}/view/"),
         ("completed_dfl_app", False, "/case/import/{pk}/view/"),
-        ("completed_dfl_app", True, "http://localhost:8080/case/import/{pk}/view/"),
+        ("completed_dfl_app", True, "http://import-a-licence/case/import/{pk}/view/"),
     ],
 )
 def test_get_case_view_url(application, full_url, expected_url, request):


### PR DESCRIPTION
All emails use the caseworker domain by default, this will change in ICMSLST-2313.