### PR TITLE
ICMSLST-2444 Data Migration - Sanctions Tests and Fixes

### DIFF
--- a/data_migration/management/commands/config/data_counts.py
+++ b/data_migration/management/commands/config/data_counts.py
@@ -90,6 +90,12 @@ CHECK_DATA_COUNTS: list[CheckCount] = [
         model=web.DFLApplication,
         filter_params={"submit_datetime__isnull": False, "constabulary_id__isnull": True},
     ),
+    CheckCount(
+        name="All Submitted Sanctions Applications Have Goods",
+        expected_count=0,
+        model=web.SanctionsAndAdhocApplication,
+        filter_params={"submit_datetime__isnull": False, "sanctions_goods__isnull": True},
+    ),
 ]
 
 
@@ -344,6 +350,9 @@ CHECK_DATA_QUERIES: list[CheckQuery] = [
         query=queries.fa_authority_quantity_count,
         model=web.ClauseQuantity,
         bind_vars={"AUTHORITY_TYPE": "SECTION5"},
+    ),
+    CheckQuery(
+        name="Sanctions Emails", query=queries.sanctions_email_count, model=web.SanctionEmail
     ),
     CheckQuery(
         name="CFS Products",

--- a/data_migration/queries/data_counts.py
+++ b/data_migration/queries/data_counts.py
@@ -152,3 +152,10 @@ COLUMNS
 WHERE ad.status_control = 'C'
 AND x.status <> 'DRAFT'
 """
+
+sanctions_email_count = """
+SELECT COUNT(*)
+FROM impmgr.saction_email_details
+WHERE sanction_email_id <> 1
+AND status_control = 'C'
+"""

--- a/data_migration/queries/import_application/sanctions.py
+++ b/data_migration/queries/import_application/sanctions.py
@@ -9,7 +9,6 @@ SELECT
   , xiad.submitted_datetime submit_datetime
   , xiad.response_decision decision
   , xiad.refuse_reason
-  , xiad.applicant_reference
   , ia.created_datetime create_datetime
   , ia.created_datetime created
   , xiad.variation_no
@@ -48,7 +47,8 @@ FROM impmgr.import_application_details ad
 CROSS JOIN XMLTABLE('/*'
   PASSING ad.xml_data
   COLUMNS
-    exporter_name VARCHAR2(4000) PATH '/IMA/APP_DETAILS/ADHOC_DETAILS/EXPORTER_NAME/text()'
+    applicant_reference VARCHAR2(4000) PATH '/IMA/APP_DETAILS/ADHOC_DETAILS/APPLICANT_REFERENCE/text()'
+    , exporter_name VARCHAR2(4000) PATH '/IMA/APP_DETAILS/ADHOC_DETAILS/EXPORTER_NAME/text()'
     , exporter_address VARCHAR2(4000) PATH '/IMA/APP_DETAILS/ADHOC_DETAILS/EXPORTER_ADDRESS/text()'
     , commodities_xml XMLTYPE PATH '/IMA/APP_DETAILS/ADHOC_DETAILS/COMMODITY_LIST'
     , sanction_emails_xml XMLTYPE PATH '/IMA/APP_PROCESSING/SANCTION_EMAIL_MASTER/SANCTION_EMAIL_LIST'

--- a/data_migration/tests/test_e2e_inactive.py
+++ b/data_migration/tests/test_e2e_inactive.py
@@ -395,19 +395,20 @@ def test_import_sps_data(mock_connect, dummy_dm_settings):
     san = web.SanctionsAndAdhocApplication.objects.first()
     assert san.exporter_name == "Test Exporter"
     assert san.exporter_address == "123 Somewhere"
-    assert web.SanctionsAndAdhocApplicationGoods.objects.count() == 2
-    sg1, sg2 = web.SanctionsAndAdhocApplicationGoods.objects.order_by("pk")
-    assert sg1.goods_description == "Nice things"
-    assert sg1.import_application_id == san.id
-    assert sg1.quantity_amount == 3.00
-    assert sg1.value == 75
-    assert sg1.commodity_id == 1
 
-    assert sg2.goods_description == "More nice things"
+    assert san.sanctions_goods.count() == 2
+    sg1, sg2 = san.sanctions_goods.order_by("pk")
+    assert sg1.goods_description == "More nice things"
+    assert sg1.import_application_id == san.id
+    assert sg1.quantity_amount == 1.00
+    assert sg1.value == 100
+    assert sg1.commodity_id == 2
+
+    assert sg2.goods_description == "Nice things"
     assert sg2.import_application_id == san.id
-    assert sg2.quantity_amount == 1.00
-    assert sg2.value == 100
-    assert sg2.commodity_id == 2
+    assert sg2.quantity_amount == 3.00
+    assert sg2.value == 75
+    assert sg2.commodity_id == 1
 
 
 tex_data_source_target = {

--- a/data_migration/tests/test_xml_parser.py
+++ b/data_migration/tests/test_xml_parser.py
@@ -271,16 +271,16 @@ def test_sanction_goods_parser():
     g1, g2 = goods
 
     assert g1.import_application_id == 1
-    assert g1.commodity_id == 1
-    assert g1.goods_description == "GOODS"
-    assert g1.quantity_amount == Decimal("5.000")
-    assert g1.value == Decimal("100.00")
+    assert g1.commodity_id == 2
+    assert g1.goods_description == "MORE"
+    assert g1.quantity_amount == Decimal("10.000")
+    assert g1.value == Decimal("40.23")
 
     assert g2.import_application_id == 1
-    assert g2.commodity_id == 2
-    assert g2.goods_description == "MORE"
-    assert g2.quantity_amount == Decimal("10.000")
-    assert g2.value == Decimal("40.23")
+    assert g2.commodity_id == 1
+    assert g2.goods_description == "GOODS"
+    assert g2.quantity_amount == Decimal("5.000")
+    assert g2.value == Decimal("100.00")
 
 
 @pytest.mark.parametrize(

--- a/data_migration/utils/xml_parser/import_application.py
+++ b/data_migration/utils/xml_parser/import_application.py
@@ -941,6 +941,7 @@ class SanctionGoodsParser(BaseXmlParser):
     PARENT = dm.SanctionsAndAdhocApplication
     FIELD = "commodities_xml"
     ROOT_NODE = "/COMMODITY_LIST/COMMODITY"
+    REVERSE_LIST = True
 
     @classmethod
     def parse_xml_fields(

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -4417,3 +4417,4 @@ Provide Supplementary Report
 tooltip_msg_id
 Select Countries
 SUBMITTED
+All Submitted Sanctions Applications Have Goods


### PR DESCRIPTION
- Add post migration checks to check all sanctions apps have sanctions goods and that no sanctions emails have been added (currently none to migrate)
- Reverse order of sanctions goods on the sanctions applications
- Fix query to pull data for applicant's reference correctly