### PR TITLE
img-src CSP header not being added.

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -482,7 +482,7 @@ CSP_FONT_SRC = (
     "data:",
 )
 # Images can only be loaded from ICMS itself or data URIs
-CSP_IMAGE_SRC = (
+CSP_IMG_SRC = (
     "'self'",
     "data:",
 )


### PR DESCRIPTION
This was because the variable in the settings file was not named correctly, and so img-src was not getting added to the CSP header.