### PR TITLE
ICMSLST-2564 Add several CFS Schedule Product Template views.

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -4291,3 +4291,10 @@ report__bought_from__registration_number
 dflapplication__goods_certificates__goods_description
 importer_first_name
 importer_address_1
+{{ fields.inline_field_with_label(form.product_type_number
+Product Type Number
+{{ fields.inline_field_with_label(form.cas_number
+schedule_pk
+id_pt_-1-product_type_number
+id_pt_-1-DELETE
+pt_-1-product_type_number

--- a/web/domains/cat/urls.py
+++ b/web/domains/cat/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path
+from django.urls import include, path
 
 from . import views
 
@@ -29,23 +29,45 @@ urlpatterns = [
         name="cfs-schedule-add",
     ),
     path(
-        "edit/<int:cat_pk>/schedule_template/<int:schedule_template_pk>/copy-schedule/",
-        views.CFSScheduleTemplateCopyView.as_view(),
-        name="cfs-schedule-copy",
-    ),
-    path(
-        "edit/<int:cat_pk>/schedule_template/<int:schedule_template_pk>/delete-schedule/",
-        views.CFSScheduleTemplateDeleteView.as_view(),
-        name="cfs-schedule-delete",
-    ),
-    path(
-        "edit/<int:cat_pk>/schedule_template/<int:schedule_template_pk>/cfs-manufacturer-update/",
-        views.CFSManufacturerUpdateView.as_view(),
-        name="cfs-manufacturer-update",
-    ),
-    path(
-        "edit/<int:cat_pk>/schedule_template/<int:schedule_template_pk>/cfs-manufacturer-delete/",
-        views.CFSManufacturerDeleteView.as_view(),
-        name="cfs-manufacturer-delete",
+        "edit/<int:cat_pk>/schedule_template/<int:schedule_template_pk>/",
+        include(
+            [
+                path(
+                    "copy-schedule/",
+                    views.CFSScheduleTemplateCopyView.as_view(),
+                    name="cfs-schedule-copy",
+                ),
+                path(
+                    "delete-schedule/",
+                    views.CFSScheduleTemplateDeleteView.as_view(),
+                    name="cfs-schedule-delete",
+                ),
+                path(
+                    "cfs-manufacturer-update/",
+                    views.CFSManufacturerUpdateView.as_view(),
+                    name="cfs-manufacturer-update",
+                ),
+                path(
+                    "cfs-manufacturer-delete/",
+                    views.CFSManufacturerDeleteView.as_view(),
+                    name="cfs-manufacturer-delete",
+                ),
+                path(
+                    "cfs-schedule-product-create/",
+                    views.CFSScheduleTemplateProductCreateView.as_view(),
+                    name="cfs-schedule-product-create",
+                ),
+                path(
+                    "cfs-schedule-product-update/<int:product_template_pk>/",
+                    views.CFSScheduleTemplateProductUpdateView.as_view(),
+                    name="cfs-schedule-product-update",
+                ),
+                path(
+                    "cfs-schedule-product-delete/<int:product_template_pk>/",
+                    views.CFSScheduleTemplateProductDeleteView.as_view(),
+                    name="cfs-schedule-product-delete",
+                ),
+            ]
+        ),
     ),
 ]

--- a/web/end_to_end/cat/test_create_cfs_cat.py
+++ b/web/end_to_end/cat/test_create_cfs_cat.py
@@ -74,6 +74,171 @@ def test_can_create_cfs_cat(pages: conftest.UserPages) -> None:
         page.get_by_label("Address\n        \n          optional").fill("Address line one")
         page.get_by_role("button", name="Save").click()
 
+        # Add, edit and delete a product.
+        page.get_by_role("link", name="Add Product").click()
+        page.get_by_label("Product Name").click()
+        page.get_by_label("Product Name").fill("Product 1")
+        page.get_by_role("button", name="Create").click()
+        product_pk = utils.get_application_id(
+            page.url,
+            r"cat/edit/\d+/schedule_template/\d+/cfs-schedule-product-update/(?P<product_pk>\d+)/",
+            "product_pk",
+        )
+        page.get_by_label("Product Name").click()
+        page.get_by_label("Product Name").fill("Product 1 updated")
+        page.get_by_role("button", name="save").click()
+        page.get_by_role("link", name="Edit schedule").click()
+        utils.get_cfs_product_list_row(page, product_pk).get_by_role(
+            "button", name="Delete"
+        ).click()
+
+        # Navigate back to main csf form (showing schedule list)
+        page.get_by_role("link", name="Certificate of Free Sale").click()
+
+        # Copy Schedule 1
+        page.get_by_label("Copy").click()
+        page.get_by_role("button", name="OK").click()
+
+        # Go back to list view
+        page.get_by_role("link", name="Certificate Application Templates").click()
+
+        # Create an application from the CFS Template
+        utils.get_cat_list_row(page, cat_pk).get_by_role("link", name="Create Application").click()
+        page.get_by_text("-- Select Exporter").click()
+        page.get_by_role("option", name="Dummy exporter").click()
+        page.locator("#select2-id_exporter_office-container").get_by_text(
+            "-- Select Office"
+        ).click()
+        page.get_by_role("option", name="Buckingham Palace\nLondon\nSW1A 1AA").click()  # /PS-IGNORE
+        page.get_by_role("button", name="Create").click()
+
+        # Check we are on the CFS Application Edit view.
+        utils.get_application_id(page.url, r"/export/cfs/(?P<app_pk>\d+)/edit/")
+
+        # Delete the template
+        page.get_by_role("link", name="Admin").click()
+        page.get_by_role("link", name="Certificate Application Templates").click()
+        utils.get_cat_list_row(page, cat_pk).get_by_role("button", name="Archive").click()
+
+        # Restore the template
+        page.get_by_label("Status").select_option("False")
+        page.get_by_role("button", name="Apply filter").click()
+        utils.get_cat_list_row(page, cat_pk).get_by_role("button", name="Restore").click()
+        page.get_by_label("Close this message").click()
+
+
+def test_test_can_create_cfs_cat_biocidal_schdedule(pages: conftest.UserPages) -> None:
+    with pages.exp_page() as page:
+        # Create a new CFS Certificate Application Template
+        page.get_by_role("link", name="Admin").click()
+        page.get_by_role("link", name="Certificate Application Templates").click()
+        page.get_by_role("link", name="Create Template").click()
+        page.get_by_label("Application Type").select_option("CFS")
+        page.get_by_label("Template Name").click()
+        page.get_by_label("Template Name").fill("Test CFS template")
+        page.get_by_label("Template Description").click()
+        page.get_by_label("Template Description").fill("Test CFS template description")
+        page.get_by_label("Sharing").select_option("edit")
+        page.get_by_role("button", name="Save").click()
+
+        # Now we are on the edit page store the cat_pk.
+        cat_pk = utils.get_application_id(page.url, r"cat/edit/(?P<cat_pk>\d+)/", "cat_pk")
+
+        # Go back to list view
+        page.get_by_role("link", name="Certificate Application Templates").click()
+
+        # Check edit link
+        utils.get_cat_list_row(page, cat_pk).get_by_role("link", name="Edit").click()
+
+        # Update the CFS CAT
+        page.get_by_label("Template Description").click()
+        page.get_by_label("Template Description").fill("Test CFS template description updated")
+        page.get_by_role("button", name="Save").click()
+
+        # Fill out the CFS form
+        page.get_by_role("link", name="Certificate of Free Sale").click()
+        page.get_by_placeholder("Select Country").click()
+        page.get_by_role("option", name="Afghanistan").click()
+        page.get_by_role("searchbox").click()
+        page.get_by_role("option", name="Albania").click()
+        page.get_by_role("button", name="Save").click()
+
+        # Delete the initial schedule
+        page.get_by_label("Delete").click()
+        page.get_by_role("button", name="OK").click()
+
+        # Add a new schedule
+        page.get_by_role("button", name="Add Schedule").click()
+
+        # Edit the only schedule
+        page.get_by_role("link", name="Edit schedule").click()
+
+        page.get_by_label("I am the manufacturer").check()
+        page.locator("#id_brand_name_holder").get_by_text("Yes").click()
+        page.get_by_placeholder("Select Legislation").click()
+
+        page.get_by_role(
+            "option", name="Biocide Products Regulation 528/2012 as retained in UK law"
+        ).click()
+        page.get_by_label("The products are currently").check()
+        page.locator("#id_goods_placed_on_uk_market_0").check()
+        page.locator("#id_goods_export_only_1").check()
+        page.locator("#id_any_raw_materials_0").check()
+        page.get_by_label("End Use or Final Product").click()
+        page.get_by_label("End Use or Final Product").fill("Test End Use or Final Product")
+        page.get_by_label("Country Of Manufacture").select_option("1")
+        page.get_by_label("These products are").check()
+        page.get_by_role("button", name="Save").click()
+
+        # Add the manufacturer details to schedule 1
+        page.get_by_role("link", name="Add Manufacturer").click()
+        page.get_by_label("Name").click()
+        page.get_by_label("Name").press("Shift+CapsLock")
+        page.get_by_label("Name").fill("Test Manufacturer")
+        page.get_by_label("Postcode").click()
+        page.get_by_label("Postcode").fill("s111S")
+        page.get_by_label("Address\n        \n          optional").click()
+        page.get_by_label("Address\n        \n          optional").fill("Address line one")
+        page.get_by_role("button", name="Save").click()
+
+        # Add, edit and delete several products (including active ingredients / product types.
+        page.get_by_role("link", name="Add Product").click()
+        page.get_by_label("Product Name").click()
+        page.get_by_label("Product Name").fill("Product 1")
+        page.get_by_role("button", name="Create").click()
+        product_pk = utils.get_application_id(
+            page.url,
+            r"cat/edit/\d+/schedule_template/\d+/cfs-schedule-product-update/(?P<product_pk>\d+)/",
+            "product_pk",
+        )
+        page.get_by_label("Product Name").click()
+        page.get_by_label("Product Name").fill("Test product updated")
+        page.locator("#id_pt_-0-product_type_number").select_option("1")
+        page.locator("#id_pt_-1-product_type_number").select_option("2")
+        page.locator("#id_pt_-2-product_type_number").select_option("3")
+        page.locator("#id_ai_-0-name").click()
+        page.locator("#id_ai_-0-name").fill("Active ingredient 1")
+        page.locator("#id_ai_-0-cas_number").click()
+        page.locator("#id_ai_-0-cas_number").fill("111-11-1111")
+        page.locator("#id_ai_-1-name").click()
+        page.locator("#id_ai_-1-name").fill("Active ingredient 2")
+        page.locator("#id_ai_-1-cas_number").click()
+        page.locator("#id_ai_-1-cas_number").fill("222-22-2222")
+        page.locator("#id_ai_-2-name").click()
+        page.locator("#id_ai_-2-name").fill("Active ingredient 3")
+        page.locator("#id_ai_-2-cas_number").click()
+        page.locator("#id_ai_-2-cas_number").fill("333-33-3333")
+        page.get_by_role("button", name="save").click()
+        page.locator("#id_pt_-1-DELETE").check()
+        page.locator("#id_pt_-2-DELETE").check()
+        page.locator("#id_ai_-1-DELETE").check()
+        page.locator("#id_ai_-2-DELETE").check()
+        page.get_by_role("button", name="save").click()
+        page.get_by_role("link", name="Edit schedule").click()
+        utils.get_cfs_product_list_row(page, product_pk).get_by_role(
+            "button", name="Delete"
+        ).click()
+
         # Navigate back to main csf form (showing schedule list)
         page.get_by_role("link", name="Certificate of Free Sale").click()
 

--- a/web/end_to_end/utils.py
+++ b/web/end_to_end/utils.py
@@ -92,3 +92,7 @@ def get_search_row(page: Page, app_id: int) -> Locator:
 
 def get_cat_list_row(page: Page, cat_pk: int) -> Locator:
     return page.locator(f'[data-test-id="cat-results-row-{cat_pk}"]')
+
+
+def get_cfs_product_list_row(page: Page, product_pk: int) -> Locator:
+    return page.locator(f'[data-test-id="schedule-product-row-{product_pk}"]')

--- a/web/management/commands/add_dummy_data.py
+++ b/web/management/commands/add_dummy_data.py
@@ -453,7 +453,11 @@ def create_certificate_application_templates(
         exporter_status=CFSScheduleTemplate.ExporterStatus.IS_MANUFACTURER,
         brand_name_holder=YesNoChoices.yes,
     )
-    cfs_schedule_template.legislations.add(ProductLegislation.objects.first())
+
+    # Add a biocidal product legislation as we add product types and active ingredients later on.
+    cfs_schedule_template.legislations.add(
+        ProductLegislation.objects.filter(is_biocidal=True).first()
+    )
 
     for i in range(1, 6):
         product = cfs_schedule_template.products.create(product_name=f"Test Product {i}")

--- a/web/templates/web/domains/case/export/partials/cfs/schedule-product-list.html
+++ b/web/templates/web/domains/case/export/partials/cfs/schedule-product-list.html
@@ -2,6 +2,27 @@
 {# products #}
 {# read_only #}
 {# is_biocidal #}
+
+{% macro get_edit_schedule_product_url(process, schedule_pk, product_pk) -%}
+  {# process is either an application or a cfs_template instance #}
+  {% if is_cfs_cat|default(False) %}
+    {% set edit_url = icms_url('cat:cfs-schedule-product-update', kwargs={'cat_pk': process.template.pk, 'schedule_template_pk': schedule_pk, 'product_template_pk': product_pk }) %}
+  {% else %}
+    {% set edit_url = icms_url('export:cfs-schedule-edit-product', kwargs={'application_pk': process.pk, 'schedule_pk': schedule_pk, 'product_pk': product_pk }) %}
+  {% endif %}
+  {{ edit_url }}
+{%- endmacro %}
+
+{% macro get_delete_schedule_product_url(process, schedule_pk, product_pk) -%}
+  {# process is either an application or a cfs_template instance #}
+  {% if is_cfs_cat|default(False) %}
+    {% set delete_url = icms_url('cat:cfs-schedule-product-delete', kwargs={'cat_pk': process.template.pk, 'schedule_template_pk': schedule_pk, 'product_template_pk': product_pk }) %}
+  {% else %}
+    {% set delete_url = icms_url('export:cfs-schedule-delete-product', kwargs={'application_pk': process.pk, 'schedule_pk': schedule_pk, 'product_pk': product_pk }) %}
+  {% endif %}
+  {{ delete_url }}
+{%- endmacro %}
+
 <table class="setoutList">
   <thead>
   <tr>
@@ -17,7 +38,7 @@
   </thead>
   <tbody>
   {% for product in products %}
-    <tr>
+    <tr data-test-id="schedule-product-row-{{ product.id }}">
       <td>{{ product.product_name }}</td>
       {% if is_biocidal %}
         <td>
@@ -59,7 +80,7 @@
           <ul class="menu-out">
             <li>
               <a
-                href="{{ icms_url('export:cfs-schedule-edit-product', kwargs={'application_pk': process.pk, 'schedule_pk': schedule.pk, 'product_pk': product.pk }) }}"
+                href="{{ get_edit_schedule_product_url(process, schedule.pk, product.pk) }}"
                 class="button link-button icon-pencil">
                 Edit
               </a>
@@ -67,7 +88,7 @@
             <li>
               <form
                 method="post"
-                action="{{ icms_url('export:cfs-schedule-delete-product', kwargs={'application_pk': process.pk, 'schedule_pk': schedule.pk, 'product_pk': product.pk }) }}"
+                action="{{ get_delete_schedule_product_url(process, schedule.pk, product.pk) }}"
                 class="form-inline">
                 {{ csrf_input }}
                 <button type="submit" class="button link-button icon-bin">

--- a/web/templates/web/domains/case/export/partials/cfs/schedule-products.html
+++ b/web/templates/web/domains/case/export/partials/cfs/schedule-products.html
@@ -33,7 +33,6 @@
         {{ csrf_input }}
         {{ product_upload_form.file }}
         <button type="submit" class="button link-button inline-link-button icon-upload" form="id_upload-product-data">Upload</button>
-        </label>
       </form>
     </div>
     <div class="four columns"></div>
@@ -44,4 +43,6 @@
   {% include "web/domains/case/export/partials/cfs/schedule-product-list.html" %}
 {% endif %}
 
-<a href="{{ add_schedule_product_url }}" class="button small-button icon-plus">Add Product</a>
+{% if not read_only %}
+  <a href="{{ add_schedule_product_url }}" class="button small-button icon-plus">Add Product</a>
+{% endif %}

--- a/web/templates/web/domains/cat/cfs/product-template-create.html
+++ b/web/templates/web/domains/cat/cfs/product-template-create.html
@@ -1,0 +1,44 @@
+{% extends "layout/sidebar.html" %}
+
+{% import "forms/forms.html" as forms %}
+{% import "forms/fields.html" as fields %}
+{% import "display/fields.html" as display %}
+
+{% block css %}
+{% endblock %}
+
+{% block content_actions %}
+  <div class="content-actions">
+    <ul class="menu-out flow-across">
+      <li>
+        <a href="{{ previous_link }}" class="prev-link">Edit schedule</a>
+      </li>
+    </ul>
+  </div>
+{% endblock %}
+
+{% block main_content %}
+  {% block main_content_intro %}{% endblock %}
+  {% call forms.form(method='post', csrf_input=csrf_input) -%}
+    {% for field in form %}
+      {{ fields.field(field) }}
+    {% endfor %}
+    <div class="section-break"></div>
+    <div class="container">
+      <div class="row">
+        <div class="three columns"></div>
+        <div class="eight columns">
+          <ul class="menu-out flow-across">
+            <li>
+              <button type="submit" class="primary-button button">Create</button>
+            </li>
+          </ul>
+        </div>
+        <div class="one columns"></div>
+      </div>
+    </div>
+  {% endcall %}
+{% endblock %}
+
+{% block page_js %}
+{% endblock %}

--- a/web/templates/web/domains/cat/cfs/product-template-update.html
+++ b/web/templates/web/domains/cat/cfs/product-template-update.html
@@ -1,0 +1,74 @@
+{% extends "layout/sidebar.html" %}
+
+{% import "forms/forms.html" as forms %}
+{% import "forms/fields.html" as fields %}
+{% import "display/fields.html" as display %}
+
+{% block css %}
+{% endblock %}
+
+{% block content_actions %}
+  <div class="content-actions">
+    <ul class="menu-out flow-across">
+      <li>
+        <a href="{{ previous_link }}" class="prev-link">Edit schedule</a>
+      </li>
+    </ul>
+  </div>
+{% endblock %}
+
+{% block main_content %}
+  {% block main_content_intro %}{% endblock %}
+  {% call forms.form(method='post', csrf_input=csrf_input) -%}
+    <h3>Product name</h3>
+    {% for field in form %}
+      {{ fields.field(field, prompt="north", label_cols='two') }}
+    {% endfor %}
+
+    {% if is_biocidal %}
+      <h3>Product types</h3>
+      <sub>Add any product types leaving unused extra rows blank</sub>
+      {{ pt_formset.management_form }}
+      {% for form in pt_formset %}
+          {{ form.id }}
+          <div class="row">
+            {{ fields.inline_field_with_label(form.product_type_number, prompt="north", label_cols='two', padding='zero', input_cols='three') }}
+            {% if form.instance.pk and pt_formset.can_delete %}
+              {{ fields.inline_field_with_label(form.DELETE, prompt="north", show_optional_indicator=False, label_cols='zero', padding='zero', input_cols='one') }}
+            {% endif %}
+          </div>
+      {% endfor %}
+      <h3>Active Ingredients</h3>
+      <sub>Add any active ingredients leaving unused extra rows blank</sub>
+      {{ ai_formset.management_form }}
+      {% for form in ai_formset %}
+          {{ form.id }}
+          <div class="row">
+            {{ fields.inline_field_with_label(form.name, prompt="north",  label_cols='two', padding='zero', input_cols='three') }}
+            {{ fields.inline_field_with_label(form.cas_number, prompt="north", label_cols='one', padding='zero', input_cols='two') }}
+            {% if form.instance.pk and ai_formset.can_delete %}
+              {{ fields.inline_field_with_label(form.DELETE, show_optional_indicator=False, prompt="north", label_cols='zero', padding='zero', input_cols='one') }}
+            {% endif %}
+          </div>
+      {% endfor %}
+    {% endif %}
+
+    <div class="section-break"></div>
+    <div class="container">
+      <div class="row">
+        <div class="three columns"></div>
+        <div class="eight columns">
+          <ul class="menu-out flow-across">
+            <li>
+              <button type="submit" class="primary-button button">Save</button>
+            </li>
+          </ul>
+        </div>
+        <div class="one columns"></div>
+      </div>
+    </div>
+  {% endcall %}
+{% endblock %}
+
+{% block page_js %}
+{% endblock %}


### PR DESCRIPTION
Changes:
  - Add CFSScheduleTemplateProductCreateView view.
  - Add CFSScheduleTemplateProductUpdateView view.
  - Add CFSScheduleTemplateProductDeleteView view.
  - Refactor shared templates to use correct urls.
  - Add E2E tests for CFS schedule product template views.
  - Add unittests for CFS schedule product template views.
  
Add Product / Edit / Delete links are now correct:
![image](https://github.com/uktrade/icms/assets/8921101/0d5cf1ee-241f-4da1-aee5-3a5fe307fe3b)

Add Product view:
![export-a-certificate_8080_cat_edit_2_schedule_template_1_cfs-schedule-product-create_](https://github.com/uktrade/icms/assets/8921101/9e5bc94d-a49c-40ee-aaa6-60c89024e568)

Edit Product view (no product types / active ingredients:
![export-a-certificate_8080_cat_edit_2_schedule_template_1_cfs-schedule-product-update_6_](https://github.com/uktrade/icms/assets/8921101/afcda69c-683d-412d-b04f-0d445f91b029)

Edit product view (existing products)
![export-a-certificate_8080_cat_edit_2_schedule_template_1_cfs-schedule-product-update_3_](https://github.com/uktrade/icms/assets/8921101/0ec20e04-a14b-4516-a9cf-8acb72c43af4)

Edit product view showing formset error handling (checks for duplicates)
![export-a-certificate_8080_cat_edit_2_schedule_template_1_cfs-schedule-product-update_3_ (1)](https://github.com/uktrade/icms/assets/8921101/35e4ef7c-6946-4267-a5f2-851da06ede3a)
