### PR TITLE
ICMSLST-2480 - V2 documents are smaller than v1

### DIFF
--- a/web/static/web/css/pdfs/fa-common-licence-style.css
+++ b/web/static/web/css/pdfs/fa-common-licence-style.css
@@ -1,5 +1,5 @@
 p, li {
-    font-size: 12px;
+    font-size: 13px;
 }
 
 p.content,

--- a/web/static/web/css/pdfs/licence-and-certificate-common-style.css
+++ b/web/static/web/css/pdfs/licence-and-certificate-common-style.css
@@ -86,7 +86,7 @@
     -webkit-print-color-adjust: exact;
 }
 
-p.content, ul li, .post_endorsement_statement p {
+.small-text{
     font-size: 10px;
 }
 

--- a/web/templates/pdf/shared/fa-licence-base.html
+++ b/web/templates/pdf/shared/fa-licence-base.html
@@ -29,7 +29,7 @@
   <div class="flex-row" id="reference-and-licence">
     <div></div>
     <div class="bordered">
-      <p class="content">Applicant's own reference</p>
+      <p class="content small-text">Applicant's own reference</p>
       {% if applicant_reference %}
         <p class="content">{{ applicant_reference }}</p>
       {% elif preview_licence %}
@@ -38,11 +38,11 @@
     </div>
 
     <div>
-      <p class="content">Quote both references in all correspondence</p>
+      <p class="content small-text">Quote both references in all correspondence</p>
     </div>
 
     <div class="bordered">
-      <p class="content">Licence No.</p>
+      <p class="content small-text">Licence No.</p>
       <p class="content {{ 'preview-orange' if preview_licence }}" id="licence-number">{{ licence_number }}</p>
     </div>
   </div>
@@ -57,7 +57,7 @@
         {% endfor %}
         <p class="content">{{ importer_postcode|upper }}</p>
         {% for number in eori_numbers %}
-          <p class="content text-right">{{ number|upper }}</p>
+          <p class="content text-right small-text">{{ number|upper }}</p>
         {% endfor %}
       </div>
     </div>
@@ -69,17 +69,17 @@
 </header>
 {# TODO: ICMSLST-1430 Revisit how sections are grouped #}
 <main>
-  <p class="content">is hereby authorised by the Secretary of State to import into the United Kingdom in accordance with
+  <p class="content small-text">is hereby authorised by the Secretary of State to import into the United Kingdom in accordance with
     the conditions set out below</p>
   <div class="flex-row" id="commodities">
     <div class="bordered">
-      <p class="content">Commodity Code<br/>ex Chapter 93</p>
+      <p class="content small-text">Commodity Code<br/>ex Chapter 93</p>
     </div>
     <div class="bordered">
-      <p class="content">Country from which consigned<br/>{{ consignment_country }}</p>
+      <p class="content small-text">Country from which consigned<br/>{{ consignment_country }}</p>
     </div>
     <div class="bordered">
-      <p class="content">Country of origin<br/>{{ origin_country }}</p>
+      <p class="content small-text">Country of origin<br/>{{ origin_country }}</p>
     </div>
   </div>
   <div class="flex-row">


### PR DESCRIPTION
Increasing default text size in V2 PDFs so they align with V1 styling.

Before:
<img width="953" alt="image" src="https://github.com/uktrade/icms/assets/23667847/3510e996-801e-48b8-8ea2-e02ce03893b5">


After:
<img width="966" alt="image" src="https://github.com/uktrade/icms/assets/23667847/8870f06d-c2b8-42a2-9d64-79802c51fb7e">
