### PR TITLE
ICMSLST-2564 Add schedule products to CFS Schedule Template view. 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         verbose: true
         require_serial: true
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.1
+    rev: v3.15.2
     hooks:
     -   id: pyupgrade
         args: [--py311-plus]

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -4283,3 +4283,4 @@ Parameters</h4
 Date Filter Type
 3288
 Max 20
+111-11-1111

--- a/web/domains/case/export/views.py
+++ b/web/domains/case/export/views.py
@@ -454,17 +454,30 @@ def cfs_edit_schedule(
         legislation_config = get_csf_schedule_legislation_config()
 
         context = {
-            "process": application,
-            "form": form,
             "page_title": "Edit Schedule",
+            "process": application,
             "schedule": schedule,
+            "form": form,
+            "case_type": "export",
             "is_biocidal": schedule.is_biocidal(),
-            "products": schedule.products.order_by("pk").all(),
+            "products": schedule.products.all().order_by("pk"),
             "product_upload_form": ProductsFileUploadForm(),
             "has_legislation": schedule_legislations.exists(),
-            "case_type": "export",
             "legislation_config": legislation_config,
             "show_schedule_statements_is_responsible_person": show_schedule_statements_is_responsible_person,
+            # Products section context
+            "upload_product_spreadsheet_url": reverse(
+                "export:cfs-schedule-product-spreadsheet-upload",
+                kwargs={"application_pk": application.pk, "schedule_pk": schedule.pk},
+            ),
+            "download_product_spreadsheet_url": reverse(
+                "export:cfs-schedule-product-download-template",
+                kwargs={"application_pk": application.pk, "schedule_pk": schedule.pk},
+            ),
+            "add_schedule_product_url": reverse(
+                "export:cfs-schedule-add-product",
+                kwargs={"application_pk": application.pk, "schedule_pk": schedule.pk},
+            ),
         }
 
         return render(request, "web/domains/case/export/cfs-edit-schedule.html", context)

--- a/web/domains/cat/views.py
+++ b/web/domains/cat/views.py
@@ -19,6 +19,7 @@ from django.views.generic.detail import SingleObjectMixin
 from django_filters import FilterSet
 from django_filters.views import FilterView
 
+from web.domains.case.export.forms import ProductsFileUploadForm
 from web.domains.case.export.views import (
     get_csf_schedule_legislation_config,
     get_show_schedule_statements_is_responsible_person,
@@ -286,6 +287,7 @@ class CATEditView(PermissionRequiredMixin, LoginRequiredMixin, UserPassesTestMix
                 extra["show_schedule_statements_is_responsible_person"] = (
                     get_show_schedule_statements_is_responsible_person(schedule)
                 )
+                # Manufacturer details section context
                 extra["edit_manufacturer_url"] = reverse(
                     "cat:cfs-manufacturer-update",
                     kwargs={"cat_pk": self.object.pk, "schedule_template_pk": schedule.pk},
@@ -294,6 +296,16 @@ class CATEditView(PermissionRequiredMixin, LoginRequiredMixin, UserPassesTestMix
                     "cat:cfs-manufacturer-delete",
                     kwargs={"cat_pk": self.object.pk, "schedule_template_pk": schedule.pk},
                 )
+
+                # Products section context
+                extra["is_biocidal"] = schedule.is_biocidal()
+                extra["products"] = schedule.products.all().order_by("pk")
+                extra["product_upload_form"] = ProductsFileUploadForm()
+                extra["has_legislation"] = schedule.legislations.filter(is_active=True).exists()
+                # TODO: ICMSLST-2564 Add urls when views exist.
+                extra["upload_product_spreadsheet_url"] = ""
+                extra["download_product_spreadsheet_url"] = ""
+                extra["add_schedule_product_url"] = ""
 
         if app_type == ExportApplicationType.Types.GMP and step == CatSteps.GMP:
             extra["include_contact"] = False
@@ -483,6 +495,9 @@ class CFSManufacturerDeleteView(
                 },
             )
         )
+
+
+# TODO: ICMSLST-2564 Add CFS product views here.
 
 
 class CFSScheduleTemplateAddView(

--- a/web/management/commands/add_dummy_data.py
+++ b/web/management/commands/add_dummy_data.py
@@ -455,6 +455,15 @@ def create_certificate_application_templates(
     )
     cfs_schedule_template.legislations.add(ProductLegislation.objects.first())
 
+    for i in range(1, 6):
+        product = cfs_schedule_template.products.create(product_name=f"Test Product {i}")
+        for z in range(1, i + 1):
+            product.product_type_numbers.create(product_type_number=z)
+            # e.g. 111-11-1111
+            z = str(z)  # type:ignore[assignment]
+            cas = f"{z * 3}-{z * 2}-{z * 4}"
+            product.active_ingredients.create(name=f"Test Ingredient {z}", cas_number=cas)
+
     #
     # Add a GMP template
     gmp_cat = CertificateApplicationTemplate.objects.create(

--- a/web/templates/web/domains/case/export/cfs-edit-schedule.html
+++ b/web/templates/web/domains/case/export/cfs-edit-schedule.html
@@ -40,56 +40,7 @@
 
   {# Products Section #}
   {% if has_legislation %}
-    <h4>Products</h4>
-    <div class="info-box info-box-info">
-      <p>Please add product information below. A separate line is required for each product.</p>
-      <p><strong>
-        If any of the information given on this schedule does not apply to all of the products below,
-        a separate schedule must be added for the products where the information is different.
-      </strong></p>
-      <p>
-        To upload products in bulk, download and complete the template provided below.
-        Once uploaded the products list will be filled out automatically.
-      </p>
-    </div>
-    <div class="container setoutForm">
-      <div class="row">
-        <div class="two columns"></div>
-        <div class="six columns">
-          <a class="icon icon-download button"
-            href="{{ icms_url('export:cfs-schedule-product-download-template', kwargs={'application_pk': process.pk, 'schedule_pk': schedule.pk}) }}">
-            Download Template Spreadsheet
-          </a>
-        </div>
-        <div class="four columns"></div>
-      </div>
-      <br>
-      <div class="row">
-        <div class="two columns">
-          <label class="prompt west">
-            Upload Spreadsheet
-            <span class="mand-label">optional</span>
-          </label>
-        </div>
-        <div class="six columns input-group">
-          <form action="{{ icms_url('export:cfs-schedule-product-spreadsheet-upload', kwargs={'application_pk': process.pk, 'schedule_pk': schedule.pk}) }}" method="post" enctype="multipart/form-data" id="id_upload-product-data">
-            {{ csrf_input }}
-            {{ product_upload_form.file }}
-            <button type="submit" class="button link-button inline-link-button icon-upload" form="id_upload-product-data">Upload</button>
-            </label>
-          </form>
-        </div>
-        <div class="four columns"></div>
-      </div>
-    </div>
-    {% if products %}
-      {% include "web/domains/case/export/partials/cfs/schedule-product-list.html" %}
-    {% endif %}
-    <a
-      href="{{ icms_url('export:cfs-schedule-add-product', kwargs={'application_pk': process.pk, 'schedule_pk': schedule.pk }) }}"
-      class="button small-button icon-plus">
-      Add Product
-    </a>
+    {% include "web/domains/case/export/partials/cfs/schedule-products.html" %}
   {% endif %}
 {% endblock %}
 

--- a/web/templates/web/domains/case/export/partials/cfs/schedule-products.html
+++ b/web/templates/web/domains/case/export/partials/cfs/schedule-products.html
@@ -1,0 +1,47 @@
+<h4>Products</h4>
+<div class="info-box info-box-info">
+  <p>Please add product information below. A separate line is required for each product.</p>
+  <p><strong>
+    If any of the information given on this schedule does not apply to all of the products below,
+    a separate schedule must be added for the products where the information is different.
+  </strong></p>
+  <p>
+    To upload products in bulk, download and complete the template provided below.
+    Once uploaded the products list will be filled out automatically.
+  </p>
+</div>
+
+
+<div class="container setoutForm">
+  <div class="row">
+    <div class="two columns"></div>
+    <div class="six columns">
+      <a class="icon icon-download button"
+        href="{{ download_product_spreadsheet_url }}">
+        Download Template Spreadsheet
+      </a>
+    </div>
+    <div class="four columns"></div>
+  </div>
+  <br>
+  <div class="row">
+    <div class="two columns">
+      <label class="prompt west">Upload Spreadsheet<span class="mand-label">optional</span></label>
+    </div>
+    <div class="six columns input-group">
+      <form action="{{ upload_product_spreadsheet_url }}" method="post" enctype="multipart/form-data" id="id_upload-product-data">
+        {{ csrf_input }}
+        {{ product_upload_form.file }}
+        <button type="submit" class="button link-button inline-link-button icon-upload" form="id_upload-product-data">Upload</button>
+        </label>
+      </form>
+    </div>
+    <div class="four columns"></div>
+  </div>
+</div>
+
+{% if products %}
+  {% include "web/domains/case/export/partials/cfs/schedule-product-list.html" %}
+{% endif %}
+
+<a href="{{ add_schedule_product_url }}" class="button small-button icon-plus">Add Product</a>

--- a/web/templates/web/domains/cat/cfs/edit-schedule.html
+++ b/web/templates/web/domains/cat/cfs/edit-schedule.html
@@ -3,4 +3,9 @@
 {% block subtasks %}
   {# Manufactured At Section #}
   {% include "web/domains/case/export/partials/cfs/edit-manufactured-at.html" %}
+
+  {# Products Section #}
+  {% if has_legislation %}
+    {% include "web/domains/case/export/partials/cfs/schedule-products.html" %}
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
Changes:
  - Add common partial template to use in CFS Edit and template view.
  - Add CFS Schedule Template products to add_dummy_data

New section added to the CFS Schedule Template edit view:
![export-a-certificate_8080_cat_edit_2_step_cfs-schedule_step_pk_1_](https://github.com/uktrade/icms/assets/8921101/836822e0-f8bf-4380-a600-1ad85e2abb49)
