### PR TITLE
ICMSLST-2666 Sanctions application form country changes

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -4715,15 +4715,12 @@ Get Certificate of Good Manufacturing Practice
 Get FA-DFL
 Get FA-OIL
 Get FA-SIL
-ICMSLST-2666 Use Country.app.get_sanctions_countries(
-ICMSLST-2666 Use
 Get Sanctions countries
 Get Wood
 Get Sanctions origin and consignment countries
 DB Field
 Duplicate the enum value to
 Refactor
-ICMSLST-2666 Use Country.app.get_sanctions_countries
 Inactive Application
 Match the V1 Country Group Name
 V2 Country Group

--- a/web/domains/commodity/forms.py
+++ b/web/domains/commodity/forms.py
@@ -117,7 +117,6 @@ class CommodityGroupFilter(FilterSet):
         label="Commodity Type",
         empty_label="Any",
     )
-
     group_code = CharFilter(field_name="group_code", lookup_expr="icontains", label="Group Code")
     group_name = CharFilter(field_name="group_name", lookup_expr="icontains", label="Group Name")
     group_description = CharFilter(
@@ -130,7 +129,15 @@ class CommodityGroupFilter(FilterSet):
         queryset=Unit.objects.all(),
         empty_label="Any",
     )
-
+    application_type = ModelChoiceFilter(
+        queryset=ImportApplicationType.objects.filter(is_active=True),
+        field_name="usages__application_type",
+        label="Application Type",
+        help_text=(
+            "Shows all commodity group usages relating to the chosen application type."
+            " Mainly useful for Sanctions and Adhoc Licence Application"
+        ),
+    )
     is_archived = BooleanFilter(
         field_name="is_active",
         widget=CheckboxInput,

--- a/web/domains/commodity/views.py
+++ b/web/domains/commodity/views.py
@@ -81,7 +81,6 @@ class CommodityGroupListView(ModelFilterView):
 
     def get_queryset(self):
         qs = super().get_queryset()
-
         return qs.select_related("commodity_type").prefetch_related("commodities")
 
     class Display:


### PR DESCRIPTION
Changes:
  - Check consignment and origin country when checking sanctioned countries.
  - Check consignment and origin country when filtering commodities.
  - Add Application Type filter to Commodity Group search.


**Sanctioned country must be either origin or consignment country or both.**
![import-a-licence_8080_import_sanctions_14_edit_](https://github.com/uktrade/icms/assets/8921101/f9387712-5d59-4d45-8a12-827ffe40a0da)

When adding Goods it will check both countries for usage records (used to filter commodities)

**Example application (choosing Russia and North Korea)**
![image](https://github.com/uktrade/icms/assets/8921101/bf6f3df9-a4d9-484a-bc22-d3c2f7a607cc)

**The available commodities in the Add Goods page:**
![image](https://github.com/uktrade/icms/assets/8921101/228c3127-c174-4574-bfd9-27a5af3e29c5)

**Edit Commodity group pages (showing the commodities available to the sanctions application)**
![caseworker_8080_commodity_group_207_edit_](https://github.com/uktrade/icms/assets/8921101/d1e20a53-19ab-4adb-9c2a-f44ea9cf24b7)
![caseworker_8080_commodity_group_206_edit_ (1)](https://github.com/uktrade/icms/assets/8921101/08539b61-403b-4b05-b04c-92a6b7cd1455)
