### PR TITLE
ICMSLST-2574 Add ILike db model lookup to improve wildcard filtering.

### DIFF
--- a/web/apps.py
+++ b/web/apps.py
@@ -3,3 +3,10 @@ from django.apps import AppConfig
 
 class WebConfig(AppConfig):
     name = "web"
+
+    def ready(self) -> None:
+        from django.db.models import Field
+
+        from web.models.lookups import ILike
+
+        Field.register_lookup(ILike)

--- a/web/models/lookups.py
+++ b/web/models/lookups.py
@@ -1,0 +1,21 @@
+from django.db.backends.postgresql.base import DatabaseWrapper
+from django.db.models import Lookup
+from django.db.models.sql.compiler import SQLCompiler
+
+
+class ILike(Lookup):
+    lookup_name = "ilike"
+
+    def as_sql(self, compiler: SQLCompiler, connection: DatabaseWrapper) -> tuple[str, list[str]]:
+        """ILIKE lookup to allow better wildcard searches.
+
+        Example usage:
+            ImportApplication.objects.filter(reference__ilike="IMA/%3/%3")
+        """
+
+        lhs, lhs_params = self.process_lhs(compiler, connection)
+        rhs, rhs_params = self.process_rhs(compiler, connection)
+
+        params = lhs_params + rhs_params
+
+        return f"{lhs} ILIKE {rhs}", params

--- a/web/tests/utils/search/test_search.py
+++ b/web/tests/utils/search/test_search.py
@@ -1046,6 +1046,7 @@ def test_export_returns_in_progress_applications(exporter_one_fixture_data: Expo
     ["case_ref_pattern", "should_match"],
     [
         ("wood/foo/0001", True),
+        ("wood/foo/0002", False),
         ("wood%", True),
         ("wood%0001", True),
         ("wood%oo%000%", True),
@@ -1053,8 +1054,10 @@ def test_export_returns_in_progress_applications(exporter_one_fixture_data: Expo
         ("WOOD%0001", True),
         ("WOOD%OO%000%", True),
         ("%foo/0001", True),
-        ("%wood", False),
-        ("%WOOD", False),
+        # wildcard_search now adds a % when not present so this row should match
+        ("%wood", True),
+        # wildcard_search now adds a % when not present so this row should match
+        ("%WOOD", True),
         ("foo/0001%", False),
     ],
 )

--- a/web/utils/search/api.py
+++ b/web/utils/search/api.py
@@ -150,7 +150,7 @@ def get_export_status_choices() -> list[tuple[Any, str]]:
 def get_wildcard_filter(field: str, search_pattern: str) -> models.Q:
     """Return the filter expression for the supplied field and search_pattern.
 
-    Strings with `%` are converted into django ORM code using one of several methods.
+    Uses the ilike lookup and adds a % to the end of the string if not in the search_pattern.
 
     :param field: The name of the field to search on
     :param search_pattern: the user supplied search pattern
@@ -159,20 +159,10 @@ def get_wildcard_filter(field: str, search_pattern: str) -> models.Q:
     if search_pattern.strip() == "%":
         return models.Q()
 
-    # The default search unless changed below
-    search_regex = search_pattern.replace("%", ".*")
-    search = {f"{field}__iregex": f"^{search_regex}"}
-    wildcards = search_pattern.count("%")
+    if not search_pattern.endswith("%"):
+        search_pattern += "%"
 
-    if wildcards == 0:
-        search = {f"{field}": search_pattern}
-
-    elif wildcards == 1:
-        if search_pattern.startswith("%"):
-            search = {f"{field}__iendswith": search_pattern[1:]}
-
-        elif search_pattern.endswith("%"):
-            search = {f"{field}__istartswith": search_pattern[:-1]}
+    search = {f"{field}__ilike": search_pattern}
 
     return models.Q(**search)
 


### PR DESCRIPTION
Search code now uses __ilike for all wildcard filtering and adds a "%" on to the end of search strings to improve search results.