### PR TITLE
ICMSLST-1935 Add postcode form validation to importer office views.

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -3492,3 +3492,4 @@ confirm_email_before_download
 CONSTABULARY_DEACTIVATED_FIREARMS
 Constabulary Deactivated Firearms
 web.mail.emails.send_constabulary_deactivated_firearms_email
+r"^[A-Z]{1,2}[0-9][A-Z0-9

--- a/web/domains/chief/serializers.py
+++ b/web/domains/chief/serializers.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, Literal, Protocol
 
 from web.domains.case.services import document_pack
 from web.flow.models import ProcessTypes
+from web.forms.utils import clean_postcode
 from web.utils.commodity import annotate_commodity_unit
 
 from . import types
@@ -305,7 +306,7 @@ def _get_organisation(application: "ImportApplication") -> types.OrganisationDat
         address=types.AddressData(
             # max address lines is 5
             **address_lines,
-            postcode=office.postcode,
+            postcode=clean_postcode(office.postcode),
         ),
         start_date=None,
         end_date=None,

--- a/web/domains/exporter/forms.py
+++ b/web/domains/exporter/forms.py
@@ -6,6 +6,7 @@ from django_filters import CharFilter, ChoiceFilter, FilterSet
 from guardian.forms import UserObjectPermissionsForm
 
 from web.errors import APIError
+from web.forms.utils import clean_postcode
 from web.permissions import ExporterObjectPermissions, Perms
 from web.utils.companieshouse import api_get_company
 
@@ -62,6 +63,9 @@ class ExporterForm(forms.ModelForm):
             address_line_2 = office_address.get("address_line_2")
             locality = office_address.get("locality")
             postcode = office_address.get("postal_code")
