### PR TITLE
Pinning PyOpenSSL to 24.0.0

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -41,7 +41,7 @@ xlsxwriter==3.0.1
 django-csp~=3.7
 PyMuPDF~=1.23.16
 playwright~=1.14
-pyOpenSSL~=24.0
+pyOpenSSL==24.0.0
 # Pin endesive sub-dependencies as they aren't pinned in endesive repo
 # Periodically review these to see if we can install newer versions
 endesive~=2.17.0


### PR DESCRIPTION
Releases after 24.0.0 remove the OpenSSL.crypto.PKCS12 module which is used for testing PDF certificate signing