### PR TITLE
ICMSLST-2593 - New view that maps V1 checker onto V2

### DIFF
--- a/web/domains/checker/views.py
+++ b/web/domains/checker/views.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from django.http import HttpResponse
 from django.utils.decorators import method_decorator
-from django.views.generic import FormView
+from django.views.generic import FormView, RedirectView
 from django_ratelimit.decorators import ratelimit
 
 from web.flow.models import ProcessTypes
@@ -117,3 +117,9 @@ class CheckCertificateView(FormView):
         return self.render_to_response(
             self.get_context_data(form=form, warning_message="You must enter all details.")
         )
+
+
+class V1ToV2RedirectCheckCertificateView(RedirectView):
+    query_string = True
+    permanent = True
+    pattern_name = "checker:certificate-checker"

--- a/web/tests/domains/checker/test_views.py
+++ b/web/tests/domains/checker/test_views.py
@@ -374,3 +374,9 @@ def test_check_cfs_revoked_certifcate(mock_presign_url, exp_client, completed_cf
     assert f'<td id="certificate-issue-date">{issue_date}</td>' in content
     assert '<td id="certificate-status">Revoked</td>' in content
     assert '<td id="certificate-document"></td>' in content
+
+
+def test_v1_to_v2_redirect(exp_client):
+    response = exp_client.get("/icms/fox/icms/IMP_CERT_CERTIFICATE_CHECKER/check/")
+    assert response.status_code == HTTPStatus.MOVED_PERMANENTLY
+    assert response.url == reverse("checker:certificate-checker")

--- a/web/urls.py
+++ b/web/urls.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.urls import include, path, register_converter
 
 from web import converters
+from web.domains.checker.views import V1ToV2RedirectCheckCertificateView
 from web.registration.views import LegacyAccountRecoveryView
 from web.views import (
     LoginRequiredSelect2AutoResponseView,
@@ -78,6 +79,11 @@ urlpatterns = [
     ),
     # Cookie consent URLs
     path("cookie-consent/", cookie_consent_view, name="cookie-consent"),
+    # V1->V2 certificate checker
+    path(
+        "icms/fox/icms/IMP_CERT_CERTIFICATE_CHECKER/check/",
+        V1ToV2RedirectCheckCertificateView.as_view(),
+    ),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
The /check URL already maps to the V2 view so we might as well keep it that way. Just adding a new view to redirect users who have bookmarked the full checker URL