### PR TITLE
ICMSLST-1831 CFS Schedule PDF Translations

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,7 +11,12 @@ omit =
     data_migration/queries/*
     web/end_to_end/*
     web/tests/*
-    web/management/commands/*
+    web/management/commands/utils/*
+    web/management/commands/add_dummy_data.py
+    web/management/commands/add_test_data.py
+    web/management/commands/countries.py
+    web/management/commands/drop_all_tables.py
+    web/management/commands/query_task_result.py
 
 [report]
 exclude_lines =

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -3458,3 +3458,12 @@ Certificate Revoked
 CERTIFICATE_REVOKED
 Application Update Response
 Application Update
+upper}}</h4
+Horario para el
+Certificado de Libre Venta
+Soy la persona
+cumplan con
+Estos
+el mercado
+Unido
+Unido Los

--- a/web/domains/template/utils.py
+++ b/web/domains/template/utils.py
@@ -1,3 +1,4 @@
+import dataclasses
 import re
 from typing import TYPE_CHECKING
 
@@ -7,6 +8,7 @@ from web.models import (
     AccessRequest,
     CertificateOfFreeSaleApplication,
     CFSSchedule,
+    Country,
     EndorsementImportApplication,
     ExportApplication,
     ImportApplication,
@@ -200,56 +202,119 @@ def get_fir_template_data(process: Process, current_user: User) -> tuple[str, st
             )
 
 
-def create_schedule_paragraph(schedule: CFSSchedule) -> str:
-    """Generate the text to appear in a Certificate of Free Sale for a specific schedule"""
+@dataclasses.dataclass
+class ScheduleParagraphs:
+    schedule: CFSSchedule
+    template: Template
+    header: str = dataclasses.field(init=False)
+    introduction: str = dataclasses.field(init=False)
+    paragraph: str = dataclasses.field(init=False)
+    product: str = dataclasses.field(init=False)
 
-    is_ni = schedule.application.exporter_office.postcode.upper().startswith("BT")
-    paragraph_names = CFSScheduleParagraph.ParagraphName
-    context = ScheduleParagraphContext(schedule)
-    paragraphs = []
+    def __post_init__(self) -> None:
+        context = ScheduleParagraphContext(self.schedule, self.template.country_translation_set)
+        names = CFSScheduleParagraph.ParagraphName
+        self.header = self.content(names.SCHEDULE_HEADER, context)
+        self.introduction = self.content(names.SCHEDULE_INTRODUCTION, context)
+        self.create_paragraph(context)
+        self.product = self.content(names.PRODUCTS, context)
 
-    def content(name: str) -> str:
-        paragraph = CFSScheduleParagraph.objects.get(name=name)
+    def content(self, name: str, context: ScheduleParagraphContext) -> str:
+        paragraph = CFSScheduleParagraph.objects.get(name=name, template=self.template)
         return replace_template_values(paragraph.content, context)
 
-    if schedule.exporter_status == schedule.ExporterStatus.IS_MANUFACTURER:
-        paragraphs.append(content(paragraph_names.IS_MANUFACTURER))
-    else:
-        paragraphs.append(content(paragraph_names.IS_NOT_MANUFACTURER))
+    def create_paragraph(self, context: ScheduleParagraphContext) -> None:
+        """Generate the text to appear in a Certificate of Free Sale for a specific schedule"""
 
-    if schedule.schedule_statements_is_responsible_person:
-        if is_ni:
-            paragraphs.append(content(paragraph_names.EU_COSMETICS_RESPONSIBLE_PERSON_NI))
+        is_ni = self.schedule.application.exporter_office.postcode.upper().startswith("BT")
+        paragraphs = []
+        names = CFSScheduleParagraph.ParagraphName
+
+        if self.schedule.exporter_status == self.schedule.ExporterStatus.IS_MANUFACTURER:
+            paragraphs.append(self.content(names.IS_MANUFACTURER, context))
         else:
-            paragraphs.append(content(paragraph_names.EU_COSMETICS_RESPONSIBLE_PERSON))
+            paragraphs.append(self.content(names.IS_NOT_MANUFACTURER, context))
 
-    paragraphs.append(content(paragraph_names.LEGISLATION_STATEMENT))
+        if self.schedule.schedule_statements_is_responsible_person:
+            if is_ni:
+                paragraphs.append(self.content(names.EU_COSMETICS_RESPONSIBLE_PERSON_NI, context))
+            else:
+                paragraphs.append(self.content(names.EU_COSMETICS_RESPONSIBLE_PERSON, context))
 
-    legislations = ", ".join(schedule.legislations.order_by("name").values_list("name", flat=True))
-    paragraphs.append(legislations + ".")
+        paragraphs.append(self.content(names.LEGISLATION_STATEMENT, context))
 
-    if schedule.product_eligibility == schedule.ProductEligibility.SOLD_ON_UK_MARKET:
-        paragraphs.append(content(paragraph_names.ELIGIBILITY_ON_SALE))
-    elif schedule.product_eligibility == schedule.ProductEligibility.MEET_UK_PRODUCT_SAFETY:
-        paragraphs.append(content(paragraph_names.ELIGIBILITY_MAY_BE_SOLD))
+        legislations = ", ".join(
+            self.schedule.legislations.order_by("name").values_list("name", flat=True)
+        )
+        paragraphs.append(legislations + ".")
 
-    if schedule.schedule_statements_accordance_with_standards:
-        if is_ni:
-            paragraphs.append(content(paragraph_names.GOOD_MANUFACTURING_PRACTICE_NI))
+        if self.schedule.product_eligibility == self.schedule.ProductEligibility.SOLD_ON_UK_MARKET:
+            paragraphs.append(self.content(names.ELIGIBILITY_ON_SALE, context))
+        elif (
+            self.schedule.product_eligibility
+            == self.schedule.ProductEligibility.MEET_UK_PRODUCT_SAFETY
+        ):
+            paragraphs.append(self.content(names.ELIGIBILITY_MAY_BE_SOLD, context))
+
+        if self.schedule.schedule_statements_accordance_with_standards:
+            if is_ni:
+                paragraphs.append(self.content(names.GOOD_MANUFACTURING_PRACTICE_NI, context))
+            else:
+                paragraphs.append(self.content(names.GOOD_MANUFACTURING_PRACTICE, context))
+
+        if self.schedule.manufacturer_name and self.schedule.manufacturer_address:
+            paragraphs.append(
+                self.content(names.COUNTRY_OF_MAN_STATEMENT_WITH_NAME_AND_ADDRESS, context)
+            )
+        elif self.schedule.manufacturer_name:
+            paragraphs.append(self.content(names.COUNTRY_OF_MAN_STATEMENT_WITH_NAME, context))
         else:
-            paragraphs.append(content(paragraph_names.GOOD_MANUFACTURING_PRACTICE))
+            paragraphs.append(self.content(names.COUNTRY_OF_MAN_STATEMENT, context))
 
-    if schedule.manufacturer_name and schedule.manufacturer_address:
-        paragraphs.append(content(paragraph_names.COUNTRY_OF_MAN_STATEMENT_WITH_NAME_AND_ADDRESS))
-    elif schedule.manufacturer_name:
-        paragraphs.append(content(paragraph_names.COUNTRY_OF_MAN_STATEMENT_WITH_NAME))
-    else:
-        paragraphs.append(content(paragraph_names.COUNTRY_OF_MAN_STATEMENT))
-
-    return " ".join(paragraphs)
+        self.paragraph = " ".join(paragraphs)
 
 
-def fetch_schedule_paragraphs(application: CertificateOfFreeSaleApplication) -> dict[int, str]:
+@dataclasses.dataclass
+class ScheduleText:
+    schedule: CFSSchedule
+    country: Country
+    english_paragraphs: ScheduleParagraphs = dataclasses.field(init=False)
+    translation_paragraphs: ScheduleParagraphs | None = dataclasses.field(init=False)
+
+    def __post_init__(self) -> None:
+        self.get_english_paragraphs()
+        self.get_translation_paragraphs()
+
+    def get_english_paragraphs(self) -> None:
+        template = Template.objects.get(is_active=True, template_type=Template.CFS_SCHEDULE)
+        self.english_paragraphs = ScheduleParagraphs(self.schedule, template)
+
+    def get_translation_paragraphs(self):
+        try:
+            template = Template.objects.get(
+                is_active=True,
+                template_type=Template.CFS_SCHEDULE_TRANSLATION,
+                countries__pk=self.country.pk,
+            )
+            self.translation_paragraphs = ScheduleParagraphs(self.schedule, template)
+        except Template.DoesNotExist:
+            self.translation_paragraphs = None
+
+
+def fetch_schedule_text(
+    application: CertificateOfFreeSaleApplication, country: Country
+) -> dict[int, ScheduleText]:
     return {
-        schedule.pk: create_schedule_paragraph(schedule) for schedule in application.schedules.all()
+        schedule.pk: ScheduleText(schedule, country) for schedule in application.schedules.all()
     }
+
+
+def fetch_cfs_declaration_translations(country: Country) -> list[str]:
+    templates = Template.objects.filter(
+        is_active=True,
+        template_type=Template.CFS_DECLARATION_TRANSLATION,
+        countries__pk=country.pk,
+        template_content__isnull=False,
+    ).order_by("pk")
+
+    return list(templates.values_list("template_content", flat=True))

--- a/web/management/commands/utils/add_template_data.py
+++ b/web/management/commands/utils/add_template_data.py
@@ -3,13 +3,14 @@ from datetime import datetime
 import pytz
 from django.conf import settings
 
-from web.models import CFSScheduleParagraph, CountryTranslationSet, Template
+from web.models import CFSScheduleParagraph, Country, CountryTranslationSet, Template
 
 
 def add_cfs_schedule_data():
     t = Template.objects.create(
         template_name="CFS Schedule template",
         template_type="CFS_SCHEDULE",
+        template_code="CFS_SCHEDULE",
         application_domain="CA",
     )
 
@@ -109,7 +110,7 @@ def remove_templates():
 
 
 def add_cfs_declaration_templates():
-    Template.objects.get_or_create(
+    spanish, _ = Template.objects.get_or_create(
         start_datetime=pytz.timezone("UTC").localize(
             datetime.strptime("01-MAY-2015 16:23:30", DATETIME_FORMAT), is_dst=None
         ),
@@ -117,8 +118,38 @@ def add_cfs_declaration_templates():
         template_name="Spanish",
         template_type="CFS_DECLARATION_TRANSLATION",
         application_domain="CA",
+        template_content=(
+            "Se certifica por el presente, a los efectos de la legislación de país citado precedentemente, "
+            "que los productos mecionados en el anexo, que forma parte integral de este certificado, se pueden "
+            "vender legalmente en el Reino Unido si satisfacen los requisitos reglamentarios."
+        ),
     )
-    Template.objects.get_or_create(
+    spanish.countries.add(
+        *Country.objects.filter(
+            name__in=[
+                "Algeria",
+                "Argentina",
+                "Bolivia",
+                "Chile",
+                "Colombia",
+                "Costa Rica",
+                "Dominican Republic",
+                "Ecuador",
+                "El Salvador",
+                "Guatemala",
+                "Honduras",
+                "Jamaica",
+                "Mexico",
+                "Nicaragua",
+                "Panama",
+                "Paraguay",
+                "Peru",
+                "Uruguay",
+                "Venezuela",
+            ]
+        )
+    )
+    french, _ = Template.objects.get_or_create(
         start_datetime=pytz.timezone("UTC").localize(
             datetime.strptime("05-MAR-2019 12:27:57", DATETIME_FORMAT), is_dst=None
         ),
@@ -126,8 +157,16 @@ def add_cfs_declaration_templates():
         template_name="French",
         template_type="CFS_DECLARATION_TRANSLATION",
         application_domain="CA",
+        template_content=(
+            "Il est certifié par les présentes, pour l&apos;application des lois du pays susnommé, "
+            "que la vente des préparations mentionnées à l&apos;annexe qui fait partie intégrale de "
+            "ce certificat est légalement permise au Royaume-Uni dans la mesure où les prescriptions "
+            "légales sont satisfaites."
+        ),
     )
-    Template.objects.get_or_create(
+    french.countries.add(*Country.objects.filter(name__in=["Algeria", "Tunisia"]))
+
+    portuguese, _ = Template.objects.get_or_create(
         start_datetime=pytz.timezone("UTC").localize(
             datetime.strptime("24-APR-2015 08:59:21", DATETIME_FORMAT), is_dst=None
         ),
@@ -135,8 +174,15 @@ def add_cfs_declaration_templates():
         template_name="Portuguese",
         template_type="CFS_DECLARATION_TRANSLATION",
         application_domain="CA",
+        template_content=(
+            "Pelo presente documento certifica-se, para os fins das leis do pais acima referido, "
+            "que os preparados designados no anexo, que faz parte integrante do presente certificado, "
+            "podem ser vendidos legalmente no Reino Unido desde que sejam satisfeitos os requisitos regulamentários."
+        ),
     )
-    Template.objects.get_or_create(
+    portuguese.countries.add(*Country.objects.filter(name__in=["Brazil"]))
+
+    russian, _ = Template.objects.get_or_create(
         start_datetime=pytz.timezone("UTC").localize(
             datetime.strptime("23-APR-2015 16:25:35", DATETIME_FORMAT), is_dst=None
         ),
@@ -144,8 +190,15 @@ def add_cfs_declaration_templates():
         template_name="Russian",
         template_type="CFS_DECLARATION_TRANSLATION",
         application_domain="CA",
+        template_content=(
+            "Настоящим удостоверяется для целей законоввышеупомянутой страны, что продукт(ы), указанный "
+            "в списке, которыйявляется частью настоящего сертификата, может на законном основаниипродаваться "
+            "в Соединённом Королевстве при условии удовлетворенияофициальных требований."
+        ),
     )
-    Template.objects.get_or_create(
+    russian.countries.add(*Country.objects.filter(name__in=["Russian Federation"]))
+
+    turkish, _ = Template.objects.get_or_create(
         start_datetime=pytz.timezone("UTC").localize(
             datetime.strptime("24-APR-2015 09:01:34", DATETIME_FORMAT), is_dst=None
         ),
@@ -153,11 +206,17 @@ def add_cfs_declaration_templates():
         template_name="Turkish",
         template_type="CFS_DECLARATION_TRANSLATION",
         application_domain="CA",
+        template_content=(
+            "Bu sertifikanın bir parçası olan Listede gösterilen preparatın, mevzuatın öngördüğü şartlara "
+            "uyduğu takdirde Birleşik Krallıkta yasal olarak satılabileceği yukarıda anılan ülke kanunları "
+            "gereği tasdik olunur."
+        ),
     )
+    turkish.countries.add(*Country.objects.filter(name__in=["Turkey"]))
 
 
 def add_schedule_translation_templates():
-    Template.objects.get_or_create(
+    t, _ = Template.objects.get_or_create(
         start_datetime=pytz.timezone("UTC").localize(
             datetime.strptime("13-FEB-2019 18:56:17", DATETIME_FORMAT), is_dst=None
         ),
@@ -167,6 +226,100 @@ def add_schedule_translation_templates():
         template_type="CFS_SCHEDULE_TRANSLATION",
         application_domain="CA",
         country_translation_set=CountryTranslationSet.objects.get(name="Spanish"),
+    )
+
+    t.countries.add(
+        *Country.objects.filter(
+            name__in=[
+                "Argentina",
+                "Bolivia",
+                "Chile",
+                "Colombia",
+                "Costa Rica",
+                "Dominican Republic",
+                "Ecuador",
+                "El Salvador",
+                "Guatemala",
+                "Honduras",
+                "Jamaica",
+                "Mexico",
+                "Nicaragua",
+                "Panama",
+                "Paraguay",
+                "Peru",
+                "Uruguay",
+                "Venezuela",
+            ]
+        )
+    )
+
+    CFSScheduleParagraph.objects.bulk_create(
+        CFSScheduleParagraph(template=t, **data)
+        for data in [
+            {
+                "order": 1,
+                "name": "SCHEDULE_HEADER",
+                "content": "Horario para el Certificado de Libre Venta",
+            },
+            {
+                "order": 2,
+                "name": "SCHEDULE_INTRODUCTION",
+                "content": "[[EXPORTER_NAME]], de [[EXPORTER_ADDRESS_FLAT]] ha hecho la siguiente declaración legal en relación con los productos enumerados en este cronograma:",
+            },
+            {"order": 3, "name": "IS_MANUFACTURER", "content": "Yo soy el fabricante."},
+            {"order": 4, "name": "IS_NOT_MANUFACTURER", "content": "No soy el fabricante."},
+            {
+                "order": 5,
+                "name": "EU_COSMETICS_RESPONSIBLE_PERSON",
+                "content": "Soy la persona responsable según lo definido por el Reglamento de cosméticos n. ° 1223/2009 según se aplique en GB. Soy la persona responsable de garantizar que los productos enumerados en este programa cumplan con los requisitos de seguridad establecidos en ese Reglamento.",
+            },
+            {
+                "order": 6,
+                "name": "LEGISLATION_STATEMENT",
+                "content": "Certifico que estos productos cumplen con los requisitos de seguridad establecidos en esta legislación:",
+            },
+            {
+                "order": 7,
+                "name": "ELIGIBILITY_ON_SALE",
+                "content": "Estos productos se venden actualmente en el mercado del Reino Unido.",
+            },
+            {
+                "order": 8,
+                "name": "ELIGIBILITY_MAY_BE_SOLD",
+                "content": "Estos productos cumplen con los requisitos de seguridad de los productos para ser vendidos en el mercado del Reino Unido.",
+            },
+            {
+                "order": 9,
+                "name": "GOOD_MANUFACTURING_PRACTICE",
+                "content": "Estos productos se fabrican de acuerdo con las normas de buenas prácticas de fabricación establecidas en las leyes del Reino Unido",
+            },
+            {
+                "order": 10,
+                "name": "COUNTRY_OF_MAN_STATEMENT",
+                "content": "Los productos fueron fabricados en [[COUNTRY_OF_MANUFACTURE]]",
+            },
+            {
+                "order": 11,
+                "name": "COUNTRY_OF_MAN_STATEMENT_WITH_NAME",
+                "content": "Los productos fueron fabricados en [[COUNTRY_OF_MANUFACTURE]] por [[MANUFACTURED_AT_NAME]]",
+            },
+            {
+                "order": 12,
+                "name": "COUNTRY_OF_MAN_STATEMENT_WITH_NAME_AND_ADDRESS",
+                "content": "Los productos fueron fabricados en [[COUNTRY_OF_MANUFACTURE]] por [[MANUFACTURED_AT_NAME]] en [[MANUFACTURED_AT_ADDRESS_FLAT]]",
+            },
+            {"order": 13, "name": "PRODUCTS", "content": "Productos"},
+            {
+                "order": 14,
+                "name": "EU_COSMETICS_RESPONSIBLE_PERSON_NI",
+                "content": "Soy la persona responsable según lo definido por el Reglamento (CE) n. ° 1223/2009 del Parlamento Europeo y del Consejo de 30 de noviembre de 2009 sobre productos cosméticos y el Reglamento sobre cosméticos n. ° 1223/2009 según corresponda en NI. Soy la persona responsable de asegurar que los productos enumerados en este programa cumplan con los requisitos de seguridad establecidos en el Reglamento.",
+            },
+            {
+                "order": 15,
+                "name": "GOOD_MANUFACTURING_PRACTICE_NI",
+                "content": "Estos productos se fabrican de acuerdo con las normas de buenas prácticas de fabricación establecidas en la legislación del Reino Unido o de la UE, cuando corresponda.",
+            },
+        ]
     )
 
 

--- a/web/templates/pdf/export/cfs-certificate.html
+++ b/web/templates/pdf/export/cfs-certificate.html
@@ -20,22 +20,33 @@
     named in the Schedule which forms part of this certificate may lawfully be sold in the United Kingdom
     if it meets the statutory requirements.
   </p>
+  {% for statement_translation in statement_translations %}
+    <p class="statement_translation">{{ statement_translation }}</p>
+  {% endfor %}
 {% endblock %}
 
 {% block schedules %}
   {% for schedule in process.schedules.order_by('created_at') %}
+    {% set english_paragraphs = schedule_text[schedule.pk].english_paragraphs %}
+    {% set translation_paragraphs = schedule_text[schedule.pk].translation_paragraphs %}
     <div class="schedule-block page-margin">
       <p class="schedule-index">Schedule {{ loop.index }} of {{ loop.length }}</p>
-      <h4 class="schedule-header">SCHEDULE TO CERTIFICATE OF FREE SALE</h4>
-      <p>{{ exporter_name }}, of {{ exporter_address }} has made the following legal declaration in relation to the products listed in this schedule:</p>
-      <p>{{ schedule_paragraphs[schedule.pk] }}</p>
-      <h4 class="product-header">PRODUCTS</h4>
+      <h4 class="schedule-header">{{ english_paragraphs.header | upper }}</h4>
+      <p>{{ english_paragraphs.introduction }}</p>
+      <p>{{ english_paragraphs.paragraph }}</p>
+      {% if translation_paragraphs %}
+        <h4>{{ translation_paragraphs.header | upper }}</h4>
+        <p>{{ translation_paragraphs.introduction }}</p>
+        <p>{{ translation_paragraphs.paragraph }}</p>
+        <h4 class="product-header">{{ english_paragraphs.product | upper }} / {{ translation_paragraphs.product | upper }}</h4>
+      {% else %}
+        <h4 class="product-header">{{ english_paragraphs.product | upper }}</h4>
+      {% endif %}
       <div class="products-block">
         {% for product_name in schedule.products.values_list("product_name", flat=True).order_by('pk') %}
           <p class="product-name">{{ product_name }}</p>
         {% endfor %}
       </div>
-    </div>
     </div>
   {% endfor %}
 {% endblock %}

--- a/web/templates/web/domains/case/export/manage/export-prepare-response.html
+++ b/web/templates/web/domains/case/export/manage/export-prepare-response.html
@@ -1,4 +1,5 @@
 {% extends "web/domains/case/manage/prepare-response.html" %}
 
+{% block document_buttons %}{% endblock %}
 {% block licence_section %}{% endblock %}
 {% block endorsements_section %}{% endblock %}

--- a/web/templates/web/domains/case/manage/prepare-response.html
+++ b/web/templates/web/domains/case/manage/prepare-response.html
@@ -6,25 +6,27 @@
 
 {% block main_content %}
   <h3>Response Preparation</h3>
-  {% if process.application_approved and not readonly_view and not variation_refused %}
-    {% if cover_letter_flag %}
+  {% block document_buttons %}
+    {% if process.application_approved and not readonly_view and not variation_refused %}
+      {% if cover_letter_flag %}
+        <a
+          href="{{ icms_url('case:cover-letter-preview', kwargs={'application_pk': process.pk, "case_type": case_type}) }}"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="button">
+          Preview Cover Letter
+        </a>
+      {% endif %}
+
       <a
-        href="{{ icms_url('case:cover-letter-preview', kwargs={'application_pk': process.pk, "case_type": case_type}) }}"
+        href="{{ icms_url('case:licence-preview', kwargs={'application_pk': process.pk, "case_type": case_type}) }}"
         target="_blank"
         rel="noopener noreferrer"
         class="button">
-        Preview Cover Letter
+        Preview Licence
       </a>
     {% endif %}
-
-    <a
-      href="{{ icms_url('case:licence-preview', kwargs={'application_pk': process.pk, "case_type": case_type}) }}"
-      target="_blank"
-      rel="noopener noreferrer"
-      class="button">
-      Preview Licence
-    </a>
-  {% endif %}
+  {% endblock %}
 
   {% if not readonly_view and not readonly_decision %}
     {% call forms.form(action='', method='post', csrf_input=csrf_input) -%}

--- a/web/tests/utils/pdf/test_generator.py
+++ b/web/tests/utils/pdf/test_generator.py
@@ -487,7 +487,8 @@ def test_get_preview_cfs_certificate_context(cfs_app_submitted):
     context = generator.get_document_context()
 
     assert context["preview"] is True
-    assert context["schedule_paragraphs"]
+    assert context["schedule_text"]
+    assert context["statement_translations"] == []
     assert context["exporter_name"] == app.exporter.name.upper()
     assert context["reference"] == "[[CERTIFICATE_REFERENCE]]"
 

--- a/web/utils/pdf/utils.py
+++ b/web/utils/pdf/utils.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import re
+from collections.abc import Collection
 from typing import TYPE_CHECKING, Union
 
 from dateutil.relativedelta import relativedelta
@@ -8,7 +9,9 @@ from django.utils import timezone
 
 from web.domains.case.services import document_pack
 from web.domains.template.utils import (
-    fetch_schedule_paragraphs,
+    ScheduleText,
+    fetch_cfs_declaration_translations,
+    fetch_schedule_text,
     get_cover_letter_content,
     get_letter_fragment,
 )
@@ -45,7 +48,7 @@ if TYPE_CHECKING:
         sil_models.SILGoodsSection582Other,  # /PS-IGNORE
     ]
 
-    Context = dict[str, str | bool | list[str] | ImpOrExp | dict[int, str]]
+    Context = dict[str, str | bool | Collection[str] | ImpOrExp | dict[int, ScheduleText]]
 
 
 def get_licence_context(
@@ -353,10 +356,13 @@ def get_cfs_certificate_context(
 ) -> "Context":
     context = _get_certificate_context(application, certificate, doc_type, country)
 
-    return context | {
-        "schedule_paragraphs": fetch_schedule_paragraphs(application),
+    context |= {
+        "schedule_text": fetch_schedule_text(application, country),
+        "statement_translations": fetch_cfs_declaration_translations(country),
         "page_title": f"Certificate of Free Sale ({country.name}) Preview",
     }
+
+    return context
 
 
 def get_com_certificate_context(


### PR DESCRIPTION
Adding translations to the CFS PDF certificates using the partial implementation that has already been added as well as the data in V1.

CFS_DECLARTION_TRANSLATION templates are used to fetch the translation for the declaration

CFS_SCHEDULE_TRANSLATION templates are used to fetch the paragraphs that are translated within the cfs schedule