### PR TITLE
ICMSLST-1259 - Disabling single-choice dropdowns

### DIFF
--- a/web/domains/case/_import/fa_oil/forms.py
+++ b/web/domains/case/_import/fa_oil/forms.py
@@ -32,12 +32,19 @@ class FirearmOILFormBase(forms.ModelForm):
         super().__init__(*args, **kwargs)
 
         self.fields["contact"].queryset = application_contacts(self.instance)
+
         self.fields["origin_country"].empty_label = None
         self.fields["consignment_country"].empty_label = None
 
         countries = Country.objects.filter(name="Any Country", is_active=True)
         self.fields["origin_country"].queryset = countries
         self.fields["consignment_country"].queryset = countries
+
+        self.fields["origin_country"].disabled = True
+        self.fields["consignment_country"].disabled = True
+
+        self.fields["origin_country"].help_text = None
+        self.fields["consignment_country"].help_text = None
 
 
 class EditFaOILForm(OptionalFormMixin, FirearmOILFormBase):


### PR DESCRIPTION
Changing origin_country and consignment_country on the OIL form to disabled as there is only one option in the dropdown anyway, also removing help_text as it's redundant for the same reason.

Initially I changed the actual field type to a `CharInput` with a corresponding `TextInput` widget however it requires some unnecessary code to convert the PK value into an actual Country object which the back-end requires. This is essentially just a duplicate of the MultipleSelectField, so the decision was made to keep it to the latter so we can rely on Django's built-in logic rather than create our own for this CharInput.