### PR TITLE
ICMSLST-2652 Supplementary Report fixes.

### DIFF
--- a/web/domains/case/_import/fa/urls.py
+++ b/web/domains/case/_import/fa/urls.py
@@ -115,6 +115,11 @@ urlpatterns = [
                             path("", views.provide_report, name="provide-report"),
                             path("repoen/", views.reopen_report, name="reopen-report"),
                             path(
+                                "view/",
+                                views.ViewFirearmsReportDetailView.as_view(),
+                                name="view-report",
+                            ),
+                            path(
                                 "create/",
                                 views.create_report,
                                 name="create-report",

--- a/web/templates/web/domains/case/import/fa/provide-report/report-info.html
+++ b/web/templates/web/domains/case/import/fa/provide-report/report-info.html
@@ -17,33 +17,32 @@
 
 {% block main_content %}
   {% if process.supplementary_info.is_complete %}
-    <div class="info-box info-box-info">
-      Use the Reopen button if you have more information to report on this application.
-    </div>
-
-    {% call forms.form(
-      action=icms_url('import:fa:reopen-report', kwargs={'application_pk': process.pk}),
-      method="post",
-      csrf_input=csrf_input,
-      id="id-reopen_report") -%}
-      <button type="submit" class="secondary-button button" for="id-reopen_report">
-        Reopen
-      </button>
-    {% endcall %}
+    {% if not ilb_read_only|default(False) %}
+      <div class="info-box info-box-info">
+        Use the Reopen button if you have more information to report on this application.
+      </div>
+      {% call forms.form(
+        action=icms_url('import:fa:reopen-report', kwargs={'application_pk': process.pk}),
+        method="post",
+        csrf_input=csrf_input,
+        id="id-reopen_report") -%}
+        <button type="submit" class="secondary-button button" for="id-reopen_report">
+          Reopen
+        </button>
+      {% endcall %}
+    {% endif %}
     <div class="section-break"></div>
   {% endif %}
 
   <h3>Details of who bought from</h3>
-  {% with can_delete = True, read_only = process.supplementary_info.is_complete %}
+  {% with can_delete = True, read_only = process.supplementary_info.is_complete or ilb_read_only|default(False) %}
     {% include "partial/import-contacts/list.html" %}
   {% endwith %}
 
-  {% with reports = process.supplementary_info.reports.all(), read_only = process.supplementary_info.is_complete or not process.importcontact_set.exists() %}
+  {% with reports = process.supplementary_info.reports.all(), read_only = process.supplementary_info.is_complete or not process.importcontact_set.exists() or ilb_read_only|default(False) %}
     {% include "web/domains/case/import/fa/partials/report-list.html" %}
   {% endwith %}
 
-  <div class="section-break"></div>
-  <h3>Complete Supplementary Reporting</h3>
   <div class="section-break"></div>
 
   {% if process.supplementary_info.is_complete %}
@@ -57,16 +56,20 @@
 
     {{ application_field(process.supplementary_info.completed_by, "Report Completed By") }}
     {{ application_field(process.supplementary_info.completed_datetime.strftime('%d-%b-%Y'), "Date Reporting Completed") }}
-  {% endif %}
-    {% call forms.form(action='', method='post', csrf_input=csrf_input) -%}
-      <div class="modal-popover-container hidden">
-        <div class="modal-popover regular-popover" tabindex="0">
-          <div class="modal-popover-content">
-            <h2 id="engine-modal-popover-title">Complete Supplementary Reporting Information</h2>
-            <p>
-              You should only complete reporting if you have provided the details of who you bought
-              the items from and goods that will be imported against this licence. Do you want to complete reporting?
-            </p>
+
+  {% else %}
+    {% if not ilb_read_only|default(False) %}
+      <h3>Complete Supplementary Reporting</h3>
+      <div class="section-break"></div>
+      {% call forms.form(action='', method='post', csrf_input=csrf_input) -%}
+        <div class="modal-popover-container hidden">
+          <div class="modal-popover regular-popover" tabindex="0">
+            <div class="modal-popover-content">
+              <h2 id="engine-modal-popover-title">Complete Supplementary Reporting Information</h2>
+              <p>
+                You should only complete reporting if you have provided the details of who you bought
+                the items from and goods that will be imported against this licence. Do you want to complete reporting?
+              </p>
               <ul class="menu-out modal-popover-actions flow-across">
                 <li>
                   <button type="submit" class="primary-button button">
@@ -79,15 +82,16 @@
                   </button>
                 </li>
               </ul>
+            </div>
           </div>
         </div>
-      </div>
-      {% if not process.supplementary_info.reports.exists() and not contacts %}
-        {{ fields.field(form.no_report_reason) }}
-      {% endif %}
-    {%- endcall %}
-
-    <button type="button" onclick="$('.modal-popover-container').show()" class="button primary-button">
-      Confirm Reporting Complete
-    </button>
+        {% if not process.supplementary_info.reports.exists() and not contacts %}
+          {{ fields.field(form.no_report_reason) }}
+        {% endif %}
+      {%- endcall %}
+      <button type="button" onclick="$('.modal-popover-container').show()" class="button primary-button">
+        Confirm Reporting Complete
+      </button>
+    {% endif %}
+  {% endif %}
 {% endblock %}

--- a/web/templates/web/domains/case/view_case.html
+++ b/web/templates/web/domains/case/view_case.html
@@ -24,10 +24,15 @@
           {{ icms_link(request, icms_url('case:applicant-case-history', kwargs={'application_pk': process.pk, 'case_type': case_type}), response_label ) }}
         {% endif %}
       {% endif %}
-
       {% if process.status in ["COMPLETED", "REVOKED"] %}
-        {% if process.application_type.type == "FA" and process.decision == process.APPROVE and user_obj_perms.can_edit_application(process) %}
-          {{ icms_link(request, icms_url('import:fa:provide-report', kwargs={'application_pk': process.pk}), 'Firearms Supplementary Information') }}
+        {% if process.application_type.type == "FA" and process.decision == process.APPROVE %}
+          {# Applicant link (they have edit access) #}
+          {% if user_obj_perms.can_edit_application(process) %}
+            {{ icms_link(request, icms_url('import:fa:provide-report', kwargs={'application_pk': process.pk}), 'Firearms Supplementary Information') }}
+          {# Readonly ILB Admin link #}
+          {% elif "web.ilb_admin" in perms %}
+            {{ icms_link(request, icms_url('import:fa:view-report', kwargs={'application_pk': process.pk}), 'Firearms Supplementary Information') }}
+          {% endif %}
         {% endif %}
       {% endif %}
 

--- a/web/tests/helpers.py
+++ b/web/tests/helpers.py
@@ -601,6 +601,11 @@ class CaseURLS:
         return reverse("import:fa:provide-report", kwargs=kwargs)
 
     @staticmethod
+    def fa_view_report(application_pk: int) -> str:
+        kwargs = {"application_pk": application_pk}
+        return reverse("import:fa:view-report", kwargs=kwargs)
+
+    @staticmethod
     def download_dfl_case_documents(code: str) -> str:
         return reverse("case:download-dfl-case-documents", kwargs={"code": code})
 

--- a/web/tests/utils/search/test_search_actions.py
+++ b/web/tests/utils/search/test_search_actions.py
@@ -11,6 +11,7 @@ from web.models import (
     ImportApplication,
     ImportApplicationLicence,
     SILApplication,
+    SILSupplementaryInfo,
     WoodQuotaApplication,
 )
 from web.utils.search import types, utils
@@ -22,6 +23,19 @@ from web.utils.search.actions import (
 _st = ImpExpStatus
 _future_date = dt.date(dt.date.today().year + 1, 1, 1)
 _past_date = dt.date(dt.date.today().year - 1, 1, 1)
+
+
+def get_sil_application(*, supplementary_report_compete: bool) -> SILApplication:
+    application = SILApplication(
+        status=_st.COMPLETED,
+        decision=SILApplication.APPROVE,
+        application_type=ImportApplicationType(type="FA", sub_type="SIL"),
+    )
+
+    application.supplementary_info = SILSupplementaryInfo(import_application=application)
+    application.supplementary_info.is_complete = supplementary_report_compete
+
+    return application
 
 
 test_import_arg_values = [
@@ -47,14 +61,16 @@ test_import_arg_values = [
         [],
     ),
     (
-        SILApplication(
-            status=_st.COMPLETED,
-            decision=SILApplication.APPROVE,
-            application_type=ImportApplicationType(type="FA", sub_type="SIL"),
-        ),
+        get_sil_application(supplementary_report_compete=False),
         ImportApplicationLicence(licence_end_date=_future_date),
-        ["Request Variation", "Revoke Licence", "Provide Supplementary Report"],
+        ["Request Variation", "Revoke Licence"],
         ["Request Variation", "Provide Supplementary Report"],
+    ),
+    (
+        get_sil_application(supplementary_report_compete=True),
+        ImportApplicationLicence(licence_end_date=_future_date),
+        ["Request Variation", "Revoke Licence"],
+        ["Request Variation"],
     ),
 ]
 

--- a/web/utils/search/actions.py
+++ b/web/utils/search/actions.py
@@ -110,7 +110,8 @@ class ProvideSupplementaryReportAction(ActionProtocol):
             app.status in [ImpExpStatus.COMPLETED, ImpExpStatus.REVOKED]
             and app.decision == app.APPROVE
             and app.application_type.type == "FA"
-            and _can_edit_org_or_agent(app, uop)
+            and _can_edit_org_or_agent(app, uop, include_ilb_admin=False)
+            and not app.supplementary_info.is_complete
         )
 
     @staticmethod
@@ -320,7 +321,9 @@ class ReopenExportCaseAction(ActionProtocol):
         )
 
 
-def _can_edit_org_or_agent(app: ImpOrExp, uop: UserOrganisationPermissions) -> bool:
+def _can_edit_org_or_agent(
+    app: ImpOrExp, uop: UserOrganisationPermissions, *, include_ilb_admin: bool = True
+) -> bool:
     """Return true if the uop user can edit the org / agent of the supplied application.
 
     Notes:
@@ -345,7 +348,7 @@ def _can_edit_org_or_agent(app: ImpOrExp, uop: UserOrganisationPermissions) -> b
 
     can_edit_org = False
     for org_id in check_orgs:
-        if uop.has_permission(org_id, obj_perms.edit):
+        if uop.has_permission(org_id, obj_perms.edit, include_ilb_admin=include_ilb_admin):
             can_edit_org = True
 
             break

--- a/web/utils/search/app_data.py
+++ b/web/utils/search/app_data.py
@@ -51,7 +51,9 @@ def get_fa_dfl_applications(search_ids: list[int]) -> "QuerySet[DFLApplication]"
     applications = DFLApplication.objects.filter(pk__in=search_ids)
     applications = _apply_import_optimisation(applications)
 
-    applications = applications.select_related("origin_country", "consignment_country")
+    applications = applications.select_related(
+        "origin_country", "consignment_country", "supplementary_info"
+    )
 
     applications = _add_import_licence_data(applications)
 
@@ -62,7 +64,9 @@ def get_fa_oil_applications(search_ids: list[int]) -> "QuerySet[OpenIndividualLi
     applications = OpenIndividualLicenceApplication.objects.filter(pk__in=search_ids)
     applications = _apply_import_optimisation(applications)
 
-    applications = applications.select_related("origin_country", "consignment_country")
+    applications = applications.select_related(
+        "origin_country", "consignment_country", "supplementary_info"
+    )
 
     applications = _add_import_licence_data(applications)
 
@@ -73,7 +77,9 @@ def get_fa_sil_applications(search_ids: list[int]) -> "QuerySet[SILApplication]"
     applications = SILApplication.objects.filter(pk__in=search_ids)
     applications = _apply_import_optimisation(applications)
 
-    applications = applications.select_related("origin_country", "consignment_country")
+    applications = applications.select_related(
+        "origin_country", "consignment_country", "supplementary_info"
+    )
 
     applications = _add_import_licence_data(applications)
 

--- a/web/utils/search/utils.py
+++ b/web/utils/search/utils.py
@@ -117,12 +117,14 @@ class UserOrganisationPermissions:
         organisation_pk: int,
         *permissions: ImporterObjectPermissions | ExporterObjectPermissions,
         any_perm: bool = False,
+        include_ilb_admin: bool = True,
     ) -> bool:
         """Check if the initialised user has permissions for a given organisation.
 
         :param organisation_pk: Primary key of organisation to check.
         :param permissions: Single permission, or sequence of permissions to check.
         :param any_perm: If True, any of permission in sequence is accepted. Default is False.
+        :param include_ilb_admin: If True, return True if user has ilb_admin permission.
         """
 
         user_org_perms = self._cache[organisation_pk]
@@ -136,4 +138,4 @@ class UserOrganisationPermissions:
             # True if all required perms are in the user org perms
             has_permission = user_org_perms.issuperset(required_perms)
 
-        return self.has_ilb_admin_perm or has_permission
+        return (include_ilb_admin and self.has_ilb_admin_perm) or has_permission


### PR DESCRIPTION
Changes:
  - Remove Provide Supplementary Report action from ILB search.
  - Only show Confirm Reporting Complete when report is not complete
  - Only show ProvideSupplementaryReportAction when report is not complete.
  - Add ILB Admin ViewFirearmsReportDetailView view.

Completed Provide report view when viewing as applicant: 
![import-a-licence_8080_import_firearms_fa_25_provide-report_](https://github.com/uktrade/icms/assets/8921101/c5d2ca8c-19e9-47e4-9638-d905648a3f64)

Completed Provide report view when viewing as caseworker: 
![caseworker_8080_import_firearms_fa_25_provide-report_view_](https://github.com/uktrade/icms/assets/8921101/7e404673-204b-41b9-b0f2-1d3a9935da3d)

In Progress Provide report view when viewing as applicant: 
![import-a-licence_8080_import_firearms_fa_27_provide-report_](https://github.com/uktrade/icms/assets/8921101/efa5ded2-7d9d-4467-b8fd-8156ac367027)

In Progress Provide report view when viewing as caseworker: 
![caseworker_8080_import_firearms_fa_27_provide-report_view_](https://github.com/uktrade/icms/assets/8921101/298a0587-9ae6-4c8f-8e3c-f52d525cebab)
