### PR TITLE
ICMSLST-2538 - COM certificate signing error

### DIFF
--- a/web/templates/pdf/export/com-certificate.html
+++ b/web/templates/pdf/export/com-certificate.html
@@ -7,6 +7,7 @@
   <head>
     <style>
       {{ get_css_rules_as_string("web/css/pdfs/licence-and-certificate-common-style.css")|safe }}
+      {{ get_css_rules_as_string("web/css/pdfs/certificate-style.css")|safe }}
       {{ get_css_rules_as_string("web/css/pdfs/com-certificate-style.css")|safe }}
       {{ get_css_rules_as_string("web/css/components/signature.css")|safe }}
 			{% if preview %}


### PR DESCRIPTION
A signature was unable to be applied to COM certificates because the QR code was WAY too big and so obscured the placeholder signature text, this is because the com-certificate.html doesn't actually inherit from the base-certificate.html template and so never got the certificate-style.css import. This has now been manually added.

Before:
<img width="882" alt="image" src="https://github.com/uktrade/icms/assets/23667847/0bf3b348-c06a-4a89-978e-5a8c44c4e254">


After:
<img width="856" alt="image" src="https://github.com/uktrade/icms/assets/23667847/a7a59438-302f-42d3-b190-8554aac21cb9">
