### PR TITLE
ICMSLST-2349 - Rate limit and retry for mail task

### DIFF
--- a/.env.circleci
+++ b/.env.circleci
@@ -25,6 +25,9 @@ GOV_UK_ONE_LOGIN_OPENID_CONFIG_URL='' # Value in Vault
 GOV_NOTIFY_API_KEY=''
 #EMAIL_BACKEND='web.mail.backends.GovNotifyEmailBackend' # For gov notify backend
 EMAIL_BACKEND='django.core.mail.backends.console.EmailBackend' # For console backend
+MAIL_TASK_RATE_LIMIT='1000/m'
+MAIL_TASK_RETRY_JITTER=True
+MAIL_TASK_MAX_RETRIES=5
 SEND_ALL_EMAILS_TO='[]'
 
 # Email/phone contacts

--- a/.env.local-docker
+++ b/.env.local-docker
@@ -26,6 +26,9 @@ GOV_NOTIFY_API_KEY=''
 #EMAIL_BACKEND='web.mail.backends.GovNotifyEmailBackend' # For gov notify backend
 EMAIL_BACKEND='django.core.mail.backends.console.EmailBackend' # For console backend
 SEND_ALL_EMAILS_TO='[]'
+MAIL_TASK_RATE_LIMIT='1000/m'
+MAIL_TASK_RETRY_JITTER=True
+MAIL_TASK_MAX_RETRIES=5
 
 # Email/phone contacts
 ICMS_EMAIL_FROM='enquiries.ilb@icms.trade.dev.uktrade.io'  # /PS-IGNORE

--- a/config/env.py
+++ b/config/env.py
@@ -75,6 +75,9 @@ class Environment(BaseSettings):
     # GOV.UK Notify to send/receive emails (which are implemented using gov notify)
     gov_notify_api_key: str
     email_backend: str
+    mail_task_rate_limit: str
+    mail_task_retry_jitter: bool
+    mail_task_max_retries: int
     # Your email address (used to test GOV.UK Notify)
     # Need to have registered with GOV Notify and have been invited to the ICMS project
     send_all_emails_to: list[str]

--- a/config/settings.py
+++ b/config/settings.py
@@ -175,6 +175,10 @@ if GOV_UK_ONE_LOGIN_ENABLED:
 GOV_NOTIFY_API_KEY = env.gov_notify_api_key
 EMAIL_BACKEND = env.email_backend
 
+MAIL_TASK_RATE_LIMIT = env.mail_task_rate_limit
+MAIL_TASK_RETRY_JITTER = env.mail_task_retry_jitter
+MAIL_TASK_MAX_RETRIES = env.mail_task_max_retries
+
 # Same logic here: icms/web/mail/decorators.py
 if APP_ENV in ("local", "dev", "staging"):
     SEND_ALL_EMAILS_TO = env.send_all_emails_to
@@ -269,6 +273,7 @@ CELERY_ACCEPT_CONTENT = ["application/json"]
 CELERY_RESULT_SERIALIZER = "json"
 CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_EXTENDED = True
+
 
 # Django cache with Redis
 CACHES = {

--- a/config/settings_test.py
+++ b/config/settings_test.py
@@ -55,3 +55,7 @@ STAFF_SSO_ENABLED = False
 GOV_UK_ONE_LOGIN_ENABLED = False
 LOGIN_URL = "accounts:login"
 LOGOUT_REDIRECT_URL = "accounts:login"  # type: ignore[assignment]
+
+MAIL_TASK_RATE_LIMIT = "1/m"
+MAIL_TASK_RETRY_JITTER = True
+MAIL_TASK_MAX_RETRIES = 5

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -3521,3 +3521,5 @@ div aria-labelledby="agents-current
 aria-labelledby="tg-agentsARCHIVED
 assert template.user_can_edit(bob
 template.form_data
+MAIL_TASK_RATE_LIMIT='1000/m'
+MAIL_TASK_MAX_RETRIES=5

--- a/web/mail/api.py
+++ b/web/mail/api.py
@@ -1,12 +1,40 @@
 from uuid import UUID
 
+from celery.app.task import Task
 from django.conf import settings
 from notifications_python_client import NotificationsAPIClient
 from notifications_python_client.errors import HTTPError
 
 from config.celery import app
+from web.utils.sentry import capture_exception
 
 from .constants import CELERY_MAIL_QUEUE_NAME, SEND_EMAIL_TASK_NAME
+
+
+class SendEmailTask(Task):
+    """
+    GOV NOTIFY LIMITS
+
+    3000 Messages per minute
+    250,000 emails per day
+
+    rate_limit = "1000/m"
+
+    Prioritises new sends over retries
+    """
+
+    autoretry_for = [HTTPError]
+    max_retries = settings.MAIL_TASK_MAX_RETRIES
+    retry_backoff = 10
+    retry_jitter = settings.MAIL_TASK_RETRY_JITTER
+    rate_limit = settings.MAIL_TASK_RATE_LIMIT
+
+    def retry(self, *args, **kwargs):
+        try:
+            super().retry(*args, **kwargs)
+        except HTTPError as e:
+            capture_exception()
+            raise e
 
 
 def get_gov_notify_client() -> NotificationsAPIClient:
@@ -31,7 +59,7 @@ def is_valid_template_id(template_id: UUID) -> bool:
     return gov_notify_template_id == template_id
 
 
-@app.task(name=SEND_EMAIL_TASK_NAME, queue=CELERY_MAIL_QUEUE_NAME)
+@app.task(base=SendEmailTask, name=SEND_EMAIL_TASK_NAME, queue=CELERY_MAIL_QUEUE_NAME)
 def send_email(template_id: UUID, personalisation: dict, email_address: str) -> dict:
     client = get_gov_notify_client()
     return client.send_email_notification(

--- a/web/mail/backends.py
+++ b/web/mail/backends.py
@@ -17,4 +17,4 @@ class GovNotifyEmailBackend(BaseEmailBackend):
                 self._send_message(message.template_id, message.get_personalisation(), recipient)
 
     def _send_message(self, template_id: UUID, personalisation: dict, recipient: str) -> None:
-        send_email.delay(template_id, personalisation, recipient)
+        send_email.apply_async(args=[template_id, personalisation, recipient])


### PR DESCRIPTION
- Retries any HTTPError thrown by the send email task.
- The retry parameters are settings so these can be tweaked on each platform if necessary.
- The rate limit seems to only affect the mail queue although it does seem to be a limit per worker which needs to be taken in to consideration when setting the value.
- The default rate limit is 1000/m. Making an assumption that we have a max of 2 workers
- If maximum retries are exceeded the exception is logged to sentry. The information in sentry is sufficient to determine which task id failed and what email type was being processed.
- By default retry jitter is set to true which will incorporate an exponential back off resulting in tasks not being retried all at the same time.
- Note if testing with low rate limits `CELERYD_PREFETCH_MULTIPLIER` will need to be set as this is set to 4 by default which can result in unexpected behaviour