+
+            if postcode:
+                postcode = clean_postcode(postcode)
 
             if address_line_1 and postcode:
                 instance.offices.get_or_create(

--- a/web/domains/importer/forms.py
+++ b/web/domains/importer/forms.py
@@ -8,6 +8,7 @@ from guardian.forms import UserObjectPermissionsForm
 
 from web.domains.importer.fields import PersonWidget
 from web.errors import APIError
+from web.forms.utils import clean_postcode
 from web.forms.widgets import CheckboxSelectMultiple
 from web.models import Importer, Section5Authority
 from web.models.shared import ArchiveReasonChoices
@@ -97,6 +98,9 @@ class ImporterOrganisationForm(forms.ModelForm):
             address_line_2 = office_address.get("address_line_2")
             locality = office_address.get("locality")
             postcode = office_address.get("postal_code")
+
+            if postcode:
+                postcode = clean_postcode(postcode)
 
             if address_line_1 and postcode:
                 instance.offices.get_or_create(

--- a/web/domains/office/forms.py
+++ b/web/domains/office/forms.py
@@ -1,9 +1,13 @@
 from django import forms
 
+from web.forms.fields import UKPostcodeField
 from web.models import Office
 
 
 class ImporterOfficeEORIForm(forms.ModelForm):
+    # Importer postcode sent to CHIEF/CDS must be valid
+    postcode = UKPostcodeField(required=True)
+
     class Meta:
         model = Office
         fields = [
@@ -18,6 +22,9 @@ class ImporterOfficeEORIForm(forms.ModelForm):
 
 
 class ImporterOfficeForm(forms.ModelForm):
+    # Importer postcode sent to CHIEF/CDS must be valid
+    postcode = UKPostcodeField(required=True)
+
     class Meta:
         model = Office
         fields = ["address_1", "address_2", "address_3", "address_4", "address_5", "postcode"]

--- a/web/forms/fields.py
+++ b/web/forms/fields.py
@@ -1,9 +1,11 @@
 import re
+from typing import Any
 
 import phonenumber_field.formfields
 from django import forms
 from phonenumber_field.widgets import PhoneNumberInternationalFallbackWidget
 
+from .utils import clean_postcode
 from .widgets import DateInput
 
 
@@ -24,6 +26,26 @@ class PhoneNumberField(phonenumber_field.formfields.PhoneNumberField):
     FORMAT: +CC STD NUMBER<br>Norway: +47 123 4568900\n\
     Spain: +34 911 12345678\n\
     America: +1 123 4568900"
+
+
+class UKPostcodeField(forms.RegexField):
+    # https://en.wikipedia.org/wiki/Postcodes_in_the_United_Kingdom#Validation
+    UK_POSTCODE_REGEX = r"^[A-Z]{1,2}[0-9][A-Z0-9]? ?[0-9][A-Z]{2}$"
+
+    def __init__(self, regex=UK_POSTCODE_REGEX, **kwargs):
+        kwargs.setdefault("required", True)
+        kwargs.setdefault("label", "Postcode")
+        kwargs.setdefault("error_messages", {"invalid": "Please enter a valid postcode"})
+
+        super().__init__(regex, **kwargs)
+
+    def to_python(self, value: Any) -> str:
+        postcode: str = super().to_python(value)
+
+        if postcode not in self.empty_values:
+            postcode = clean_postcode(postcode)
+
+        return postcode
 
 
 class WildcardField(forms.RegexField):

--- a/web/forms/utils.py
+++ b/web/forms/utils.py
@@ -1,10 +1,8 @@
-import json
+import re
 
-import structlog as logging
-from django.core.serializers.json import DjangoJSONEncoder
-from django.forms.formsets import BaseFormSet
 
-logger = logging.getLogger(__name__)
+def clean_postcode(postcode: str) -> str:
+    return re.sub(r"\s+", "", postcode).upper()
 
 
 def forms_valid(forms):
@@ -21,32 +19,3 @@ def save_forms(forms):
     """
     for key, form in forms.items():
         form.save()
-
-
-def add_to_session(request, key, value):
-    logger.debug('Adding "%s" to session:\n%s', key, value)
-    request.session[key] = json.dumps(value, cls=DjangoJSONEncoder)
-
-
-def save_forms_to_session(request, forms):
-    """
-    Saves forms given as dict object to session using dictionary keys as keys
-    """
-    for key, form in forms.items():
-        if not isinstance(form, BaseFormSet):
-            add_to_session(request, key, form.data)
-        else:  # Formset
-            forms_data = []
-            for f in form.forms:
-                forms_data.append(f.data)
-            add_to_session(request, key, forms_data)
-
-
-def remove_from_session(request, key):
-    logger.debug('Removing "%s" from session', key)
-    if request.method == "POST":
-        data = request.session.pop(key)
-        if data:
-            return json.loads(data)
-
-    return {}

--- a/web/tests/domains/importer/test_views.py
+++ b/web/tests/domains/importer/test_views.py
@@ -633,6 +633,27 @@ class TestCreateOfficeView(AuthTestCase):
 
         assert self.importer.offices.count() == 2
 
+    def test_post_cleans_postcode(self):
+        assert self.importer.offices.count() == 1
+        data = {
+            "address_1": "Address line 1",
+            "address_2": "Address line 2",
+            "address_3": "Address line 3",
+            "address_4": "Address line 4",
+            "address_5": "Address line 5",
+            "postcode": "s1 2ss",  # /PS-IGNORE
+            "eori_number": "GB0123456789ABCDE",
+        }
+
+        response = self.ilb_admin_client.post(self.url, data=data)
+        assert response.status_code == HTTPStatus.FOUND
+
+        assert self.importer.offices.count() == 2
+
+        latest = self.importer.offices.last()
+        # test space stripped and upper case.
+        assert latest.postcode == "S12SS"  # /PS-IGNORE
+
 
 class TestEditOfficeView(AuthTestCase):
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
CHIEF/CDS requires trader postcodes to be valid and will error if not. Add form validation to reduce the number of errors raised in this way.