### PR TITLE
Data Migration - Correct Document Pack Revoked Statuses

### DIFF
--- a/data_migration/queries/export_application/export.py
+++ b/data_migration/queries/export_application/export.py
@@ -32,6 +32,7 @@ SELECT
   , card.issue_datetime case_completion_datetime
   , CASE
     WHEN card.status = 'DRAFT' THEN 'DR'
+    WHEN cad.status = 'REVOKED' THEN 'RE'
     WHEN card.is_last_issued = 'false' THEN 'AR'
     ELSE 'AC'
     END status
@@ -46,7 +47,7 @@ SELECT
 FROM impmgr.certificate_app_responses car
   INNER JOIN impmgr.cert_app_response_details card ON card.car_id = car.id
   INNER JOIN impmgr.certificate_applications ca ON ca.id = car.ca_id
-  INNER JOIN impmgr.certificate_app_details cad ON cad.id = card.cad_id
+  INNER JOIN impmgr.certificate_app_details cad ON cad.ca_id = car.ca_id AND cad.status_control = 'C'
   LEFT JOIN decmgr.xview_document_packs dp ON dp.ds_id = card.document_set_id
 WHERE card.status <> 'DELETED'
 ORDER BY card.id

--- a/data_migration/queries/import_application/licence.py
+++ b/data_migration/queries/import_application/licence.py
@@ -12,7 +12,8 @@ SELECT
   , CASE xiad.print_documents_flag WHEN 'Y' THEN 1 ELSE 0 END issue_paper_licence_only
   , ird.id legacy_id
   , CASE
-    WHEN xiad.status IN ('REVOKED', 'WITHDRAWN', 'STOPPED') THEN 'AR'
+    WHEN ixad.status = 'REVOKED' THEN 'RE'
+    WHEN xiad.status IN ('WITHDRAWN', 'STOPPED') THEN 'AR'
     WHEN ird.variation_no < xiad.variation_no THEN 'AR'
     WHEN xiad.status IN ('PROCESSING', 'VARIATION_REQUESTED', 'SUBMITTED') THEN 'DR'
     ELSE 'AC'

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -3867,3 +3867,4 @@ Retraction Subject
 MAILSHOT_DOCUMENT
 Test Mailshot 3.pdf
 args="add_reports_data
+ON cad.ca_id


### PR DESCRIPTION
Revoked status was added to document after the data migration was written. Add revoked status to the queries pulling the document pack data from V1