### PR TITLE
Remove "user-provided" key from VCAPServices environment variable.

### DIFF
--- a/config/env.py
+++ b/config/env.py
@@ -18,7 +18,6 @@ class VCAPServices(BaseModel):
 
     postgres: list[dict[str, Any]]
     redis: list[dict[str, Any]]
-    user_provided: list[dict[str, Any]] = Field(alias="user-provided")
     aws_s3_bucket: list[dict[str, Any]] = Field(alias="aws-s3-bucket")
 
 


### PR DESCRIPTION
Model is configured to ignore extra attributes and the user-provided key only appears in the dev and staging environments.