### PR TITLE
Allowing non-docker setup, optimising pre-commit hooks, celery debugging.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,4 @@ output_documents/
 
 # Added by pyenv after setting a local python version on mac
 .python-version
+/local.env

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,21 +30,15 @@ repos:
         # The end_to_end directory runs under python 3.8 and isn't suitable for pyupgrade
         exclude: end_to_end
 -   repo: https://github.com/psf/black
-    rev: 23.11.0
+    rev: 23.12.1
     hooks:
     -   id: black
 -   repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
     -   id: flake8
 -   repo: https://github.com/pycqa/isort
-    rev: 5.13.0
+    rev: 5.13.2
     hooks:
       - id: isort
         name: isort
-- repo: local
-  hooks:
-    - id: check-django-migrations
-      name: django-migrations
-      entry: make check_migrations
-      language: system

--- a/config/env.py
+++ b/config/env.py
@@ -143,10 +143,22 @@ class Environment(BaseSettings):
     sentry_dsn: str = ""
     sentry_environment: str = ""
 
-    #
     # Cloud Foundry Environment Variables
     vcap_services: VCAPServices | None = None
     vcap_application: VCAPApplication | None = None
+
+    # Redis settings
+    local_redis_url: str = "redis://redis:6379"
+
+    # S3 endpoint URL
+    local_aws_s3_endpoint_url: str = "http://localstack:4566/"
+
+    # celery settings
+    celery_task_always_eager: bool = False
+    celery_eager_propagates_exceptions: bool = False
+
+    # local site URL management
+    local_site_url: str = "http://web:8080/"
 
 
 env: Environment = Environment()  # type:ignore[call-arg]

--- a/config/settings.py
+++ b/config/settings.py
@@ -264,7 +264,7 @@ if env.vcap_services:
     CELERY_BROKER_USE_SSL = {"ssl_cert_reqs": ssl.CERT_REQUIRED}
 
 else:
-    REDIS_URL = "redis://redis:6379"
+    REDIS_URL = env.local_redis_url
 
 CELERY_BROKER_URL = REDIS_URL
 CELERY_RESULT_BACKEND = "django-db"
@@ -456,3 +456,6 @@ else:
     # Used in tests to override the TEMPLATES setting.
     STRICT_TEMPLATES = copy.deepcopy(TEMPLATES)
     STRICT_TEMPLATES[0]["OPTIONS"].update({"undefined": jinja2.StrictUndefined})  # type: ignore[attr-defined]
+
+# Local site URL management
+LOCAL_SITE_URL = env.local_site_url

--- a/config/settings_local.py
+++ b/config/settings_local.py
@@ -8,7 +8,7 @@ AWS_REGION = "eu-west-2"
 AWS_ACCESS_KEY_ID = "test"
 AWS_SECRET_ACCESS_KEY = "test"
 AWS_STORAGE_BUCKET_NAME = "icms.local"
-AWS_S3_ENDPOINT_URL = "http://localstack:4566/"
+AWS_S3_ENDPOINT_URL = env.local_aws_s3_endpoint_url
 
 # Debug toolbar config
 INTERNAL_IPS = ("127.0.0.1", "localhost")
@@ -26,7 +26,6 @@ SHOW_DB_QUERIES = env.show_db_queries
 
 if SHOW_DB_QUERIES:
     MIDDLEWARE += ["web.middleware.common.DBQueriesMiddleware"]
-
 
 DEBUG_TOOLBAR_PANELS = [
     "debug_toolbar.panels.versions.VersionsPanel",
@@ -107,3 +106,8 @@ LOGGING = {
 
 # django-ratelimit
 RATELIMIT_ENABLE = False
+
+# celery settings
+# sometimes we want to run celery tasks synchronously to help with debugging
+CELERY_TASK_ALWAYS_EAGER = env.celery_task_always_eager
+CELERY_EAGER_PROPAGATES_EXCEPTIONS = env.celery_eager_propagates_exceptions

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,7 +24,7 @@ requests-mock==1.10.0
 sqlparse==0.4.4
 pipdeptree
 pip-check
-pre-commit==3.5.0
+pre-commit==3.6.0
 boto3-stubs[essential]
 types-openpyxl==3.1.0.0
 types-pytz==2023.3

--- a/web/utils/pdf/generator.py
+++ b/web/utils/pdf/generator.py
@@ -208,6 +208,6 @@ def get_icms_domain() -> str:
 
     # Need to use the local docker-compose network name to access the static files.
     if settings.APP_ENV == "local":
-        return "http://web:8080/"
+        return settings.LOCAL_SITE_URL
 
     return get_caseworker_site_domain()


### PR DESCRIPTION
updating pre-commit hooks

adding REDIS_URL to .env to support non-docker setups

adding local.env to .gitignore

formatting .pre-commit-config.yaml

adding celery always_eagier and making s3_endpoint url compatible outside of docker.

updating pre-commit package to deal with black changes