### PR TITLE
ICMSLST-2505 Add requirements for running Playwright in Cloud Foundry.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: scripts/entry.sh
-celery_worker: celery --app=config.celery:app worker --loglevel=INFO -Q celery,mail
+celery_worker: scripts/celery-worker-entry.sh
 celery_beat: celery --app=config.celery:app beat --loglevel=INFO

--- a/apt.yml
+++ b/apt.yml
@@ -1,0 +1,15 @@
+---
+packages:
+  # Playwright dependencies
+  - libnss3
+  - libnspr4
+  - libatk1.0-0
+  - libatk-bridge2.0-0
+  - libcups2
+  - libxkbcommon0
+  - libatspi2.0-0
+  - libxcomposite1
+  - libxdamage1
+  - libxrandr2
+  - libgbm1
+  - libasound2

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,5 +2,6 @@
 applications:
   - name: icms
     buildpacks:
+      - https://github.com/cloudfoundry/apt-buildpack.git
       - python_buildpack
     stack: cflinuxfs4

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -3822,3 +3822,4 @@ SELECT MAX(xseq_value
 ir.licence_ref END
 Licence Doc Refs
 ce.email_cc_address_list cc_address_list_str
+playwright install chromium && celery

--- a/scripts/celery-worker-entry.sh
+++ b/scripts/celery-worker-entry.sh
@@ -1,0 +1,14 @@
+#!/bin/sh -e
+
+if [ -n "${COPILOT_ENVIRONMENT_NAME}" ]; then
+    echo "Running in DBT Platform"
+    celery --app=config.celery:app worker --loglevel=INFO -Q celery,mail
+
+else
+    echo "Running in Cloud Foundry"
+    # In DBT platform the following will be done at the build stage
+    echo "Installing playwright chromium browser for celery worker."
+    playwright install chromium
+
+    celery --app=config.celery:app worker --loglevel=INFO -Q celery,mail
+fi

--- a/scripts/entry.sh
+++ b/scripts/entry.sh
@@ -9,10 +9,9 @@ if [ -n "${COPILOT_ENVIRONMENT_NAME}" ]; then
 else
     echo "Running in Cloud Foundry"
 
-# TODO ICMSLST-2505 Install playwright successfully.
     # In DBT platform the following will be done at the build stage
-#    echo "Installing playwright chromium browser & dependencies"
-#    playwright install --with-deps chromium
+    echo "Installing playwright chromium browser"
+    playwright install chromium
 
     echo "Collecting static files"
     python manage.py collectstatic --noinput --traceback


### PR DESCRIPTION
Changes:
  - Add apt-buildpack to install playwright system dependencies.
  - Add entry script for celery worker to install playwright browser.
  - Install playwright browser in web entry script.
  - Scale celery_worker process to fix memory issues:
    - cf scale icms-dev -k 2G --process celery_worker
    - cf scale icms-dev -m 2G --process celery_worker
    
The celery_worker disk space increase is to accommodate the extra install space required for chromium.
The celery_worker RAM increase fixes an out of memory exception caused when signing the PDF.