### PR TITLE
ICMSLST-2594 Add "Add Multiple Products" view to Edit CFS Schedule.

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -4277,3 +4277,4 @@ pt_-1-product_type_number
 Section 5 of the Firearms Act
 GOODS_ITEM_ID
 Existing Export Application
+Add Products

--- a/web/domains/case/export/forms.py
+++ b/web/domains/case/export/forms.py
@@ -489,6 +489,22 @@ class CFSProductForm(forms.ModelForm):
         return super().save(commit=commit)
 
 
+class CFSProductFormSetBase(forms.BaseInlineFormSet):
+    def get_form_kwargs(self, index: int) -> dict[str, Any]:
+        kwargs = super().get_form_kwargs(index)
+
+        return kwargs | {"schedule": self.instance}
+
+
+CFSProductFormSet = forms.inlineformset_factory(
+    CFSSchedule,
+    CFSProduct,
+    form=CFSProductForm,
+    formset=CFSProductFormSetBase,
+    extra=5,
+)
+
+
 class CFSProductTypeForm(forms.ModelForm):
     class Meta:
         model = CFSProductType

--- a/web/domains/case/export/urls.py
+++ b/web/domains/case/export/urls.py
@@ -47,6 +47,11 @@ schedule_urls = [
     ),
     path("product/add/", views.cfs_add_product, name="cfs-schedule-add-product"),
     path(
+        "product/add-multiple/",
+        views.CFSScheduleProductCreateMultipleView.as_view(),
+        name="cfs-schedule-add-multiple-products",
+    ),
+    path(
         "product/spreadsheet/download-template/",
         views.product_spreadsheet_download_template,
         name="cfs-schedule-product-download-template",

--- a/web/domains/cat/forms.py
+++ b/web/domains/cat/forms.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterable
+from typing import Any
 
 import django_filters
 from django import forms
@@ -110,6 +111,22 @@ class CFSProductTemplateForm(CFSProductForm):
         }
 
 
+class CFSProductTemplateFormSetBase(forms.BaseInlineFormSet):
+    def get_form_kwargs(self, index: int) -> dict[str, Any]:
+        kwargs = super().get_form_kwargs(index)
+
+        return kwargs | {"schedule": self.instance}
+
+
+CFSProductTemplateFormSet = forms.inlineformset_factory(
+    CFSScheduleTemplate,
+    CFSProductTemplate,
+    form=CFSProductTemplateForm,
+    formset=CFSProductTemplateFormSetBase,
+    extra=5,
+)
+
+
 class CFSProductTypeTemplateForm(CFSProductTypeForm):
     class Meta:
         model = CFSProductTypeTemplate
@@ -120,7 +137,7 @@ class CFSProductTypeTemplateForm(CFSProductTypeForm):
 
 
 class CFSProductTypeTemplateFormSetBase(forms.BaseInlineFormSet):
-    def get_form_kwargs(self, index):
+    def get_form_kwargs(self, index: int) -> dict[str, Any]:
         kwargs = super().get_form_kwargs(index)
 
         return kwargs | {"product": self.instance}
@@ -163,7 +180,7 @@ class CFSActiveIngredientTemplateForm(CFSActiveIngredientForm):
 
 
 class CFSActiveIngredientTemplateFormSetBase(forms.BaseInlineFormSet):
-    def get_form_kwargs(self, index):
+    def get_form_kwargs(self, index: int) -> dict[str, Any]:
         kwargs = super().get_form_kwargs(index)
 
         return kwargs | {"product": self.instance}

