### PR TITLE
ICMSLST-1355 - Display supplementary report details in correct order

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -3853,3 +3853,7 @@ Department for International Trade<
 Foo Bar
 f"COM/{today.year}/00002
 Create Reports Data
+{{ report.str_title
+the Supplementary Report
+{{ application_field(report.transport |
+Add New Supplementary Report

--- a/web/templates/web/domains/case/import/fa/partials/report-list.html
+++ b/web/templates/web/domains/case/import/fa/partials/report-list.html
@@ -37,13 +37,6 @@
         {% endif %}
       </h3>
 
-      <div class="section-break"></div>
-      <div class="container setOutForm">
-        {{ application_field(report.transport | capitalize, 'Transport')}}
-        {{ application_field(report.str_date_received(), 'Date Received')}}
-        {{ application_field(report.bought_from, 'Bought From')}}
-      </div>
-
       {% with
         manual_firearms = report.get_report_firearms(is_manual=True),
         upload_firearms = report.get_report_firearms(is_upload=True),
@@ -52,6 +45,12 @@
       %}
         {% include "web/domains/case/import/fa/partials/report-firearm-list.html" %}
       {% endwith %}
+      <div class="section-break"></div>
+      <div class="container setOutForm">
+        {{ application_field(report.transport | capitalize, 'Transport')}}
+        {{ application_field(report.str_date_received(), 'Date Received')}}
+        {{ application_field(report.bought_from, 'Bought From')}}
+      </div>
     </fieldset>
   {% endfor %}
 {% endif %}


### PR DESCRIPTION
Before:
<img width="1670" alt="image" src="https://github.com/uktrade/icms/assets/23667847/20a27602-8bd7-42eb-8b40-c74e7bc83f9f">


After:
<img width="1662" alt="image" src="https://github.com/uktrade/icms/assets/23667847/496ef0da-c5ff-457c-be72-17eaa5894e90">
