### PR TITLE
ICMSLST-1779 Fix RadioSelectInline css to render elements inline.

### DIFF
--- a/web/static/web/css/fox.css
+++ b/web/static/web/css/fox.css
@@ -4967,7 +4967,8 @@ ul.radio-input, ul.radio-input-inline {
 }
 
 /* Display the radios inline */
-ul.radio-input-inline > li {
+ul.radio-input-inline > li,
+div.radio-input-inline > div {
     display: inline;
     padding-right: 0.7em;
 }


### PR DESCRIPTION
The default render changed from Form.as_ul to Form.as_div in django 4.1.