### PR TITLE
ICMSLST-2708 Fix FA-SIL goods descriptions in reports.

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -4763,3 +4763,9 @@ DBT Notification
 DBT-NameChangeNotification.pdf'
 DBT Notification Document
 Dummy Exporter 1
+Goods 1
+Goods 4
+Section 5(B
+Goods 7
+Goods 8
+GoodsSectionSerializer

--- a/web/reports/serializers.py
+++ b/web/reports/serializers.py
@@ -222,6 +222,7 @@ class GoodsSectionSerializer(pydantic.BaseModel):
     quantity: int | None
     unlimited_quantity: bool = False
     obsolete_calibre: str | None = None
+    clause: str | None = None
 
 
 class UserSerializer(BaseSerializer):

--- a/web/reports/utils.py
+++ b/web/reports/utils.py
@@ -2,10 +2,8 @@ import datetime as dt
 
 from django.db.models import QuerySet
 
-from web.domains.case._import.fa.types import FaImportApplication
 from web.models import (
     ExportApplicationType,
-    ImportApplication,
     ImportApplicationType,
     ProductLegislation,
     Report,
@@ -23,7 +21,7 @@ from .serializers import (
 )
 
 
-def get_licence_details(ia: ImportApplication) -> LicenceSerializer:
+def get_licence_details(ia: dict) -> LicenceSerializer:
     if ia["latest_licence_cdr_data"]:
         licence = LicenceSerializer(
             start_date=ia["latest_licence_start_date"],
@@ -86,7 +84,7 @@ def format_time_delta(from_datetime: dt.datetime, to_datetime: dt.datetime) -> s
     return f"{time_delta.days}d {hours}h {minutes}m"
 
 
-def get_constabulary_email_times(ia: FaImportApplication) -> ConstabularyEmailTimesSerializer:
+def get_constabulary_email_times(ia: dict) -> ConstabularyEmailTimesSerializer:
     return ConstabularyEmailTimesSerializer(
         first_email_sent=ia["constabulary_email_first_email_sent"],
         last_email_closed=ia["constabulary_email_last_email_closed"],

--- a/web/tests/reports/test_report_interfaces.py
+++ b/web/tests/reports/test_report_interfaces.py
@@ -1258,7 +1258,7 @@ class TestFirearmsLicencesInterface:
                 "Goods Description": (
                     "111 x Section 1 goods to which Section 1 of the Firearms Act 1968, as amended, applies.\n"
                     "222 x Section 2 goods to which Section 2 of the Firearms Act 1968, as amended, applies.\n"
-                    "333 x Section 5 goods to which Section 5(1)(ac) of the Firearms Act 1968, as amended, applies.\n"
+                    "333 x Section 5 goods to which Section 5(A) of the Firearms Act 1968, as amended, applies.\n"
                     "555 x Section 58 other goods to which Section 58(2) of the Firearms Act 1968, as amended, applies.\n"
                     "444 x Section 58 obsoletes goods chambered in the obsolete calibre Obsolete calibre value to which Section 58(2)"
                     " of the Firearms Act 1968, as amended, applies."


### PR DESCRIPTION
Update the code used to generate goods descriptions in the SILFirearmsLicenceInterface report.

This change does nothing to address the fact that we create fa-sil goods descriptions in 4 separate places.
- Chief serializers 
- Email Template context
- Report data
- PDF licence context