### PR TITLE
Playwright image updated to latest

### DIFF
--- a/playwright/Dockerfile
+++ b/playwright/Dockerfile
@@ -1,6 +1,6 @@
-FROM mcr.microsoft.com/playwright/python:v1.41.1-jammy
+FROM mcr.microsoft.com/playwright/python:latest
 # Available playwright tags:
-#https://mcr.microsoft.com/en-us/product/playwright/tags
+# https://mcr.microsoft.com/en-us/product/playwright/tags
 
 WORKDIR /code
 COPY requirements-playwright.txt /code/


### PR DESCRIPTION
End to end tests don't run if there is a new version of the playwright image available.
This sets the image to use the latest tag