### PR TITLE
Data Migration - Fix Licence Unique Reference Migration

### DIFF
--- a/data_migration/management/commands/config/run_order/import_application.py
+++ b/data_migration/management/commands/config/run_order/import_application.py
@@ -5,6 +5,7 @@ from data_migration.utils import xml_parser
 from web import models as web
 
 ia_query_model = [
+    QueryModel(queries.ia_licence_doc_refs, "Import Licence Doc References", dm.UniqueReference),
     QueryModel(queries.sps_application, "sps_application", dm.PriorSurveillanceApplication),
     QueryModel(
         queries.derogations_application, "derogations_application", dm.DerogationsApplication

--- a/data_migration/models/case.py
+++ b/data_migration/models/case.py
@@ -36,7 +36,7 @@ class CaseDocument(MigrationBase):
 
     @classmethod
     def models_to_populate(cls) -> list[str]:
-        return ["File", "UniqueReference", cls.__name__]
+        return ["File", cls.__name__]
 
     @classmethod
     def get_excludes(cls) -> list[str]:

--- a/data_migration/queries/import_application/derogations.py
+++ b/data_migration/queries/import_application/derogations.py
@@ -49,7 +49,7 @@ SELECT
   , xiad.variation_decision
   , xiad.variation_refuse_reason
   , xiad.licence_extended licence_extended_flag
-  , 'ILD' || ir.licence_ref licence_uref_id
+  , CASE WHEN ir.licence_ref IS NULL THEN NULL ELSE 'ILD' || ir.licence_ref END licence_uref_id
   , xiad.last_updated_datetime last_update_datetime
   , xiad.submitted_by_wua_id submitted_by_id
   , xiad.created_by_wua_id created_by_id

--- a/data_migration/queries/import_application/fa/dfl.py
+++ b/data_migration/queries/import_application/fa/dfl.py
@@ -47,7 +47,7 @@ SELECT
   , xiad.variation_decision
   , xiad.variation_refuse_reason
   , xiad.licence_extended licence_extended_flag
-  , 'ILD' || ir.licence_ref licence_uref_id
+  , CASE WHEN ir.licence_ref IS NULL THEN NULL ELSE 'ILD' || ir.licence_ref END licence_uref_id
   , xiad.last_updated_datetime last_update_datetime
   , xiad.submitted_by_wua_id submitted_by_id
   , xiad.created_by_wua_id created_by_id

--- a/data_migration/queries/import_application/fa/oil.py
+++ b/data_migration/queries/import_application/fa/oil.py
@@ -47,7 +47,7 @@ SELECT
   , xiad.variation_decision
   , xiad.variation_refuse_reason
   , xiad.licence_extended licence_extended_flag
-  , 'ILD' || ir.licence_ref licence_uref_id
+  , CASE WHEN ir.licence_ref IS NULL THEN NULL ELSE 'ILD' || ir.licence_ref END licence_uref_id
   , xiad.last_updated_datetime last_update_datetime
   , xiad.submitted_by_wua_id submitted_by_id
   , xiad.created_by_wua_id created_by_id

--- a/data_migration/queries/import_application/fa/sil.py
+++ b/data_migration/queries/import_application/fa/sil.py
@@ -47,7 +47,7 @@ SELECT
   , xiad.variation_decision
   , xiad.variation_refuse_reason
   , xiad.licence_extended licence_extended_flag
-  , 'ILD' || ir.licence_ref licence_uref_id
+  , CASE WHEN ir.licence_ref IS NULL THEN NULL ELSE 'ILD' || ir.licence_ref END licence_uref_id
   , xiad.last_updated_datetime last_update_datetime
   , xiad.submitted_by_wua_id submitted_by_id
   , xiad.created_by_wua_id created_by_id

--- a/data_migration/queries/import_application/licence.py
+++ b/data_migration/queries/import_application/licence.py
@@ -36,9 +36,6 @@ ia_licence_docs = r"""
 SELECT
   ird.imad_id licence_id
   , dd.id document_legacy_id
-  , CASE WHEN ir.response_type LIKE '%_COVER' THEN 'COVER' ELSE 'ILD' END prefix
-  , ir.licence_ref reference_no
-  , CASE WHEN ir.response_type LIKE '%_COVER' THEN NULL ELSE 'ILD' || ir.licence_ref END uref
   , CASE
       WHEN ir.response_type LIKE '%_COVER' THEN ''
       WHEN xiad.print_documents_flag = 'Y' THEN ''
@@ -92,6 +89,14 @@ FROM decmgr.xview_notifications xn
 WHERE xn.acknowledgement_status = 'ACKNOWLEDGED'
 """
 
+ia_licence_doc_refs = """
+SELECT
+  'ILD' prefix
+  , ir.licence_ref reference_no
+  , 'ILD' || ir.licence_ref uref
+FROM impmgr.ima_responses ir
+WHERE ir.response_type LIKE '%_LICENCE'
+"""
 
 ia_licence_max_ref = (
     "SELECT MAX(licence_ref) FROM impmgr.ima_responses WHERE licence_ref IS NOT NULL"

--- a/data_migration/queries/import_application/opt.py
+++ b/data_migration/queries/import_application/opt.py
@@ -47,7 +47,7 @@ SELECT
   , xiad.variation_decision
   , xiad.variation_refuse_reason
   , xiad.licence_extended licence_extended_flag
-  , 'ILD' || ir.licence_ref licence_uref_id
+  , CASE WHEN ir.licence_ref IS NULL THEN NULL ELSE 'ILD' || ir.licence_ref END licence_uref_id
   , xiad.last_updated_datetime last_update_datetime
   , xiad.submitted_by_wua_id submitted_by_id
   , xiad.created_by_wua_id created_by_id

--- a/data_migration/queries/import_application/quota.py
+++ b/data_migration/queries/import_application/quota.py
@@ -47,7 +47,7 @@ SELECT
   , xiad.variation_decision
   , xiad.variation_refuse_reason
   , xiad.licence_extended licence_extended_flag
-  , 'ILD' || ir.licence_ref licence_uref_id
+  , CASE WHEN ir.licence_ref IS NULL THEN NULL ELSE 'ILD' || ir.licence_ref END licence_uref_id
   , xiad.last_updated_datetime last_update_datetime
   , xiad.submitted_by_wua_id submitted_by_id
   , xiad.created_by_wua_id created_by_id
@@ -195,7 +195,7 @@ SELECT
   , xiad.variation_decision
   , xiad.variation_refuse_reason
   , xiad.licence_extended licence_extended_flag
-  , 'ILD' || ir.licence_ref licence_uref_id
+  , CASE WHEN ir.licence_ref IS NULL THEN NULL ELSE 'ILD' || ir.licence_ref END licence_uref_id
   , xiad.last_updated_datetime last_update_datetime
   , xiad.submitted_by_wua_id submitted_by_id
   , xiad.created_by_wua_id created_by_id

--- a/data_migration/queries/import_application/sanctions.py
+++ b/data_migration/queries/import_application/sanctions.py
@@ -47,7 +47,7 @@ SELECT
   , xiad.variation_decision
   , xiad.variation_refuse_reason
   , xiad.licence_extended licence_extended_flag
-  , 'ILD' || ir.licence_ref licence_uref_id
+  , CASE WHEN ir.licence_ref IS NULL THEN NULL ELSE 'ILD' || ir.licence_ref END licence_uref_id
   , xiad.last_updated_datetime last_update_datetime
   , xiad.submitted_by_wua_id submitted_by_id
   , xiad.created_by_wua_id created_by_id

--- a/data_migration/queries/import_application/sps.py
+++ b/data_migration/queries/import_application/sps.py
@@ -47,7 +47,7 @@ SELECT
   , xiad.variation_decision
   , xiad.variation_refuse_reason
   , xiad.licence_extended licence_extended_flag
-  , 'ILD' || ir.licence_ref licence_uref_id
+  , CASE WHEN ir.licence_ref IS NULL THEN NULL ELSE 'ILD' || ir.licence_ref END licence_uref_id
   , xiad.last_updated_datetime last_update_datetime
   , xiad.submitted_by_wua_id submitted_by_id
   , xiad.created_by_wua_id created_by_id

--- a/data_migration/tests/test_e2e.py
+++ b/data_migration/tests/test_e2e.py
@@ -135,6 +135,7 @@ sil_data_source_target = {
             QueryModel(queries.ia_licence_docs, "ia_licence_docs", dm.CaseDocument),
         ],
         "import_application": [
+            QueryModel(queries.ia_licence_doc_refs, "Licence Doc Refs", dm.UniqueReference),
             QueryModel(queries.ia_type, "ia_type", dm.ImportApplicationType),
             QueryModel(queries.sil_application, "sil_application", dm.SILApplication),
             QueryModel(queries.ia_licence, "ia_licence", dm.ImportApplicationLicence),

--- a/data_migration/tests/utils/ia_data.py
+++ b/data_migration/tests/utils/ia_data.py
@@ -246,9 +246,6 @@ ia_query_result = {
             ("created_by_id",),
             ("signed_datetime",),
             ("signed_by_id",),
-            ("prefix",),
-            ("reference_no",),
-            ("uref",),
         ],
         [
             (
@@ -264,9 +261,6 @@ ia_query_result = {
                 2,  # created_by_id
                 datetime(2022, 4, 27),  # signed_datetime
                 2,  # signed_by_id
-                "ILD",  # prefix
-                "1234",  # reference_no
-                "ILD1234",  # uref
             ),
             (
                 None,  # reference
@@ -281,9 +275,6 @@ ia_query_result = {
                 2,  # created_by_id
                 datetime(2022, 4, 27),  # signed_datetime
                 2,  # signed_by_id
-                "COVER",  # prefix
-                None,  # reference_no
-                None,  # uref
             ),
             (
                 "1235B",  # reference
@@ -298,9 +289,6 @@ ia_query_result = {
                 2,  # created_by_id
                 datetime(2022, 4, 27),  # signed_datetime
                 2,  # signed_by_id
-                "ILD",  # prefix
-                "1235",  # reference_no
-                "ILD1235",  # uref
             ),
             (
                 "1236C",  # referece
@@ -315,9 +303,6 @@ ia_query_result = {
                 2,  # created_by_id
                 datetime(2022, 4, 27),  # signed_datetime
                 2,  # signed_by_id
-                "ILD",  # prefix
-                "12346",  # reference_no
-                "ILD12346",  # uref
             ),
             (
                 "1237E",  # referece
@@ -332,9 +317,6 @@ ia_query_result = {
                 2,  # created_by_id
                 datetime(2022, 4, 30),  # signed_datetime
                 2,  # signed_by_id
-                "ILD",  # prefix
-                "1237",  # reference_no
-                "ILD1237",  # uref
             ),
             (
                 None,  # reference
@@ -350,10 +332,16 @@ ia_query_result = {
                 datetime(2022, 4, 27),  # signed_datetime
                 2,  # signed_by_id
                 "COVER",  # prefix
-                None,  # reference_no
-                None,  # ur_imad_id
-                None,  # uref
             ),
+        ],
+    ),
+    queries.ia_licence_doc_refs: (
+        [("prefix",), ("reference_no",), ("uref",)],
+        [
+            ("ILD", "1234", "ILD1234"),
+            ("ILD", "1235", "ILD1235"),
+            ("ILD", "12346", "ILD12346"),
+            ("ILD", "1237", "ILD1237"),
         ],
     ),
     queries.opt_application: (

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -3824,3 +3824,4 @@ GA/2022/9910
 reference_no
 SELECT MAX(xseq_value
 ir.licence_ref END
+Licence Doc Refs


### PR DESCRIPTION
- Licence unique references need to exist before import applications due to fk, so extracting out from licence docs into separate query
- Not all import applications have a licence reference