### PR TITLE
ICMSLST-1328 Prevent search on all views until search has been pressed.

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -3471,3 +3471,4 @@ Unido Los
 {{ fir.requested_datetime.strftime('%d-%b-%Y %
 fir.request_subject|default('N/A'
 {{ fir.response_datetime.strftime('%d-%b-%Y %
+{{fields.field(filter.form[field]

--- a/web/templates/model/list.html
+++ b/web/templates/model/list.html
@@ -25,9 +25,10 @@
           <div class="three columns"></div>
           <div class="six columns">
             <ul class="menu-out flow-across">
-              <button id="btn-submit-search" type="submit" name="" value="" class="primary-button button">
-                Search
-              </button>
+              <li>
+                <button id="btn-submit-search" type="submit" name="" value="" class="primary-button button">
+                  Search
+                </button>
               </li>
             </ul>
           </div>
@@ -86,7 +87,9 @@
     {% endif %}
 
   {% else %}
-    {{banners.warning(empty_message)}}
+    {% if not initial_page_load %}
+      {{ banners.warning(empty_message) }}
+    {% endif %}
   {% endif %}
 
 <div class=content-actions></div>

--- a/web/tests/domains/commodity/test_views.py
+++ b/web/tests/domains/commodity/test_views.py
@@ -30,13 +30,16 @@ class TestCommodityListView(AuthTestCase):
         assert response.context_data["page_title"] == "Maintain Commodities"
 
     def test_number_of_pages(self):
-        response = self.ilb_admin_client.get(self.url)
+        response = self.ilb_admin_client.get(self.url, {"commodity_code": ""})
         page = response.context_data["page"]
-        assert page.paginator.num_pages == 68
+
+        # Page count has reduced as it is filter excluded commodity codes.
+        assert page.paginator.num_pages == 59
 
     def test_page_results(self):
-        response = self.ilb_admin_client.get(self.url + "?page=2")
+        response = self.ilb_admin_client.get(self.url, {"page": "2", "commodity_code": ""})
         page = response.context_data["page"]
+
         assert len(page.object_list) == 50
 
 

--- a/web/tests/domains/constabulary/test_views.py
+++ b/web/tests/domains/constabulary/test_views.py
@@ -60,16 +60,16 @@ class TestConstabularyListView(AuthTestCase):
     def test_number_of_pages(self):
         # Create 51 product legislation as paging lists 50 items per page
         for i in range(62):
-            ConstabularyFactory()
+            ConstabularyFactory(is_active=True)
 
-        response = self.ilb_admin_client.get(self.url)
+        response = self.ilb_admin_client.get(self.url, {"name": ""})
         page = response.context_data["page"]
         assert page.paginator.num_pages == 2
 
     def test_page_results(self):
         for i in range(65):
             ConstabularyFactory(is_active=True)
-        response = self.ilb_admin_client.get(self.url + "?page=2")
+        response = self.ilb_admin_client.get(self.url, {"page": "2", "name": ""})
         page = response.context_data["page"]
         assert len(page.object_list) == 15
 

--- a/web/tests/domains/firearms/test_views.py
+++ b/web/tests/domains/firearms/test_views.py
@@ -34,7 +34,7 @@ class TestObsoleteCalibreGroupListView(AuthTestCase):
     def test_page_results(self):
         for i in range(58):
             ObsoleteCalibreGroupFactory(is_active=True)
-        response = self.ilb_admin_client.get(self.url)
+        response = self.ilb_admin_client.get(self.url, {"calibre_name": ""})
         results = response.context_data["results"]
         assert len(results) == 59
 

--- a/web/tests/domains/importer/test_views.py
+++ b/web/tests/domains/importer/test_views.py
@@ -63,7 +63,7 @@ class TestImporterListAdminView(AuthTestCase):
         for i in range(58):
             ImporterFactory()
 
-        response = self.ilb_admin_client.get(self.url)
+        response = self.ilb_admin_client.get(self.url, {"name": ""})
         page = response.context_data["page"]
         assert page.paginator.num_pages == 2
 
@@ -71,7 +71,7 @@ class TestImporterListAdminView(AuthTestCase):
         for i in range(50):
             ImporterFactory(is_active=True)
 
-        response = self.ilb_admin_client.get(self.url + "?page=2")
+        response = self.ilb_admin_client.get(self.url, {"page": "2", "name": ""})
         page = response.context_data["page"]
 
         # We have added three to use as a pytest fixture

--- a/web/tests/domains/legislation/test_views.py
+++ b/web/tests/domains/legislation/test_views.py
@@ -29,7 +29,7 @@ class TestProductLegislationListView(AuthTestCase):
         assert response.context_data["page_title"] == "Maintain Product Legislation"
 
     def test_number_of_results(self):
-        response = self.ilb_admin_client.get(self.url)
+        response = self.ilb_admin_client.get(self.url, {"name": ""})
         results = response.context_data["results"]
         assert results.count() == 26
 

--- a/web/tests/domains/mailshot/test_views.py
+++ b/web/tests/domains/mailshot/test_views.py
@@ -38,13 +38,13 @@ class TestMailshotListView(AuthTestCase):
     def test_number_of_pages(self, importer_one_contact):
         MailshotFactory.create_batch(62, created_by=importer_one_contact)
 
-        response = self.ilb_admin_client.get(self.url)
+        response = self.ilb_admin_client.get(self.url, {"reference": ""})
         page = response.context_data["page"]
         assert page.paginator.num_pages == 2
 
     def test_page_results(self, importer_one_contact):
         MailshotFactory.create_batch(65, created_by=importer_one_contact)
-        response = self.ilb_admin_client.get(self.url + "?page=2")
+        response = self.ilb_admin_client.get(self.url, {"page": "2", "reference": ""})
         page = response.context_data["page"]
         assert len(page.object_list) == 15
 

--- a/web/tests/domains/section5/test_views.py
+++ b/web/tests/domains/section5/test_views.py
@@ -8,7 +8,7 @@ from web.tests.domains.section5.factories import Section5ClauseFactory
 def test_list_ok(ilb_admin_user, ilb_admin_client):
     Section5ClauseFactory.create(clause="42aaa", created_by=ilb_admin_user)
 
-    response = ilb_admin_client.get("/section5/")
+    response = ilb_admin_client.get("/section5/", {"description": ""})
 
     assert response.status_code == 200
     assert "42aaa" in response.content.decode()

--- a/web/tests/domains/template/test_views.py
+++ b/web/tests/domains/template/test_views.py
@@ -31,14 +31,14 @@ class TestTemplateListView(AuthTestCase):
     def test_number_of_pages(self):
         TemplateFactory.create_batch(118, is_active=True)
 
-        response = self.ilb_admin_client.get(self.url)
+        response = self.ilb_admin_client.get(self.url, {"template_name": ""})
         page = response.context_data["page"]
         assert page.paginator.num_pages == 5
 
     def test_page_results(self):
         TemplateFactory.create_batch(103, is_active=True)
 
-        response = self.ilb_admin_client.get(self.url + "?page=3")
+        response = self.ilb_admin_client.get(self.url, {"page": "3", "template_name": ""})
         page = response.context_data["page"]
         assert len(page.object_list) == 50
 


### PR DESCRIPTION
All classes that inherit from ModelFilterView no longer perform a search until the search button is pressed.

Admin views updated:
  - Importers
  - Exporters
  - Mailshots
  - Commodities
  - Constabularies
  - Sanction Emails
  - Obsolete Calibres
  - Section 5 Clauses
  - Product legislation
  - Manage Country Groups
  - Templates
  - Web User Accounts