### PR TITLE
ICMSLST-1259 - Locking dropdowns with only 1 option

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -3572,5 +3572,6 @@ Active Dummy Signature
 document.cookie
 {{ calibre.name
 Search Addresses{% endblock %
+in_progress
 delete-fir'
 novalidate

--- a/web/tests/conftest.py
+++ b/web/tests/conftest.py
@@ -537,6 +537,20 @@ def fa_oil_app_submitted(
 
 
 @pytest.fixture()
+def fa_oil_app_in_progress(
+    importer_client, importer, office, importer_one_contact
+) -> OpenIndividualLicenceApplication:
+    """A valid FA OIL application in the in_progress state."""
+
+    app = create_in_progress_fa_oil_app(importer_client, importer, office, importer_one_contact)
+
+    case_progress.check_expected_status(app, [ImpExpStatus.IN_PROGRESS])
+    case_progress.check_expected_task(app, Task.TaskType.PREPARE)
+
+    return app
+
+
+@pytest.fixture()
 def fa_sil_app_in_progress(
     importer_client, importer, office, importer_one_contact
 ) -> SILApplication:

--- a/web/tests/domains/case/_import/fa_oil/test_forms.py
+++ b/web/tests/domains/case/_import/fa_oil/test_forms.py
@@ -1,0 +1,53 @@
+import pytest
+
+from web.domains.case._import.fa_oil.forms import EditFaOILForm
+from web.models import Country
+from web.models.shared import FirearmCommodity
+from web.tests.auth import AuthTestCase
+
+
+class TestOILForm(AuthTestCase):
+    @pytest.fixture(autouse=True)
+    def setup(self, _setup, fa_oil_app_in_progress):
+        self.process = fa_oil_app_in_progress
+        self.all_countries_object = Country.objects.get(name="Any Country")
+
+    def get_form(self, extra_data=None):
+        data = {
+            "contact": self.importer_user,
+            "origin_country": self.all_countries_object,
+            "consignment_country": self.all_countries_object,
+            "exporter_name": None,
+            "exporter_address": None,
+            "commodity_code": FirearmCommodity.EX_CHAPTER_93,
+        }
+        if extra_data:
+            data.update(extra_data)
+
+        return EditFaOILForm(data, instance=self.process, initial={"contact": self.importer_user})
+
+    def test_form_valid(self):
+        form = self.get_form()
+        assert form.is_valid()
+
+    def test_form_country_disabled(self):
+        """Tests that the origin_country and consignment_country fields are disabled."""
+        form = self.get_form()
+        assert form.fields["origin_country"].disabled
+        assert form.fields["consignment_country"].disabled
+
+    def test_form_country_cleaned(self):
+        """Tests that the origin_country and consignment_country fields are cleaned and return the correct object."""
+        form = self.get_form()
+        assert form.is_valid()
+        assert form.cleaned_data["origin_country"] == self.all_countries_object
+        assert form.cleaned_data["consignment_country"] == self.all_countries_object
+
+    def test_form_country_queryset(self):
+        """Tests that the origin_country and consignment_country fields have the correct queryset."""
+        form = self.get_form()
+        assert form.fields["origin_country"].queryset.count() == 1
+        assert form.fields["origin_country"].queryset.get() == self.all_countries_object
+
+        assert form.fields["consignment_country"].queryset.count() == 1
+        assert form.fields["consignment_country"].queryset.get() == self.all_countries_object


### PR DESCRIPTION
Disabling country dropdowns in the OIL form that only have 1 possible options - "Any Country"