### PR TITLE
ICMSLST-2536 Add middleware to skip adding site attribute to request obj.

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -65,7 +65,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "django.contrib.sites.middleware.CurrentSiteMiddleware",
+    "web.middleware.common.ICMSCurrentSiteMiddleware",
     "htmlmin.middleware.HtmlMinifyMiddleware",
     "htmlmin.middleware.MarkRequestMiddleware",
     "web.middleware.common.ICMSMiddleware",

--- a/web/middleware/common.py
+++ b/web/middleware/common.py
@@ -1,3 +1,6 @@
+from django.contrib.sites.middleware import CurrentSiteMiddleware
+from django.urls import resolve
+
 from web.utils.lock_manager import LockManager
 
 
@@ -48,3 +51,17 @@ class SetPermittedCrossDomainPolicyHeaderMiddleware:
         response = self.get_response(request)
         response.headers["X-Permitted-Cross-Domain-Policies"] = "none"
         return response
+
+
+class ICMSCurrentSiteMiddleware(CurrentSiteMiddleware):
+    """Middleware that sets `site` attribute to request object."""
+
+    # List of views that do not add the site to the current request object.
+    site_exempt_views = [
+        "dbt-platform-health-check",
+    ]
+
+    def process_request(self, request):
+        """Middleware that sets `site` attribute to request object."""
+        if resolve(request.path).view_name not in self.site_exempt_views:
+            super().process_request(request)

--- a/web/tests/middleware/test_common.py
+++ b/web/tests/middleware/test_common.py
@@ -1,6 +1,14 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, create_autospec
 
-from web.middleware.common import ICMSMiddleware, ICMSMiddlewareContext
+import pytest
+from django.http import HttpRequest
+from django.urls import reverse
+
+from web.middleware.common import (
+    ICMSCurrentSiteMiddleware,
+    ICMSMiddleware,
+    ICMSMiddlewareContext,
+)
 from web.utils.lock_manager import LockManager
 
 
@@ -17,3 +25,26 @@ def test_request_icms():
 
     assert isinstance(request.icms, ICMSMiddlewareContext)
     assert isinstance(request.icms.lock_manager, LockManager)
+
+
+class TestICMSCurrentSiteMiddleware:
+    @pytest.fixture(autouse=True)
+    def setup(self, db):
+        self.request = create_autospec(HttpRequest)
+        self.request.get_host.return_value = "import-a-licence"
+
+    def test_request_site_not_added(self):
+        self.request.path = reverse("dbt-platform-health-check")
+
+        middleware = ICMSCurrentSiteMiddleware(Mock())
+        middleware(self.request)
+
+        assert not hasattr(self.request, "site")
+
+    def test_request_site_added(self):
+        self.request.path = reverse("workbasket")
+
+        middleware = ICMSCurrentSiteMiddleware(Mock())
+        middleware(self.request)
+
+        assert hasattr(self.request, "site")


### PR DESCRIPTION
The DBT Platform healthcheck uses the machine IP address as the host when calling the pingdom/ping.xml endpoint. This throws an exception as the IP address is not a valid site.