### PR TITLE
ICMSLST-2641 Data Migration - Fix import licence query

### DIFF
--- a/data_migration/management/commands/_base.py
+++ b/data_migration/management/commands/_base.py
@@ -72,7 +72,7 @@ class MigrationBaseCommand(BaseCommand):
     def _log_time(self) -> None:
         time_taken = tm.perf_counter() - self.split_time
         if time_taken // 60 > 0:
-            self.log(f"\t\t--> {time_taken // 60} mins {time_taken % 60} seconds", "\n\n")
+            self.log(f"\t\t--> {time_taken // 60:.0f} mins {time_taken % 60:.0f} seconds", "\n\n")
         else:
             self.log(f"\t\t--> {time_taken:.2f} seconds", "\n\n")
         self.split_time = tm.perf_counter()

--- a/data_migration/management/commands/export_from_v1.py
+++ b/data_migration/management/commands/export_from_v1.py
@@ -96,7 +96,7 @@ class Command(MigrationBaseCommand):
 
                     self._export_model_data(columns, rows, query_model.model)
 
-                    if export_start_time - tm.perf_counter() >= 60:
+                    if tm.perf_counter() - export_start_time >= 60:
                         self.log(f"\t\t {cursor.rowcount} records added..")
                         export_start_time = tm.perf_counter()
 

--- a/data_migration/queries/import_application/licence.py
+++ b/data_migration/queries/import_application/licence.py
@@ -30,12 +30,11 @@ FROM impmgr.ima_responses ir
   INNER JOIN impmgr.xview_ima_details xiad ON xiad.ima_id = ia.id AND xiad.status_control = 'C'
   INNER JOIN impmgr.import_application_details iad ON iad.id = xiad.imad_id
   LEFT JOIN decmgr.xview_document_packs dp ON dp.ds_id = ird.ds_id
-  CROSS JOIN XMLTABLE(
-    '/IMA/APP_PROCESSING/REVOKE'
+  CROSS JOIN XMLTABLE('/*'
     PASSING iad.xml_data
     COLUMNS
-      revoke_email_sent VARCHAR2(20) PATH './EMAIL_FLAG/text()'
-      , revoke_reason CLOB PATH './REASON/text()'
+      revoke_email_sent VARCHAR2(20) PATH '/IMA/APP_PROCESSING/REVOKE/EMAIL_FLAG/text()'
+      , revoke_reason CLOB PATH '/IMA/APP_PROCESSING/REVOKE/REASON/text()'
   ) x
 WHERE ir.response_type LIKE '%_LICENCE'
 ORDER BY ird.id


### PR DESCRIPTION
The cross join in the query was filtering to only licences that had been revoked. Change the cross join to not join on the revoke element of the xml and instead the root element.