### PR TITLE
ICMSLST-2598 Return a 403 status code when ProcessError is raised.

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -20,6 +20,10 @@ from django.urls import include, path
 
 from web.admin import icms_admin_site
 
+# Custom 403 handler to send process_error exceptions to sentry
+handler403 = "web.views.handler403_capture_process_error_view"
+
+
 urlpatterns = [
     #
     # Django Admin Site (superuser admin site)

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -4358,3 +4358,6 @@ email.</p4
 kwargs={"code
 Constabulary Contact Users
 "Load the form using query params
+ProcessError
+Custom 403
+UI

--- a/web/flow/errors.py
+++ b/web/flow/errors.py
@@ -1,4 +1,7 @@
-class ProcessError(Exception):
+from django.core.exceptions import PermissionDenied
+
+
+class ProcessError(PermissionDenied):
     pass
 
 

--- a/web/tests/domains/case/export/test_views.py
+++ b/web/tests/domains/case/export/test_views.py
@@ -232,8 +232,9 @@ class TestEditCom(AuthTestCase):
     def test_no_task(self):
         """Assert an application/flow requires an active task."""
         self.appl.tasks.all().delete()
-        with pytest.raises(Exception, match="prepare not in active task list"):
-            self.exporter_client.get(self.url)
+        response = self.exporter_client.get(self.url)
+
+        assert response.status_code == HTTPStatus.FORBIDDEN
 
 
 class TestSubmitCom(AuthTestCase):
@@ -268,8 +269,9 @@ class TestSubmitCom(AuthTestCase):
     def test_no_task(self):
         """Assert an application/flow requires an active task."""
         self.appl.tasks.all().delete()
-        with pytest.raises(Exception, match="prepare not in active task list"):
-            self.exporter_client.get(self.url)
+        response = self.exporter_client.get(self.url)
+
+        assert response.status_code == HTTPStatus.FORBIDDEN
 
 
 def test_create_csf_app_has_a_schedule(exporter_client, exporter, exporter_office):

--- a/web/tests/domains/case/views/test_views_misc.py
+++ b/web/tests/domains/case/views/test_views_misc.py
@@ -14,7 +14,6 @@ from web.domains.case.models import DocumentPackBase, WithdrawApplication
 from web.domains.case.services import case_progress, document_pack
 from web.domains.case.shared import ImpExpStatus
 from web.domains.case.views.views_misc import get_document_context
-from web.flow.errors import ProcessStateError
 from web.mail.constants import EmailTypes
 from web.mail.url_helpers import get_case_view_url, get_validate_digital_signatures_url
 from web.models import (
@@ -76,8 +75,8 @@ def test_take_ownership(ilb_admin_client: "Client", wood_app_submitted):
 
 def test_take_ownership_in_progress(ilb_admin_client: "Client", wood_app_in_progress):
     # Can't own an in progress application
-    with pytest.raises(ProcessStateError):
-        ilb_admin_client.post(CaseURLS.take_ownership(wood_app_in_progress.pk))
+    response = ilb_admin_client.post(CaseURLS.take_ownership(wood_app_in_progress.pk))
+    assert response.status_code == HTTPStatus.FORBIDDEN
 
 
 @pytest.mark.parametrize(

--- a/web/tests/domains/case/views/test_views_search.py
+++ b/web/tests/domains/case/views/test_views_search.py
@@ -13,7 +13,6 @@ from pytest_django.asserts import assertRedirects, assertTemplateUsed
 
 from web.domains.case.services import case_progress, document_pack
 from web.domains.case.shared import ImpExpStatus
-from web.flow import errors
 from web.mail.constants import EmailTypes
 from web.mail.url_helpers import get_case_view_url, get_validate_digital_signatures_url
 from web.models import (
@@ -315,10 +314,11 @@ class TestReopenApplicationViewImportApplication:
         self._check_valid_response(resp, self.wood_app)
 
     def test_reopen_application_when_processing_errors(self):
-        with pytest.raises(expected_exception=errors.ProcessStateError):
-            url = SearchURLS.reopen_case(application_pk=self.wood_app.pk)
-            self.client.post(url)
-            self._check_email_is_not_sent()
+        url = SearchURLS.reopen_case(application_pk=self.wood_app.pk)
+        response = self.client.post(url)
+        assert response.status_code == HTTPStatus.FORBIDDEN
+
+        self._check_email_is_not_sent()
 
     def test_reopen_application_unsets_caseworker(self, ilb_admin_user):
         self.wood_app.status = ImpExpStatus.STOPPED
@@ -414,10 +414,11 @@ class TestReopenApplicationViewExportApplication:
         self._check_valid_response(resp, self.app)
 
     def test_reopen_application_when_processing_errors(self):
-        with pytest.raises(expected_exception=errors.ProcessStateError):
-            url = SearchURLS.reopen_case(application_pk=self.app.pk)
-            self.client.post(url)
-            self._check_email_is_not_sent()
+        url = SearchURLS.reopen_case(application_pk=self.app.pk)
+        response = self.client.post(url)
+        assert response.status_code == HTTPStatus.FORBIDDEN
+
+        self._check_email_is_not_sent()
 
     def test_reopen_application_unsets_caseworker(self, ilb_admin_user):
         self.app.status = ImpExpStatus.STOPPED

--- a/web/utils/sentry.py
+++ b/web/utils/sentry.py
@@ -1,4 +1,5 @@
 import traceback
+from typing import Literal
 
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
@@ -21,14 +22,17 @@ def init_sentry(sentry_dsn: str, sentry_environment: str) -> None:
     sentry_initialized = True
 
 
-def capture_message(msg: str) -> None:
+def capture_message(
+    msg: str, level: Literal["fatal", "critical", "error", "warning", "info", "debug"] = "info"
+) -> None:
     """If Sentry is enabled, log the given message, otherwise print it to the console.
 
     :param msg: message to capture
+    :param level: message level
     """
 
     if sentry_initialized:
-        sentry_sdk.capture_message(msg)
+        sentry_sdk.capture_message(msg, level=level)
     else:
         print("Sentry::capture_message: %s" % msg)
 

--- a/web/views/__init__.py
+++ b/web/views/__init__.py
@@ -5,6 +5,7 @@ from .views import (
     ModelUpdateView,
     RedirectBaseDomainView,
     cookie_consent_view,
+    handler403_capture_process_error_view,
     home,
     login_start_view,
     logout_view,
@@ -22,4 +23,5 @@ __all__ = [
     "logout_view",
     "health_check",
     "cookie_consent_view",
+    "handler403_capture_process_error_view",
 ]


### PR DESCRIPTION
ProcessError is raised when a resource is accessed when it doesn't have the expected status or active task.
Returning a 403 instead of a 500 status code is more appropriate.