### PR TITLE
ICMSLST-2639 Data migration logging improvements

### DIFF
--- a/data_migration/management/commands/_base.py
+++ b/data_migration/management/commands/_base.py
@@ -71,7 +71,10 @@ class MigrationBaseCommand(BaseCommand):
 
     def _log_time(self) -> None:
         time_taken = tm.perf_counter() - self.split_time
-        self.log(f"\t\t--> {time_taken:.2f} seconds", "\n\n")
+        if time_taken // 60 > 0:
+            self.log(f"\t\t--> {time_taken // 60} mins {time_taken % 60} seconds", "\n\n")
+        else:
+            self.log(f"\t\t--> {time_taken:.2f} seconds", "\n\n")
         self.split_time = tm.perf_counter()
 
     def _log_script_end(self) -> None:

--- a/data_migration/management/commands/export_from_v1.py
+++ b/data_migration/management/commands/export_from_v1.py
@@ -1,4 +1,5 @@
 import argparse
+import time as tm
 from typing import TYPE_CHECKING
 
 import oracledb
@@ -80,6 +81,8 @@ class Command(MigrationBaseCommand):
                 f"\t{idx} - Exporting {query_model.query_name} to {query_model.model.__name__} model"
             )
 
+            export_start_time = tm.perf_counter()
+
             # Create a new cursor for each query
             # oracledb sometimes throws `IndexError: list index out of range` when reusing cursor
             with connection.cursor() as cursor:
@@ -92,6 +95,10 @@ class Command(MigrationBaseCommand):
                         break
 
                     self._export_model_data(columns, rows, query_model.model)
+
+                    if export_start_time - tm.perf_counter() >= 60:
+                        self.log(f"\t\t {cursor.rowcount} records added..")
+                        export_start_time = tm.perf_counter()
 
             self._log_time()
 


### PR DESCRIPTION
Connection in dbt platform will timeout if nothing is printed to stdout in 10 mins. Making sure a record count is printed every minute so that it doesn't time out on long running queries.