### PR TITLE
Fix for add report data when resetting local db

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -3866,3 +3866,4 @@ Published Subject
 Retraction Subject
 MAILSHOT_DOCUMENT
 Test Mailshot 3.pdf
+args="add_reports_data

--- a/scripts/reset-local-docker-db
+++ b/scripts/reset-local-docker-db
@@ -6,7 +6,8 @@ make down
 docker volume rm icms_pgdata
 make migrate
 make localstack
-make manage args="create_icms_groups add_reports_data"
+make manage args="create_icms_groups"
+make manage args="add_reports_data"
 make add_dummy_data
 make manage args="set_icms_sites http://caseworker:8080 http://export-a-certificate:8080 http://import-a-licence:8080"
 


### PR DESCRIPTION
Commands need to be separate as `add_reports_data` was interrupted as a argument to the other command.