### PR TITLE
ICMSLST-2511 - Fix PDF signature image sizing

### DIFF
--- a/web/static/web/css/components/signature.css
+++ b/web/static/web/css/components/signature.css
@@ -19,7 +19,8 @@ div[name="signature-widget"] > span {
 }
 
 #signature-widget-image {
-    max-width: 175px;
+    width: 175px;
+    max-height: 100px;
 }
 
 @media print {


### PR DESCRIPTION
Enforcing a standardised width for the PDF signature image and setting a max height so it doesn't overflow.