### PR TITLE
ICMSLST-2673 Fix section 5 goods having hardcoded subsection in pdf.

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -4732,3 +4732,4 @@ FA_SIL_COC
 OPT_TEMP_EXPORT_COO
 F("country_group_legacy__id
 https://www.fonts.gstatic.com
+Section FAKE CLAUSE of the Firearms Act 1968


### PR DESCRIPTION
Added [another bug](https://uktrade.atlassian.net/browse/ICMSLST-2708) to revisit this as the same problem is in one of the reports.

Once I have written tests and fixed ICMSLST-2708 I hope to remove some of the duplication relating to fetching FA-SIL goods.

I believe there are at least 3 places that fetch FA-SIL goods places that could do with a refactor.