### PR TITLE
ICMSLST-1624 - allow update of historical record without EORI Number present.

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -4217,3 +4217,5 @@ HTML markup
 href="https://www.hse.gov.uk
 noreferrer">this</a
 "Testing that the legislation config
+Assert the
+ImporterFactory


### PR DESCRIPTION
As per the ILB Team feedback, older Importer records may not have an EORI Number, as previously is was not a mandatory value.

The following changes should be implemented:

Check if an Importer has an EORI Number entered when the Admin initiates editing of the Importer record

When [Save] is used, if the EORI Number was populated on entry, maintain mandatory value checks on this field

When [Save] is used, if there was no EORI Number on the record, skip the mandatory value checks on this specific field only