### PR TITLE
ICMSLST-2121 Add importer_regulator permission to NCA Case Officer group.

### DIFF
--- a/web/domains/importer/views.py
+++ b/web/domains/importer/views.py
@@ -145,6 +145,7 @@ class ImporterListRegulatorView(ModelFilterView):
     Groups:
       - Home Office Case Officer
       - Constabulary Contact
+      - NCA Case Officer
     """
 
     # PermissionRequiredMixin config
@@ -172,6 +173,7 @@ class ImporterDetailRegulatorView(PermissionRequiredMixin, LoginRequiredMixin, D
     Groups:
       - Home Office Case Officer
       - Constabulary Contact
+      - NCA Case Officer
     """
 
     permission_required = Perms.sys.importer_regulator

--- a/web/management/commands/create_icms_groups.py
+++ b/web/management/commands/create_icms_groups.py
@@ -67,6 +67,7 @@ def get_groups():
         ],
         "NCA Case Officer": [
             # Page permissions
+            Perms.sys.importer_regulator,
             Perms.page.view_import_case_search,
             # Sys permissions
             Perms.sys.search_all_cases,

--- a/web/tests/conftest.py
+++ b/web/tests/conftest.py
@@ -161,6 +161,11 @@ def ho_admin_client(ho_admin_user, caseworker_site) -> Client:
 
 
 @pytest.fixture()
+def constabulary_client(constabulary_contact, caseworker_site) -> Client:
+    return get_test_client(caseworker_site.domain, constabulary_contact)
+
+
+@pytest.fixture()
 def importer_client(importer_one_contact, importer_site) -> Client:
     return get_test_client(importer_site.domain, importer_one_contact)
 

--- a/web/tests/domains/importer/test_views.py
+++ b/web/tests/domains/importer/test_views.py
@@ -101,11 +101,19 @@ class TestImporterListRegulatorView(AuthTestCase):
     url = reverse("regulator-importer-list")
 
     @pytest.fixture(autouse=True)
-    def setup(self, _setup, ho_admin_client):
+    def setup(self, _setup, ho_admin_client, nca_admin_client, constabulary_client):
         self.ho_admin_client = ho_admin_client
+        self.nca_admin_client = nca_admin_client
+        self.constabulary_client = constabulary_client
 
     def test_permission(self):
         response = self.ho_admin_client.get(self.url)
+        assert response.status_code == HTTPStatus.OK
+
+        response = self.nca_admin_client.get(self.url)
+        assert response.status_code == HTTPStatus.OK
+
+        response = self.constabulary_client.get(self.url)
         assert response.status_code == HTTPStatus.OK
 
         response = self.ilb_admin_client.get(self.url)
@@ -130,12 +138,22 @@ class TestImporterListRegulatorView(AuthTestCase):
 
 class TestImporterDetailRegulatorView(AuthTestCase):
     @pytest.fixture(autouse=True)
-    def setup(self, _setup, strict_templates, ho_admin_client):
+    def setup(
+        self, _setup, strict_templates, ho_admin_client, nca_admin_client, constabulary_client
+    ):
         self.ho_admin_client = ho_admin_client
+        self.nca_admin_client = nca_admin_client
+        self.constabulary_client = constabulary_client
         self.url = reverse("regulator-importer-detail", kwargs={"importer_pk": self.importer.id})
 
     def test_permission(self):
         response = self.ho_admin_client.get(self.url)
+        assert response.status_code == HTTPStatus.OK
+
+        response = self.nca_admin_client.get(self.url)
+        assert response.status_code == HTTPStatus.OK
+
+        response = self.constabulary_client.get(self.url)
         assert response.status_code == HTTPStatus.OK
 
         response = self.ilb_admin_client.get(self.url)


### PR DESCRIPTION
ILB confirmed it is useful for NCA Case Offers to be able to search importer records.