### PR TITLE
ICMSLST-2699 Add support to withdraw an update request.

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -4771,3 +4771,6 @@ Goods 8
 GoodsSectionSerializer
 "Returns the app processing label
 goods?</li
+Update Request
+process.update_requests.filter(is_active
+Send Withdraw Application Update

--- a/web/domains/case/app_checks.py
+++ b/web/domains/case/app_checks.py
@@ -480,13 +480,11 @@ def get_org_update_request_errors(application: ImpOrExp, case_type: str) -> Page
         ),
     )
 
-    update_requests = application.update_requests.filter(is_active=True)
-    pending_update = update_requests.filter(status=models.UpdateRequest.Status.UPDATE_IN_PROGRESS)
-    incomplete_update = update_requests.filter(status=models.UpdateRequest.Status.RESPONDED).filter(
-        response_detail__isnull=True
+    incomplete_update = application.update_requests.filter(is_active=True).filter(
+        status=models.UpdateRequest.Status.UPDATE_IN_PROGRESS, response_detail__isnull=True
     )
 
-    if pending_update.exists() or incomplete_update.exists():
+    if incomplete_update.exists():
         update_request_errors.add(
             FieldError(field_name="Response to request", messages=["You must enter this item."])
         )

--- a/web/domains/workbasket/app_data.py
+++ b/web/domains/workbasket/app_data.py
@@ -403,7 +403,12 @@ def _add_user_import_annotations(
     open_ur_pks_annotation = ArrayAgg(
         "update_requests__pk",
         distinct=True,
-        filter=Q(**{"update_requests__status": UpdateRequest.Status.OPEN, "is_active": True}),
+        filter=Q(
+            **{
+                "update_requests__status": UpdateRequest.Status.OPEN,
+                "update_requests__is_active": True,
+            }
+        ),
         default=Value([]),
     )
 
@@ -448,7 +453,12 @@ def _add_user_export_annotations(
     open_ur_pks_annotation = ArrayAgg(
         "update_requests__pk",
         distinct=True,
-        filter=Q(**{"update_requests__status": UpdateRequest.Status.OPEN, "is_active": True}),
+        filter=Q(
+            **{
+                "update_requests__status": UpdateRequest.Status.OPEN,
+                "update_requests__is_active": True,
+            }
+        ),
         default=Value([]),
     )
 

--- a/web/templates/partial/case/export/sidebar-management.html
+++ b/web/templates/partial/case/export/sidebar-management.html
@@ -26,8 +26,8 @@
                  'Application Withdrawals (' + processed|string + '/' + total|string + ')') }}
   {% endwith %}
 
-  {% with total = process.update_requests.count(),
-          processed = process.update_requests.exclude(status="OPEN").count() %}
+  {% with total = process.update_requests.filter(is_active=True).count(),
+          processed = process.update_requests.filter(is_active=True).exclude(status="OPEN").count() %}
     {{ icms_link(request, icms_url('case:list-update-requests', kwargs={'application_pk': process.pk, 'case_type': 'export'}),
                  'Application Updates (' + processed|string + '/' + total|string + ')') }}
   {% endwith %}

--- a/web/templates/partial/case/import/sidebar-management.html
+++ b/web/templates/partial/case/import/sidebar-management.html
@@ -54,8 +54,8 @@
                   'Application Withdrawals (' + processed|string + '/' + total|string + ')') }}
   {% endwith %}
 
-  {% with total = process.update_requests.count(),
-          processed = process.update_requests.exclude(status="OPEN").count() %}
+  {% with total = process.update_requests.filter(is_active=True).count(),
+          processed = process.update_requests.filter(is_active=True).exclude(status="OPEN").count() %}
     {{ icms_link(request, icms_url('case:list-update-requests', kwargs={'application_pk': process.pk, 'case_type': 'import'}),
         'Application Updates (' + processed|string + '/' + total|string + ')') }}
   {% endwith %}

--- a/web/templates/web/domains/case/manage/list-update-requests.html
+++ b/web/templates/web/domains/case/manage/list-update-requests.html
@@ -19,13 +19,18 @@
       <div class="row">
         <div class="three columns"></div>
         <div class="six columns">
-          {% if not readonly_view %}
+          {% if not readonly_view and update_request.status in ["OPEN", "RESPONDED"] %}
             <br/>
             <form
               method="POST"
               action="{{ icms_url('case:close-update-request', kwargs={'application_pk': process.pk, 'update_request_pk': update_request.pk, 'case_type': case_type}) }}">
               {{ csrf_input }}
-              <input type="submit" class="button primary-button" value="Close Request">
+              {# Change style of button depending on status #}
+              {% if update_request.status == "OPEN" %}
+                <input type="submit" class="button" value="Withdraw Request">
+              {% elif update_request.status == "RESPONDED" %}
+                <input type="submit" class="button primary-button" value="Close Request">
+              {% endif %}
             </form>
           {% endif %}
         </div>


### PR DESCRIPTION
Changes:
  - Change withdraw / close request button label depending on status.
  - Update submit logic to check for incomplete update requests.
  - Mark withdrawn update requests as inactive instead of responded.
  - Fix workbasket query that retrieves open URs to filter active records.
  - Update update request count on caseworker sidebars.
  - ICMSLST-2737 Email ILB when an user resubmits an application.

Initial caseworker view to send an update request:
![caseworker_8080_case_import_1_update-requests_manage_](https://github.com/uktrade/icms/assets/8921101/c83e6979-c98e-4fe6-9758-b39102f36295)
Caseworker view after sending an update request (new Withdraw Request button)
![caseworker_8080_case_import_1_update-requests_list_](https://github.com/uktrade/icms/assets/8921101/a5d17d2b-f881-4018-bdd4-55460646281e)
Initial applicant view when viewing an update request:
![import-a-licence_8080_case_import_1_update-requests_1_start_](https://github.com/uktrade/icms/assets/8921101/77135b47-4166-4697-8651-833ee4325ec7)
Applicant view after submitting response to request (Status stays as Update In Progress)
![import-a-licence_8080_case_import_1_update-requests_respond_](https://github.com/uktrade/icms/assets/8921101/aeb66bba-711c-4b54-b470-395bc6e3ae79)
Caseworker edge case showing warning if they try to withdraw an in progress update request:
![caseworker_8080_case_import_1_update-requests_list_ (1)](https://github.com/uktrade/icms/assets/8921101/e226cd93-d017-42a3-a560-25d7679a0f05)
Caseworker view showing a Close Request button when the applicant has resubmitted the application:
![caseworker_8080_case_import_1_update-requests_list_ (2)](https://github.com/uktrade/icms/assets/8921101/d7e36100-4eda-468a-866c-1960c12b7f96)
Caseworker view showing closed Update Request:
![caseworker_8080_case_import_1_update-requests_list_ (3)](https://github.com/uktrade/icms/assets/8921101/f06c845a-0d7a-4c51-a821-5d2419a67f69)