--- a/web/domains/cat/urls.py
+++ b/web/domains/cat/urls.py
@@ -58,6 +58,11 @@ urlpatterns = [
                     name="cfs-schedule-product-create",
                 ),
                 path(
+                    "cfs-schedule-product-create-multiple/",
+                    views.CFSScheduleTemplateProductCreateMultipleView.as_view(),
+                    name="cfs-schedule-product-create-multiple",
+                ),
+                path(
                     "cfs-schedule-product-update/<int:product_template_pk>/",
                     views.CFSScheduleTemplateProductUpdateView.as_view(),
                     name="cfs-schedule-product-update",

--- a/web/templates/forms/forms.html
+++ b/web/templates/forms/forms.html
@@ -42,3 +42,18 @@
     </div>
   {% endif %}
 {%- endmacro %}
+
+{% macro submit_button(padding_cols="three", field_cols="six", btn_label="Create") %}
+  <div class="row">
+    <div class="{{ padding_cols }} columns"></div>
+    <div class="{{ field_cols }} columns">
+      <ul class="menu-out flow-across">
+        <li>
+          <button type="submit" class="primary-button button">{{ btn_label }}</button>
+        </li>
+      </ul>
+    </div>
+    {# Required to ensure column padding works correctly. #}
+    <div class="zero columns"></div>
+  </div>
+{% endmacro %}

--- a/web/templates/web/domains/case/export/cfs-product-create-multiple.html
+++ b/web/templates/web/domains/case/export/cfs-product-create-multiple.html
@@ -1,0 +1,31 @@
+{% extends "web/domains/case/applicant-base.html" %}
+{% import "forms/fields.html" as fields %}
+
+
+{% block content_actions %}
+  <div class="content-actions">
+    <ul class="menu-out flow-across">
+      <li>
+        <a href="{{ previous_link }}" class="prev-link">Edit schedule</a>
+      </li>
+    </ul>
+  </div>
+{% endblock %}
+
+{% block main_content %}
+  <h4>{{ page_title }}</h4>
+  <sub>Add any products leaving unused extra rows blank.</sub>
+  {% call forms.form(action='', method='post', csrf_input=csrf_input) -%}
+    {{ formset.management_form }}
+    {% for form in formset %}
+        {{ form.id }}
+        <div class="row">
+          {{ fields.inline_field_with_label(form.product_name, prompt="north", label_cols='two', padding='zero', input_cols='four') }}
+          {% if form.instance.pk and formset.can_delete %}
+            {{ fields.inline_field_with_label(form.DELETE, prompt="north", show_optional_indicator=False, label_cols='zero', padding='zero', input_cols='one') }}
+          {% endif %}
+        </div>
+    {% endfor %}
+    {{ forms.submit_button(padding_cols="two") }}
+  {% endcall %}
+{% endblock %}

--- a/web/templates/web/domains/case/export/partials/cfs/schedule-products.html
+++ b/web/templates/web/domains/case/export/partials/cfs/schedule-products.html
@@ -45,4 +45,5 @@
 
 {% if not read_only %}
   <a href="{{ add_schedule_product_url }}" class="button small-button icon-plus">Add Product</a>
+  <a href="{{ add_multiple_schedule_product_url }}" class="button small-button icon-plus">Add Multiple Products</a>
 {% endif %}

--- a/web/templates/web/domains/cat/cfs/product-template-create-multiple.html
+++ b/web/templates/web/domains/cat/cfs/product-template-create-multiple.html
@@ -1,0 +1,40 @@
+{% extends "layout/sidebar.html" %}
+
+{% import "forms/forms.html" as forms %}
+{% import "forms/fields.html" as fields %}
+{% import "display/fields.html" as display %}
+
+{% block css %}
+{% endblock %}
+
+{% block content_actions %}
+  <div class="content-actions">
+    <ul class="menu-out flow-across">
+      <li>
+        <a href="{{ previous_link }}" class="prev-link">Edit schedule</a>
+      </li>
+    </ul>
+  </div>
+{% endblock %}
+
+{% block main_content %}
+  {% block main_content_intro %}{% endblock %}
+  <h4>{{ page_title }}</h4>
+  <sub>Add any products leaving unused extra rows blank.</sub>
+  {% call forms.form(method='post', csrf_input=csrf_input) -%}
+    {{ formset.management_form }}
+    {% for form in formset %}
+        {{ form.id }}
+        <div class="row">
+          {{ fields.inline_field_with_label(form.product_name, prompt="north", label_cols='two', padding='zero', input_cols='four') }}
+          {% if form.instance.pk and formset.can_delete %}
+            {{ fields.inline_field_with_label(form.DELETE, prompt="north", show_optional_indicator=False, label_cols='zero', padding='zero', input_cols='one') }}
+          {% endif %}
+        </div>
+    {% endfor %}
+    {{ forms.submit_button(padding_cols="two") }}
+  {% endcall %}
+{% endblock %}
+
+{% block page_js %}
+{% endblock %}

--- a/web/tests/domains/case/export/test_views.py
+++ b/web/tests/domains/case/export/test_views.py
@@ -1,4 +1,5 @@
 import re
+from http import HTTPStatus
 
 import pytest
 from django.urls import reverse, reverse_lazy
@@ -259,3 +260,69 @@ def test_edit_cfs_schedule_biocidal_claim_legislation_config(exporter_client, cf
     assert "legislation_config" in response.context
     legislation_config = response.context["legislation_config"]
     assert legislation_config[chosen_legislation.pk]["isBiocidalClaim"] is True
+
+
+class TestCFSScheduleProductCreateMultipleView(AuthTestCase):
+    @pytest.fixture(autouse=True)
+    def setup(self, _setup, cfs_app_in_progress):
+        self.application = cfs_app_in_progress
+        self.schedule = cfs_app_in_progress.schedules.first()
+
+        self.url = reverse(
+            "export:cfs-schedule-add-multiple-products",
+            kwargs={"application_pk": self.application.pk, "schedule_pk": self.schedule.pk},
+        )
+
+    def test_permission(self):
+        response = self.importer_client.get(self.url)
+        assert response.status_code == HTTPStatus.FORBIDDEN
+
+        response = self.exporter_client.get(self.url)
+        assert response.status_code == HTTPStatus.OK
+
+    def test_get(self):
+        response = self.exporter_client.get(self.url)
+        assert response.status_code == HTTPStatus.OK
+
+        context = response.context
+        assert context["formset"] is not None
+        assert context["page_title"] == "Add Products"
+        assert context["process"] == self.application
+        assert context["case_type"] == "export"
+
+    def test_post(self):
+        # The fixture already has a product
+        assert self.schedule.products.count() == 1
+
+        form_data = {
+            "products-TOTAL_FORMS": "5",
+            "products-INITIAL_FORMS": "0",
+            "products-MIN_NUM_FORMS": "0",
+            "products-MAX_NUM_FORMS": "1000",
+            "products-0-id": "",
+            "products-0-product_name": "Test product 1",
+            "products-1-id": "",
+            "products-1-product_name": "Test product 2",
+            "products-2-id": "",
+            "products-2-product_name": "Test product 3",
+            "products-3-id": "",
+            "products-3-product_name": "Test product 4",
+            "products-4-id": "",
+            "products-4-product_name": "Test product 5",
+        }
+
+        response = self.exporter_client.post(self.url, data=form_data)
+        assert response.status_code == HTTPStatus.FOUND
+
+        self.schedule.refresh_from_db()
+        assert self.schedule.products.count() == 6
+        assert list(self.schedule.products.all().values_list("product_name", flat=True)) == [
+            # The existing product.
+            "A Product",
+            # The new products.
+            "Test product 1",
+            "Test product 2",
+            "Test product 3",
+            "Test product 4",
+            "Test product 5",
+        ]

--- a/web/views/generic.py
+++ b/web/views/generic.py
@@ -1,0 +1,66 @@
+from typing import Any
+
+from django.core.exceptions import ImproperlyConfigured
+from django.db import models
+from django.forms.models import BaseInlineFormSet
+from django.http import HttpResponse, HttpResponseRedirect
+from django.shortcuts import redirect
+from django.views.generic import View
+from django.views.generic.detail import (
+    SingleObjectMixin,
+    SingleObjectTemplateResponseMixin,
+)
+
+from web.types import AuthenticatedHttpRequest
+
+
+class InlineFormsetView(SingleObjectTemplateResponseMixin, SingleObjectMixin, View):
+    """Generic view for inline formsets.
+
+    Notes:
+      - Parent model is loaded by SingleObjectMixin and is stored as self.object.
+      - Currently restricted to a single formset for simplicity but could be extended to support
+        multiple formsets.
+      - Formset available in template with context variable 'formset'.
+    """
+
+    formset_class: type[BaseInlineFormSet]
+    template_name: str
+    success_url: str | None
+    object: models.Model
+
+    def get(self, request: AuthenticatedHttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
+        self.object = self.get_object()
+
+        formset = self.get_formset()
+
+        return self.render_to_response(self.get_context_data(formset=formset))
+
+    def post(self, request: AuthenticatedHttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
+        self.object = self.get_object()
+
+        formset = self.get_formset()
+
+        if formset.is_valid():
+            return self.formset_valid(formset)
+        else:
+            return self.formset_invalid(formset)
+
+    def get_formset(self) -> BaseInlineFormSet:
+        kwargs = self.get_formset_kwargs()
+        return self.formset_class(self.request.POST or None, **kwargs)
+
+    def get_formset_kwargs(self) -> dict[str, Any]:
+        return {"instance": self.object}
+
+    def formset_valid(self, formset: BaseInlineFormSet) -> HttpResponseRedirect:
+        formset.save()
+        return redirect(self.get_success_url())
+
+    def formset_invalid(self, formset: BaseInlineFormSet) -> HttpResponse:
+        return self.render_to_response(self.get_context_data(formset=formset))
+
+    def get_success_url(self) -> str:
+        if not self.success_url:
+            raise ImproperlyConfigured("No URL to redirect to. Provide a success_url.")
+        return str(self.success_url)  # success_url may be lazy


### PR DESCRIPTION
Changes:
  - Add CFSScheduleProductCreateMultipleView view
  - Add CFSScheduleTemplateProductCreateMultipleView view.
  - Add reusable InlineFormsetView view.
  - Add unittests for new views.
  - Add submit_button form macro.
  - Add missing type hints to cfs views.

New button to add multiple products in both template editor and CFS application:
![image](https://github.com/uktrade/icms/assets/8921101/7d8abb6d-0f23-43a1-894a-8b122615e1c2)

New form in template editor to add multiple products:
![export-a-certificate_8080_cat_edit_2_schedule_template_1_cfs-schedule-product-create-multiple_](https://github.com/uktrade/icms/assets/8921101/3de8b5d4-1483-4e56-95d6-8ef170c23e8d)

New form in CFS application to add multiple products:
![export-a-certificate_8080_export_cfs_7_schedule_3_product_add-multiple_](https://github.com/uktrade/icms/assets/8921101/36c57e2e-9393-4577-9dfe-c3545952ac84)
