### PR TITLE
ICMSLST-2566 Several fixes relating to biocidal_claim field.

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -4361,3 +4361,5 @@ Constabulary Contact Users
 ProcessError
 Custom 403
 UI
+schedule.is_biocidal_claim
+Dummy 'Is Biocidal Claim

--- a/web/domains/case/app_copy.py
+++ b/web/domains/case/app_copy.py
@@ -7,8 +7,8 @@ from web.domains.case.export.forms import (
     CFSManufacturerDetailsForm,
     CFSProductForm,
     CFSProductTypeForm,
-    EditCFScheduleForm,
     EditCFSForm,
+    EditCFSScheduleForm,
     EditCOMForm,
     EditGMPForm,
 )
@@ -172,7 +172,7 @@ class CFSApplicationCopy(ApplicationCopy):
         for existing_schedule in self.existing.schedules.all():
             self.copy_schedule(
                 existing_schedule,
-                EditCFScheduleForm,
+                EditCFSScheduleForm,
                 CFSManufacturerDetailsForm,
                 CFSProductForm,
                 CFSProductTypeForm,
@@ -198,7 +198,7 @@ class CFSApplicationCopy(ApplicationCopy):
         for existing_schedule in self.existing.schedules.all():
             self.copy_schedule(
                 existing_schedule,
-                EditCFScheduleForm,
+                EditCFSScheduleForm,
                 CFSManufacturerDetailsForm,
                 CFSProductForm,
                 CFSProductTypeForm,
@@ -208,7 +208,7 @@ class CFSApplicationCopy(ApplicationCopy):
     def copy_schedule(
         self,
         existing_schedule: CFSSchedule | CFSScheduleTemplate,
-        edit_schedule_form: type[EditCFScheduleForm | CFSScheduleTemplateForm],
+        edit_schedule_form: type[EditCFSScheduleForm | CFSScheduleTemplateForm],
         manufacturer_details_form: type[
             CFSManufacturerDetailsForm | CFSManufacturerDetailsTemplateForm
         ],

--- a/web/domains/case/export/models/cfs_models.py
+++ b/web/domains/case/export/models/cfs_models.py
@@ -158,6 +158,9 @@ class CFSScheduleABC(models.Model):
     def is_biocidal(self) -> bool:
         return self.legislations.filter(is_biocidal=True).exists()
 
+    def is_biocidal_claim(self) -> bool:
+        return self.legislations.filter(is_biocidal_claim=True).exists()
+
 
 class CFSSchedule(CFSScheduleABC):
     application = models.ForeignKey(

--- a/web/domains/case/export/views.py
+++ b/web/domains/case/export/views.py
@@ -66,8 +66,8 @@ from .forms import (
     CFSProductFormSet,
     CFSProductTypeForm,
     CreateExportApplicationForm,
-    EditCFScheduleForm,
     EditCFSForm,
+    EditCFSScheduleForm,
     EditCOMForm,
     EditGMPForm,
     ProductsFileUploadForm,
@@ -414,7 +414,7 @@ def cfs_edit_schedule(
         )
 
         if request.method == "POST":
-            form = EditCFScheduleForm(data=request.POST, instance=schedule)
+            form = EditCFSScheduleForm(data=request.POST, instance=schedule)
 
             if form.is_valid():
                 form.save()
@@ -435,7 +435,7 @@ def cfs_edit_schedule(
                 form_kwargs["data"] = model_to_dict(schedule)
                 form = SubmitCFSScheduleForm(**form_kwargs)
             else:
-                form = EditCFScheduleForm(**form_kwargs)
+                form = EditCFSScheduleForm(**form_kwargs)
 
         schedule_legislations = schedule.legislations.filter(is_active=True)
 
@@ -452,6 +452,7 @@ def cfs_edit_schedule(
             "form": form,
             "case_type": "export",
             "is_biocidal": schedule.is_biocidal(),
+            "is_biocidal_claim": schedule.is_biocidal_claim(),
             "products": schedule.products.all().order_by("pk"),
             "product_upload_form": ProductsFileUploadForm(),
             "has_legislation": schedule_legislations.exists(),

--- a/web/domains/cat/forms.py
+++ b/web/domains/cat/forms.py
@@ -10,8 +10,8 @@ from web.domains.case.export.forms import (
     CFSManufacturerDetailsForm,
     CFSProductForm,
     CFSProductTypeForm,
-    EditCFScheduleForm,
     EditCFSForm,
+    EditCFSScheduleForm,
     EditCOMForm,
     EditGMPForm,
 )
@@ -148,11 +148,11 @@ class CertificateOfFreeSaleApplicationTemplateForm(EditCFSForm):
         widgets = EditCFSForm.Meta.widgets
 
 
-class CFSScheduleTemplateForm(EditCFScheduleForm):
+class CFSScheduleTemplateForm(EditCFSScheduleForm):
     class Meta:
         model = CFSScheduleTemplate
-        fields = copy_form_fields(EditCFScheduleForm.Meta.fields)
-        widgets = EditCFScheduleForm.Meta.widgets
+        fields = copy_form_fields(EditCFSScheduleForm.Meta.fields)
+        widgets = EditCFSScheduleForm.Meta.widgets
 
     def get_legislations_queryset(self) -> QuerySet[ProductLegislation]:
         legislation_qs = ProductLegislation.objects.filter(is_active=True)

--- a/web/domains/cat/views.py
+++ b/web/domains/cat/views.py
@@ -303,6 +303,7 @@ class CATEditView(PermissionRequiredMixin, LoginRequiredMixin, UserPassesTestMix
 
                 # Products section context
                 extra["is_biocidal"] = schedule.is_biocidal()
+                extra["is_biocidal_claim"] = schedule.is_biocidal_claim()
                 extra["products"] = schedule.products.all().order_by("pk")
                 extra["product_upload_form"] = ProductsFileUploadForm()
                 extra["has_legislation"] = schedule.legislations.filter(is_active=True).exists()

--- a/web/management/commands/add_dummy_data.py
+++ b/web/management/commands/add_dummy_data.py
@@ -424,6 +424,11 @@ class Command(BaseCommand):
             ]
         )
 
+        # Add a dummy biocidal_claim legislation (defaults to GB and NI legislation)
+        ProductLegislation.objects.create(
+            name="Dummy 'Is Biocidal Claim legislation'", is_biocidal_claim=True
+        )
+
     def create_user(
         self,
         username: str,

--- a/web/management/commands/add_test_data.py
+++ b/web/management/commands/add_test_data.py
@@ -19,6 +19,7 @@ from web.models import (
     ObsoleteCalibre,
     ObsoleteCalibreGroup,
     Office,
+    ProductLegislation,
     Signature,
     Task,
     User,
@@ -97,6 +98,11 @@ class Command(BaseCommand):
 
         group = ObsoleteCalibreGroup.objects.create(name="Group 1", order=1)
         ObsoleteCalibre.objects.create(calibre_group=group, name="9mm", order=1)
+
+        # Add a dummy biocidal_claim legislation (defaults to GB and NI legislation)
+        ProductLegislation.objects.create(
+            name="Dummy 'Is Biocidal Claim legislation'", is_biocidal_claim=True
+        )
 
     def create_test_importers(self) -> None:
         for imp in TEST_IMPORTERS:

--- a/web/static/web/js/pages/cfs-schedule-edit.js
+++ b/web/static/web/js/pages/cfs-schedule-edit.js
@@ -1,4 +1,4 @@
-window.addEventListener('load', (event) => {
+window.addEventListener('DOMContentLoaded', (event) => {
   const selectedProductRawMaterial = getCheckedRadioValue("any_raw_materials");
   setEndUse(selectedProductRawMaterial);
 
@@ -8,9 +8,6 @@ window.addEventListener('load', (event) => {
   const exportRadios = getRadioElements("goods_export_only");
 
   const events = new EditScheduleEventHandler(legislationSelect2);
-
-  // Show-hiding the is-biocidal-claim question on page load
-  showIsBiocidalClaim(events.legislationSelect2.val(), events.legislationConfig);
 
   // Setup listeners
   productRawMaterialRadios.forEach(

--- a/web/templates/web/domains/case/export/cfs-view.html
+++ b/web/templates/web/domains/case/export/cfs-view.html
@@ -39,7 +39,7 @@
       {{ application_field(schedule.get_exporter_status_display(), labels["exporter_status"]) }}
       {{ application_field(schedule.get_brand_name_holder_display(), labels["brand_name_holder"]) }}
       {{ application_field(schedule_legislation_names|join("\n"), labels["legislations"]) }}
-      {% if schedule.biocidal_claim %}
+      {% if schedule.is_biocidal_claim() and schedule.biocidal_claim %}
         {{ application_field(schedule.get_biocidal_claim_display(), labels["biocidal_claim"]) }}
       {% endif %}
       {{ application_field(schedule.get_product_eligibility_display(), labels["product_eligibility"]) }}

--- a/web/templates/web/domains/case/export/partials/cfs/edit-schedule-form-content.html
+++ b/web/templates/web/domains/case/export/partials/cfs/edit-schedule-form-content.html
@@ -2,7 +2,7 @@
 {{ fields.field(form.exporter_status, tooltip_msg_id="manufacturer-guidance-tooltip") }}
 {{ fields.field(form.brand_name_holder) }}
 {{ fields.field(form.legislations) }}
-<div id="biocidal-claim-question-wrapper" {% if not is_biocidal %} style="display: none;"{% endif %}>
+<div id="biocidal-claim-question-wrapper" {% if not is_biocidal_claim %} style="display: none;"{% endif %}>
   {{ fields.field(form.biocidal_claim, mark_safe=True, show_optional_indicator=False) }}
 </div>
 {{ fields.field(form.product_eligibility) }}

--- a/web/tests/domains/legislation/test_forms.py
+++ b/web/tests/domains/legislation/test_forms.py
@@ -46,15 +46,15 @@ class TestProductLegislationFilter(TestCase):
 
     def test_name_filter(self):
         results = self.run_filter({"name": "legislation"})
-        assert results.count() == 3
+        assert results.count() == 4
 
     def test_biocidal_filter(self):
         results = self.run_filter({"is_biocidal": False})
-        assert results.count() == 25
+        assert results.count() == 26
 
     def test_biocidal_claim_filter(self):
         results = self.run_filter({"is_biocidal_claim": True})
-        assert results.count() == 1
+        assert results.count() == 2
 
         # Check the test legislation is in the results
         results = results.filter(name="Test Legislation")
@@ -67,11 +67,11 @@ class TestProductLegislationFilter(TestCase):
 
     def test_status_filter(self):
         results = self.run_filter({"status": True})
-        assert results.count() == 27
+        assert results.count() == 28
 
     def test_filter_order(self):
         results = self.run_filter({"name": "legislation"})
-        assert results.count() == 3
+        assert results.count() == 4
         first = results.first()
         last = results.last()
         assert first.name == "Comprehensive legislation"

--- a/web/tests/domains/legislation/test_views.py
+++ b/web/tests/domains/legislation/test_views.py
@@ -31,7 +31,7 @@ class TestProductLegislationListView(AuthTestCase):
     def test_number_of_results(self):
         response = self.ilb_admin_client.get(self.url, {"name": ""})
         results = response.context_data["results"]
-        assert results.count() == 26
+        assert results.count() == 27
 
 
 class TestProductLegislationCreateView(AuthTestCase):


### PR DESCRIPTION
Changes:
  - Add is_biocidal_claim method to CFSScheduleABC.
  - Display biocidal_claim field in template based on is_biocidal_claim.
  - Add is_biocidal_claim context to cfs schedule edit and template view.
  - Remove showIsBiocidalClaim call on page load.
  - Update cfs-view.html to check is_biocidal_claim() before showing value.
  - Remove "--------" option from biocidal_claim choices.
  - Move clean logic to submit form rather than edit form.
  - Clear biocidal_claim value when no biocidal_claim legislations are selected.
  - Add dummy and test ProductLegislation record.
  - Rename EditCFScheduleForm to EditCFSScheduleForm.
 

Before:
![image](https://github.com/uktrade/icms/assets/8921101/063862bc-1fd0-4659-a6bb-e2e9f704c55f)

After:
![image](https://github.com/uktrade/icms/assets/8921101/0a5e15c7-3621-412d-96dd-3e78f9112a20)


Submit screen checking value is set (when required):
![image](https://github.com/uktrade/icms/assets/8921101/24765eb1-28a2-4bdb-a97d-370459f5fc0e)

Edit screen showing field is required (after clicking link on Schedule 1 screen)
![image](https://github.com/uktrade/icms/assets/8921101/417d117e-8519-438f-ab0b-e0db5b49633a)
