### PR TITLE
ICMSLST-2386 - Fix restarting of import files from v1 cmd

### DIFF
--- a/data_migration/management/commands/_types.py
+++ b/data_migration/management/commands/_types.py
@@ -20,6 +20,7 @@ class QueryModel:
     query_name: str
     model: Model
     parameters: Params = field(default_factory=dict)
+    limit_by_field: str = "secure_lob_ref_id"
 
 
 class SourceTarget(NamedTuple):

--- a/data_migration/management/commands/config/run_order/files.py
+++ b/data_migration/management/commands/config/run_order/files.py
@@ -4,6 +4,7 @@ from data_migration.management.commands._types import M2M, QueryModel, SourceTar
 from web import models as web
 
 DEFAULT_FILE_CREATED_DATETIME = "2013-01-01 01:00:00"
+DEFAULT_SECURE_LOB_REF_ID = 0
 
 file_folder_query_model = [
     QueryModel(
@@ -225,7 +226,7 @@ file_query_model = [
         "SPS Application Files",
         dm.File,
         {
-            "created_datetime": DEFAULT_FILE_CREATED_DATETIME,
+            "secure_lob_ref_id": DEFAULT_SECURE_LOB_REF_ID,
             "ima_type": "SPS",
             "ima_sub_type": "SPS1",
             "path_prefix": "sps_application_files",
@@ -236,7 +237,7 @@ file_query_model = [
         "FA-DFL Application Files",
         dm.File,
         {
-            "created_datetime": DEFAULT_FILE_CREATED_DATETIME,
+            "secure_lob_ref_id": DEFAULT_SECURE_LOB_REF_ID,
             "ima_type": "FA",
             "ima_sub_type": "DEACTIVATED",
             "path_prefix": "dfl_application_files",
@@ -247,7 +248,7 @@ file_query_model = [
         "FA-OIL Application Files",
         dm.File,
         {
-            "created_datetime": DEFAULT_FILE_CREATED_DATETIME,
+            "secure_lob_ref_id": DEFAULT_SECURE_LOB_REF_ID,
             "ima_type": "FA",
             "ima_sub_type": "OIL",
             "path_prefix": "oil_application_files",
@@ -258,7 +259,7 @@ file_query_model = [
         "FA-SIL Application Files",
         dm.File,
         {
-            "created_datetime": DEFAULT_FILE_CREATED_DATETIME,
+            "secure_lob_ref_id": DEFAULT_SECURE_LOB_REF_ID,
             "ima_type": "FA",
             "ima_sub_type": "SIL",
             "path_prefix": "sil_application_files",
@@ -269,7 +270,7 @@ file_query_model = [
         "Sanctions & Adhoc Application Files",
         dm.File,
         {
-            "created_datetime": DEFAULT_FILE_CREATED_DATETIME,
+            "secure_lob_ref_id": DEFAULT_SECURE_LOB_REF_ID,
             "ima_type": "ADHOC",
             "ima_sub_type": "ADHOC1",
             "path_prefix": "sanctions_application_files",
@@ -280,7 +281,7 @@ file_query_model = [
         "OPT Application Files",
         dm.File,
         {
-            "created_datetime": DEFAULT_FILE_CREATED_DATETIME,
+            "secure_lob_ref_id": DEFAULT_SECURE_LOB_REF_ID,
             "ima_type": "OPT",
             "ima_sub_type": "QUOTA",
             "path_prefix": "opt_application_files",
@@ -291,7 +292,7 @@ file_query_model = [
         "Wood Application Files",
         dm.File,
         {
-            "created_datetime": DEFAULT_FILE_CREATED_DATETIME,
+            "secure_lob_ref_id": DEFAULT_SECURE_LOB_REF_ID,
             "ima_type": "WD",
             "ima_sub_type": "QUOTA",
             "path_prefix": "wood_application_files",
@@ -302,7 +303,7 @@ file_query_model = [
         "Textiles Application Files",
         dm.File,
         {
-            "created_datetime": DEFAULT_FILE_CREATED_DATETIME,
+            "secure_lob_ref_id": DEFAULT_SECURE_LOB_REF_ID,
             "ima_type": "TEX",
             "ima_sub_type": "QUOTA",
             "path_prefix": "textiles_application_files",
@@ -312,26 +313,26 @@ file_query_model = [
         queries.fa_certificate_files,
         "Firearms & Ammunition Certificate Files",
         dm.File,
-        {"created_datetime": DEFAULT_FILE_CREATED_DATETIME, "path_prefix": "fa_certificate_files"},
+        {"secure_lob_ref_id": DEFAULT_SECURE_LOB_REF_ID, "path_prefix": "fa_certificate_files"},
     ),
     QueryModel(
         queries.fir_files,
         "Further Information Request Files",
         dm.File,
-        {"created_datetime": DEFAULT_FILE_CREATED_DATETIME, "path_prefix": "fir_files"},
+        {"secure_lob_ref_id": DEFAULT_SECURE_LOB_REF_ID, "path_prefix": "fir_files"},
     ),
     QueryModel(
         queries.mailshot_files,
         "Mailshot Files",
         dm.File,
-        {"created_datetime": DEFAULT_FILE_CREATED_DATETIME, "path_prefix": "mailshot_files"},
+        {"secure_lob_ref_id": DEFAULT_SECURE_LOB_REF_ID, "path_prefix": "mailshot_files"},
     ),
     QueryModel(
         queries.file_objects_folder_type,
         "GMP Application Files",
         dm.File,
         {
-            "created_datetime": DEFAULT_FILE_CREATED_DATETIME,
+            "secure_lob_ref_id": DEFAULT_SECURE_LOB_REF_ID,
             "folder_type": "GMP_SUPPORTING_DOCUMENTS",
             "path_prefix": "gmp_application_files",
         },
@@ -341,7 +342,7 @@ file_query_model = [
         "Import Application Case Note Files",
         dm.File,
         {
-            "created_datetime": DEFAULT_FILE_CREATED_DATETIME,
+            "secure_lob_ref_id": DEFAULT_SECURE_LOB_REF_ID,
             "folder_type": "IMP_CASE_NOTE_DOCUMENTS",
             "path_prefix": "import_application_case_note_files",
         },
@@ -350,25 +351,26 @@ file_query_model = [
         queries.export_case_note_docs,
         "Export Application Case Note Documents",
         dm.File,
-        {"created_datetime": DEFAULT_FILE_CREATED_DATETIME},
+        {"secure_lob_ref_id": DEFAULT_SECURE_LOB_REF_ID},
     ),
     QueryModel(
         queries.fa_supplementary_report_upload_files,
         "Supplementary Report Goods Uploaded Files",
         dm.File,
         {"created_datetime": DEFAULT_FILE_CREATED_DATETIME},
+        "created_datetime",
     ),
     QueryModel(
         queries.ia_licence_docs,
         "Import Application Licence Documents",
         dm.CaseDocument,
-        {"created_datetime": DEFAULT_FILE_CREATED_DATETIME},
+        {"secure_lob_ref_id": DEFAULT_SECURE_LOB_REF_ID},
     ),
     QueryModel(
         queries.export_certificate_docs,
         "Export Application Certificate Documents",
         dm.ExportCertificateCaseDocumentReferenceData,
-        {"created_datetime": DEFAULT_FILE_CREATED_DATETIME},
+        {"secure_lob_ref_id": DEFAULT_SECURE_LOB_REF_ID},
     ),
 ]
 

--- a/data_migration/queries/export_application/export.py
+++ b/data_migration/queries/export_application/export.py
@@ -68,14 +68,15 @@ SELECT
   , dd.created_datetime
   , created_by_wua_id created_by_id
   , sld.blob_data
+  , sld.id AS secure_lob_ref_id
 FROM impmgr.certificate_app_responses car
   INNER JOIN impmgr.cert_app_response_details card ON card.car_id = car.id
   INNER JOIN impmgr.cert_app_response_detail_certs cardc ON cardc.card_id = card.id
   INNER JOIN decmgr.xview_document_data xdd ON xdd.di_id = cardc.document_instance_id AND xdd.system_document = 'N' AND xdd.content_description = 'PDF'
   INNER JOIN decmgr.document_data dd ON dd.id = xdd.dd_id
   INNER JOIN securemgr.secure_lob_data sld ON sld.id = DEREF(dd.secure_lob_ref).id
-WHERE dd.created_datetime > TO_DATE(:created_datetime, 'YYYY-MM-DD HH24:MI:SS')
-ORDER BY cardc.id
+WHERE sld.id > :secure_lob_ref_id
+ORDER BY sld.id
 """
 
 export_document_pack_acknowledged = """

--- a/data_migration/queries/import_application/licence.py
+++ b/data_migration/queries/import_application/licence.py
@@ -54,6 +54,7 @@ SELECT
   , dd.created_by created_by_str
   , wl.wua_id created_by_id
   , sld.blob_data
+  , sld.id AS secure_lob_ref_id
 FROM impmgr.ima_responses ir
   INNER JOIN impmgr.ima_response_details ird ON ird.ir_id = ir.id
   INNER JOIN impmgr.xview_ima_details xiad ON xiad.imad_id = ird.imad_id
@@ -68,7 +69,7 @@ FROM impmgr.ima_responses ir
     GROUP BY wua_id, login_id
   ) wl ON wl.login_id = REGEXP_SUBSTR(dd.created_by, '\((.+)\)', 1, 1, NULL, 1)
 WHERE (ir.response_type LIKE '%_LICENCE' OR ir.response_type LIKE '%_COVER')
-  AND dd.created_datetime > TO_DATE(:created_datetime, 'YYYY-MM-DD HH24:MI:SS')
+  AND sld.id > :secure_lob_ref_id
 ORDER BY sld.id
 """
 

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -3472,3 +3472,8 @@ Unido Los
 fir.request_subject|default('N/A'
 {{ fir.response_datetime.strftime('%d-%b-%Y %
 {{fields.field(filter.form[field]
+SECURE_LOB_REF_ID
+col1
+sld.id AS secure_lob_ref_id FROM
+case_ref
+sld.id AS secure_lob_ref_id


### PR DESCRIPTION
Fixed the following:
 - Missing query parameters after script restart
 - Duplicate files (associated to none complete applications) no longer processed
 - Support for alternative `limit by field` added (`secure_lob_ref_id` now default)
 - Sql order bys updated to use `secure_lob_ref_id` where possible
 - Files with the same date time as the last file processed are now processed