### PR TITLE
ICMSLST-1298 - Commodities - Add 'Any' as default search option for Commodity Type.

### DIFF
--- a/web/domains/commodity/forms.py
+++ b/web/domains/commodity/forms.py
@@ -37,7 +37,7 @@ class CommodityFilter(FilterSet):
     )
 
     commodity_type = ModelChoiceFilter(
-        queryset=CommodityType.objects.all(), label="Commodity Types"
+        queryset=CommodityType.objects.all(), label="Commodity Type", empty_label="Any"
     )
 
     valid_start = JqueryDateFilter(


### PR DESCRIPTION
Adding 'Any' option on CommodityFilter.

Before:
<img width="914" alt="image" src="https://github.com/uktrade/icms/assets/23667847/07132872-1404-43d0-a000-3ba3a1e2e641">


After:
<img width="731" alt="image" src="https://github.com/uktrade/icms/assets/23667847/53e7563b-f359-4231-956e-73a9afa316b6">
