### PR TITLE
ICMSLST-2626 - Rejected withdrawals are not being updated in the status. There is no way to reject a withdrawal

### DIFF
--- a/web/static/web/js/pages/withdrawals.js
+++ b/web/static/web/js/pages/withdrawals.js
@@ -5,9 +5,9 @@ window.addEventListener("load", function (event) {
 
   // The div row containing the response field
   const showResponse = UTILS.getShowElementFunc("div.row_id_response");
-  showResponse(status.value === "rejected");
+  showResponse(status.value === "REJECTED");
 
   status.addEventListener("change", function (e) {
-    showResponse(e.target.value === "rejected");
+    showResponse(e.target.value === "REJECTED");
   });
 });


### PR DESCRIPTION
Response box was not being shown due to JS not matching `rejected===REJECTED`