### PR TITLE
ICMSLST-1299 - Commodities - Add 'Any' as default search option for Commodity Group fields.

### DIFF
--- a/web/domains/commodity/forms.py
+++ b/web/domains/commodity/forms.py
@@ -107,16 +107,15 @@ class CommodityEditForm(CommodityForm):
 
 class CommodityGroupFilter(FilterSet):
     group_type = ChoiceFilter(
-        field_name="group_type", choices=CommodityGroup.TYPES, label="Group Type"
+        field_name="group_type",
+        choices=CommodityGroup.TYPES,
+        label="Group Type",
+        empty_label="Any",
     )
     commodity_type = ModelChoiceFilter(
-        queryset=CommodityType.objects.all(), label="Commodity Types"
-    )
-
-    application_type = ModelChoiceFilter(
-        queryset=ImportApplicationType.objects.filter(is_active=True),
-        field_name="usages__application_type",
-        label="Application Type",
+        queryset=CommodityType.objects.all(),
+        label="Commodity Type",
+        empty_label="Any",
     )
 
     group_code = CharFilter(field_name="group_code", lookup_expr="icontains", label="Group Code")
@@ -127,7 +126,10 @@ class CommodityGroupFilter(FilterSet):
     commodity_code = CharFilter(
         field_name="commodities__commodity_code", lookup_expr="icontains", label="Commodity Code"
     )
-    unit = ModelChoiceFilter(queryset=Unit.objects.all())
+    unit = ModelChoiceFilter(
+        queryset=Unit.objects.all(),
+        empty_label="Any",
+    )
 
     is_archived = BooleanFilter(
         field_name="is_active",


### PR DESCRIPTION
Adding 'Any' as an option to fields on the CommodityGroup search filter, removing redundant field, and fixing label.

Before:
<img width="1264" alt="image" src="https://github.com/uktrade/icms/assets/23667847/c7ead50f-5a05-4032-a0f9-375f5df6ce03">


After:
<img width="1084" alt="image" src="https://github.com/uktrade/icms/assets/23667847/d9a24520-2305-4dbf-9ec4-bf7a3a53ca7d">
