### PR TITLE
ICMSLST-1621 - Importer/Exporter - carry name into Access Request form.

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -4199,3 +4199,5 @@ ON cad_c.ca_id
 {{ object.sent_datetime.strftime("%d-%b-%Y %
 {{ object.response|nl2br }
 {{ object.closed_datetime.strftime("%d-%b-%Y %
+=Import Ltd
+f"{self.url}?exporter_name=Export Ltd

--- a/web/domains/case/access/filters.py
+++ b/web/domains/case/access/filters.py
@@ -36,6 +36,13 @@ class ImporterAccessRequestFilter(FilterSet):
             | Q(submitted_by__last_name__icontains=value)
         )
 
+    @property
+    def form(self):
+        form = super().form
+        if importer_name := self.request.GET.get("importer_name"):
+            form.fields["q"].initial = importer_name
+        return form
+
 
 class ExporterAccessRequestFilter(FilterSet):
     q = CharFilter(
@@ -66,3 +73,10 @@ class ExporterAccessRequestFilter(FilterSet):
             | Q(submitted_by__first_name__icontains=value)
             | Q(submitted_by__last_name__icontains=value)
         )
+
+    @property
+    def form(self):
+        form = super().form
+        if exporter_name := self.request.GET.get("exporter_name"):
+            form.fields["q"].initial = exporter_name
+        return form

--- a/web/templates/partial/exporter/sidebar.html
+++ b/web/templates/partial/exporter/sidebar.html
@@ -6,7 +6,12 @@
         <a href="{{ icms_url('exporter-list') }}">Exporter</a>
     </li>
     <li>
-      <a href="{{ icms_url('access:exporter-list') }}">Exporter Access Requests</a>
+      {% if request.resolver_match.url_name == "exporter-edit" %}
+        {# we want to pass the current exporter ID into the URL so it can be prefilled in the exporter-list view #}
+        <a href="{{ icms_url('access:exporter-list') }}?exporter_name={{ form.instance.name }}">Exporter Access Requests</a>
+      {% else %}
+        <a href="{{ icms_url('access:exporter-list') }}">Exporter Access Requests</a>
+      {% endif %}
     </li>
   </ul>
   <h5>Create</h5>

--- a/web/templates/partial/importer/sidebar.html
+++ b/web/templates/partial/importer/sidebar.html
@@ -6,7 +6,11 @@
       <a href="{{ icms_url('importer-list') }}">Importer</a>
     </li>
     <li>
-      <a href="{{ icms_url('access:importer-list') }}">Importer Access Requests</a>
+      {% if request.resolver_match.url_name == "importer-edit" %}
+        <a href="{{ icms_url('access:importer-list') }}?importer_name={{ form.instance.name }}">Importer Access Requests</a>
+      {% else %}
+        <a href="{{ icms_url('access:importer-list') }}">Importer Access Requests</a>
+      {% endif %}
     </li>
   </ul>
   {% if page_title == "Agent" %}

--- a/web/tests/domains/exporter/test_views.py
+++ b/web/tests/domains/exporter/test_views.py
@@ -146,7 +146,7 @@ class TestEditExporterView(AuthTestCase):
         response = self.ilb_admin_client.get(self.url)
         resp_html = response.content.decode("utf-8")
         assertInHTML(
-            f"{reverse('access:importer-list')}?importer_name={self.exporter.name}", resp_html
+            f"{reverse('access:exporter-list')}?exporter_name={self.exporter.name}", resp_html
         )
 
 

--- a/web/tests/domains/exporter/test_views.py
+++ b/web/tests/domains/exporter/test_views.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 from django.urls import reverse
 from guardian.shortcuts import remove_perm
-from pytest_django.asserts import assertRedirects
+from pytest_django.asserts import assertInHTML, assertRedirects
 
 from web.models import Exporter
 from web.permissions import Perms
@@ -140,6 +140,14 @@ class TestEditExporterView(AuthTestCase):
                 response.context["form"].fields[field].help_text
                 == "Contact ILB to update this field."
             )
+
+    def test_prefilled_search_url(self):
+        """Tests that the URL to search Importer Access Requests is prefilled with the importer name."""
+        response = self.ilb_admin_client.get(self.url)
+        resp_html = response.content.decode("utf-8")
+        assertInHTML(
+            f"{reverse('access:importer-list')}?importer_name={self.exporter.name}", resp_html
+        )
 
 
 class TestDetailExporterView(AuthTestCase):

--- a/web/tests/domains/importer/test_views.py
+++ b/web/tests/domains/importer/test_views.py
@@ -308,6 +308,14 @@ class TestImporterEditView(AuthTestCase):
                 == "Contact ILB to update this field."
             )
 
+    def test_prefilled_search_url(self):
+        """Tests that the URL to search Importer Access Requests is prefilled with the importer name."""
+        response = self.ilb_admin_client.get(self.url)
+        resp_html = response.content.decode("utf-8")
+        assertInHTML(
+            f"{reverse('access:importer-list')}?importer_name={self.importer.name}", resp_html
+        )
+
 
 class TestCreateSection5View(AuthTestCase):
     @pytest.fixture(autouse=True)

--- a/web/views/views.py
+++ b/web/views/views.py
@@ -226,7 +226,9 @@ class ModelFilterView(
         else:
             filterset_data = self.request.GET
 
-        return self.filterset_class(filterset_data, queryset=queryset, **kwargs)
+        return self.filterset_class(
+            filterset_data, queryset=queryset, request=self.request, **kwargs
+        )
 
     def is_initial_page_load(self):
         """Work out if this view has been loaded for the first time.


### PR DESCRIPTION
Changes Required

As per the ILB Team feedback, the Search box should auto-populate with the name of the Exporter/Importer that the Admin was viewing when they chose to search access requests.

The following changes should be implemented:

Carry the name of the Exporter/Importer into the ‘Search’ box on the access request search page (it can be edited)