### PR TITLE
ICMSLST-1260 - Firearms OIL - Application - Certificate Type field does not need drop-down list.

### DIFF
--- a/web/domains/case/_import/fa/forms.py
+++ b/web/domains/case/_import/fa/forms.py
@@ -100,3 +100,7 @@ class UserImportCertificateForm(forms.ModelForm):
             self.fields["certificate_type"].choices = (
                 UserImportCertificate.CertificateType.registered_as_choice(),
             )
+            self.fields["certificate_type"].initial = (
+                UserImportCertificate.CertificateType.registered.value
+            )
+            self.fields["certificate_type"].disabled = True

--- a/web/tests/domains/case/_import/fa_oil/test_forms.py
+++ b/web/tests/domains/case/_import/fa_oil/test_forms.py
@@ -1,5 +1,7 @@
 import pytest
 
+from web.domains.case._import.fa.forms import UserImportCertificateForm
+from web.domains.case._import.fa.models import UserImportCertificate
 from web.domains.case._import.fa_oil.forms import EditFaOILForm
 from web.models import Country
 from web.models.shared import FirearmCommodity
@@ -51,3 +53,13 @@ class TestOILForm(AuthTestCase):
 
         assert form.fields["consignment_country"].queryset.count() == 1
         assert form.fields["consignment_country"].queryset.get() == self.all_countries_object
+
+
+def test_user_import_certificate_form(fa_oil_app_in_progress):
+    form = UserImportCertificateForm(application=fa_oil_app_in_progress)
+    assert len(form.fields["certificate_type"].choices) == 1
+    assert (
+        form.fields["certificate_type"].initial
+        == UserImportCertificate.CertificateType.registered.value
+    )
+    assert form.fields["certificate_type"].disabled


### PR DESCRIPTION
Before:
<img width="1174" alt="image" src="https://github.com/uktrade/icms/assets/23667847/63c350f5-3bbc-41dc-9ea4-e7d8ee2ac368">


After:
<img width="1041" alt="image" src="https://github.com/uktrade/icms/assets/23667847/1502e28b-5d8e-4636-b795-b5cd1dd77ed5">
