### PR TITLE
ICMSLST-2700 - Email content update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,16 +182,13 @@ end_to_end_clear_session: ## Clears the session cookies stored after running end
 	rm -f exporter_user.json && \
 	rm -f ilb_admin.json
 
-end_to_end_test: ## Run end to end tests in a container
-	make end_to_end_clear_session && \
+end_to_end_test: end_to_end_clear_session ## Run end to end tests in a container
 	docker-compose run -it --rm playwright-runner pytest -c playwright/pytest.ini  web/end_to_end/ --numprocesses=auto ${args}
 
-end_to_end_test_firearm_chief: ## Ran to send applications to icms-hmrc
-	make end_to_end_clear_session && \
+end_to_end_test_firearm_chief: end_to_end_clear_session ## Run send applications end to end tests to icms-hmrc
 	docker-compose run -it --rm -e CHIEF_END_TO_END_TEST=1 playwright-runner pytest -c playwright/pytest.ini web/end_to_end/ -k test_can_create_fa_ --numprocesses 3 ${args}
 
-end_to_end_test_local: ## Run end to end tests locally
-	make end_to_end_clear_session && \
+end_to_end_test_local: end_to_end_clear_session ## Run end to end tests locally
 	.venv/bin/python -m pytest -c playwright/pytest.ini web/end_to_end/ ${args}
 
 create_end_to_end_caseworker: ## Create an end to end test using codegen for the caseworker site

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -4787,3 +4787,12 @@ DownloadLink
 undo2
 f"{url}?{qd.urlencode
 Django HttpRequest
+NEEDED
+UNCLEAR
+Section 5) Grateful if the Home Office
+CLARIFICATION
+INCLUDE SUGGESTIONS
+Registered Firearms Dealer
+the Import licencing Branch
+CASE_REFERENCE]]
+%Y-%m-%d %

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -22,7 +22,7 @@ humanize==4.9.0
 Jinja2==3.1.4
 lxml==4.9.3
 mohawk==1.1.0
-notifications-python-client==8.1.0
+notifications-python-client==9.1.0
 openpyxl==3.0.7
 oracledb==1.2.0
 phonenumbers==8.12.12

--- a/web/domains/template/context.py
+++ b/web/domains/template/context.py
@@ -373,4 +373,6 @@ class UserManagementContext:
                 return f"{get_importer_site_domain()} for import or {get_exporter_site_domain()} for export."
             case "CASE_OFFICER_EMAIL", _, _:
                 return settings.ILB_CONTACT_EMAIL
+            case "FIRST_NAME", _, _:
+                return self.user.first_name
         raise ValueError(f"{item} is not a valid user management template context value")

--- a/web/domains/template/models.py
+++ b/web/domains/template/models.py
@@ -59,6 +59,8 @@ class Template(Archivable, models.Model):
     template_code = models.CharField(max_length=50, blank=True, null=True)
     template_type = models.CharField(max_length=50, choices=TYPES, blank=False, null=False)
     application_domain = models.CharField(max_length=20, choices=DOMAINS, blank=False, null=False)
+
+    # Subject
     template_title = models.CharField(max_length=4000, blank=False, null=True)
 
     # everything except CFS schedules uses this; CFS schedules use "paragraphs" (see CFSScheduleParagraph, below)

--- a/web/domains/user/views.py
+++ b/web/domains/user/views.py
@@ -245,7 +245,7 @@ class UserReactivateFormView(PermissionRequiredMixin, FormView):
         ctx = UserManagementContext(user)
         email_template = Template.objects.get(template_code=self.email_template_code)
         return initial | {
-            "subject": replace_template_values(email_template.template_name, ctx),
+            "subject": replace_template_values(email_template.template_title, ctx),
             "body": replace_template_values(email_template.template_content, ctx),
         }
 

--- a/web/mail/url_helpers.py
+++ b/web/mail/url_helpers.py
@@ -17,6 +17,7 @@ from web.models import (
     Importer,
     ImporterContactInvite,
     Mailshot,
+    UpdateRequest,
 )
 from web.sites import (
     get_caseworker_site_domain,
@@ -39,6 +40,26 @@ def get_case_view_url(application: ImpOrExp, domain: str) -> str:
     else:
         url_kwargs["case_type"] = "export"
     return urljoin(domain, reverse("case:view", kwargs=url_kwargs))
+
+
+def get_case_manage_view_url(application: ImpOrExp) -> str:
+    url_kwargs = {"application_pk": application.pk}
+    if application.is_import_application():
+        url_kwargs["case_type"] = "import"
+    else:
+        url_kwargs["case_type"] = "export"
+    return urljoin(get_caseworker_site_domain(), reverse("case:manage", kwargs=url_kwargs))
+
+
+def get_update_request_view_url(
+    application: ImpOrExp, update_request: UpdateRequest, domain: str
+) -> str:
+    url_kwargs = {"application_pk": application.pk, "update_request_pk": update_request.pk}
+    if application.is_import_application():
+        url_kwargs["case_type"] = "import"
+    else:
+        url_kwargs["case_type"] = "export"
+    return urljoin(domain, reverse("case:start-update-request", kwargs=url_kwargs))
 
 
 def get_importer_view_url(importer: Importer, full_url: bool = False) -> str:

--- a/web/management/commands/update_email_data.py
+++ b/web/management/commands/update_email_data.py
@@ -1,0 +1,394 @@
+import datetime as dt
+
+import pytz
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from web.mail.constants import EmailTypes
+from web.models import EmailTemplate, Template
+
+EMAIL_TEMPLATES = [
+    (EmailTypes.ACCESS_REQUEST, "6d20993f-7e9f-49b5-8c74-28654e6e84d0"),
+    (EmailTypes.ACCESS_REQUEST_CLOSED, "956b148a-796c-4052-b7dd-7bbfb51cc049"),  # /PS-IGNORE
+    (
+        EmailTypes.ACCESS_REQUEST_APPROVAL_COMPLETE,
+        "61320f80-36ec-4bdf-97f7-68bf3d9f1d9c",  # /PS-IGNORE
+    ),
+    (EmailTypes.APPLICATION_COMPLETE, "68b93697-95db-4e95-a00f-5106489fd264"),  # /PS-IGNORE
+    (
+        EmailTypes.APPLICATION_EXTENSION_COMPLETE,
+        "cdabbddd-5c80-44a4-ad7c-5f9624325d66",  # /PS-IGNORE
+    ),
+    (
+        EmailTypes.APPLICATION_VARIATION_REQUEST_COMPLETE,
+        "428fc248-d668-4f46-9522-b60b88142e36",  # /PS-IGNORE
+    ),
+    (
+        EmailTypes.APPLICATION_VARIATION_REQUEST_CANCELLED,
+        "4083d2ae-efd9-420c-b159-29cbfa9bf1b6",  # /PS-IGNORE
+    ),
+    (
+        EmailTypes.APPLICATION_VARIATION_REQUEST_REFUSED,
+        "63d2228e-27b4-4810-957c-75ba5baae463",  # /PS-IGNORE
+    ),
+    (
+        EmailTypes.APPLICATION_VARIATION_REQUEST_UPDATE_REQUIRED,
+        "9bfe0641-bc19-4ac1-b2d8-8ec7b4011fe0",  # /PS-IGNORE
+    ),
+    (
+        EmailTypes.APPLICATION_VARIATION_REQUEST_UPDATE_RECEIVED,
+        "7b272d9b-ccc0-4ef4-8a7a-e9d7cb4eceb5",  # /PS-IGNORE
+    ),
+    (
+        EmailTypes.APPLICATION_VARIATION_REQUEST_UPDATE_CANCELLED,
+        "f9f04289-fd0a-46ed-b521-a2cd2402ca83",  # /PS-IGNORE
+    ),
+    (EmailTypes.APPLICATION_STOPPED, "bac90963-7e9f-4e67-8c16-99ff905b3e02"),  # /PS-IGNORE
+    (EmailTypes.APPLICATION_REFUSED, "02b558e7-2902-429d-b5de-c8dac83da7b7"),  # /PS-IGNORE
+    (EmailTypes.APPLICATION_REASSIGNED, "99c3103b-8bf5-470f-8624-6b7791aedb32"),  # /PS-IGNORE
+    (EmailTypes.APPLICATION_REOPENED, "179ff4fe-236a-4718-befc-56cd2c977d0c"),  # /PS-IGNORE
+    (EmailTypes.APPLICATION_UPDATE, "960f3436-a190-4f65-9e05-1fef479a7a0b"),  # /PS-IGNORE
+    (EmailTypes.APPLICATION_UPDATE_RESPONSE, "f6c09508-bcc8-49e7-be2c-102d32f153ed"),  # /PS-IGNORE
+    (
+        EmailTypes.EXPORTER_ACCESS_REQUEST_APPROVAL_OPENED,
+        "267b4a1c-7f61-4e76-becd-286b5252b0e7",  # /PS-IGNORE
+    ),
+    (
+        EmailTypes.FIREARMS_SUPPLEMENTARY_REPORT,
+        "55fc0197-94c8-4125-8784-1b637faa15fb",  # /PS-IGNORE
+    ),
+    (
+        EmailTypes.IMPORTER_ACCESS_REQUEST_APPROVAL_OPENED,
+        "09b7654d-26b4-49d7-967d-ca457f5f1f3a",  # /PS-IGNORE
+    ),
+    (EmailTypes.WITHDRAWAL_ACCEPTED, "93b464af-a0a0-479d-b69d-4ec5c6ef6966"),  # /PS-IGNORE
+    (EmailTypes.WITHDRAWAL_CANCELLED, "8d18435a-6c8a-41ca-aa98-64f99438076e"),  # /PS-IGNORE
+    (EmailTypes.WITHDRAWAL_OPENED, "fd0e9524-bcb8-4d3d-8fe0-09910bb2f6a2"),  # /PS-IGNORE
+    (EmailTypes.WITHDRAWAL_REJECTED, "59cee5db-9f9f-4966-b46a-07743b3e9e72"),  # /PS-IGNORE
+    (EmailTypes.CASE_EMAIL, "3e68fc83-ad05-4c32-826a-d950ce2dfa32"),  # /PS-IGNORE
+    (
+        EmailTypes.APPLICATION_FURTHER_INFORMATION_REQUEST,
+        "7aa33950-19ac-4d1c-ad7b-e0a1b493914f",  # /PS-IGNORE
+    ),
+    (
+        EmailTypes.APPLICATION_FURTHER_INFORMATION_REQUEST_RESPONDED,
+        "5e198272-1ae5-4dff-98bc-2f2f52142ee2",  # /PS-IGNORE
+    ),
+    (
+        EmailTypes.APPLICATION_FURTHER_INFORMATION_REQUEST_WITHDRAWN,
+        "c4e9e6fc-c48d-4eac-a556-a0bc9026ad58",  # /PS-IGNORE
+    ),
+    (
+        EmailTypes.ACCESS_REQUEST_FURTHER_INFORMATION_REQUEST,
+        "683c2b2e-352c-493d-ab7f-aa08c118afb2",  # /PS-IGNORE
+    ),
+    (
+        EmailTypes.ACCESS_REQUEST_FURTHER_INFORMATION_REQUEST_RESPONDED,
+        "b8fa5a85-bdbf-4dcf-8eec-e23bc5c805fa",  # /PS-IGNORE
+    ),
+    (
+        EmailTypes.ACCESS_REQUEST_FURTHER_INFORMATION_REQUEST_WITHDRAWN,
+        "853224f4-fb63-4d83-9a56-ee78f39ef636",  # /PS-IGNORE
+    ),
+    (EmailTypes.LICENCE_REVOKED, "642e8280-a6f0-4e45-89db-4cf37f9cb446"),  # /PS-IGNORE
+    (EmailTypes.CERTIFICATE_REVOKED, "eb8c610c-35c9-4a47-aa5d-5bfa465b5156"),  # /PS-IGNORE
+    (EmailTypes.AUTHORITY_ARCHIVED, "845c64ba-43ca-4145-a7e3-a54d1f565991"),  # /PS-IGNORE
+    (EmailTypes.AUTHORITY_EXPIRING_SECTION_5, "fe064185-33ff-44c0-bef9-6e0763121974"),  # /PS-IGNORE
+    (EmailTypes.AUTHORITY_EXPIRING_FIREARMS, "e1a3439c-bd1b-4553-a924-4a9db2cd6420"),  # /PS-IGNORE
+    (EmailTypes.MAILSHOT, "ecf686cf-b312-4a95-b984-246fdfdbd03a"),  # /PS-IGNORE
+    (EmailTypes.RETRACT_MAILSHOT, "811448a4-5cdc-4258-bd8b-734d67f6624c"),  # /PS-IGNORE
+    (
+        EmailTypes.CONSTABULARY_DEACTIVATED_FIREARMS,
+        "e8602eab-2312-4e18-8a8e-b0d99b569bb8",  # /PS-IGNORE
+    ),
+    (EmailTypes.NEW_USER_WELCOME, "2880f0ec-4f33-45a8-b98c-ff383dfdb577"),  # /PS-IGNORE
+    (EmailTypes.ORG_CONTACT_INVITE, "974d789b-7881-4a68-b262-c958c74567b8"),  # /PS-IGNORE
+]
+
+APPLICATION_UPDATE_IMPORTER_BODY = f"""Dear [[IMPORTER_NAME]]
+
+You need to update your application with the following information for Import Licencing Branch (ILB) to process your application.
+[DESCRIBE WHAT UPDATES ARE NEEDED / WHAT IS UNCLEAR, MAKE SUGGESTIONS IF RELEVANT]
+
+Your application will not be processed further until you submit these updates.
+
+The application will be closed if the requested updates are not received within 1 working day of this email.
+
+Contact {settings.ILB_CONTACT_EMAIL} if you have any questions about your application.
+
+Include case reference number [[CASE_REFERENCE]] in your email, so we know which application you are contacting us about.
+
+Yours sincerely,
+
+[[CASE_OFFICER_NAME]]
+"""
+
+APPLICATION_UPDATE_EXPORTER_BODY = f"""Dear [[EXPORTER_NAME]]
+
+You need to update your application with the following information for the Import Licencing Branch (ILB) to process your application.
+[DESCRIBE WHAT UPDATES ARE NEEDED / WHAT IS UNCLEAR, MAKE SUGGESTIONS IF RELEVANT].
+
+Select the responsible person statement if you have placed the product on the EU market. This only applies to cosmetics. [DELETE IF NOT APPLICABLE]
+
+The application will not be processed further until you submit the updates.
+
+The application will be closed if the requested updates are not received within 1 working day of this email.
+
+Contact {settings.ILB_GSI_CONTACT_EMAIL} if you have any questions about your application.
+Include the case reference number [[CASE_REFERENCE]] in your email, so we know which application you are contacting us about.
+
+Yours sincerely,
+
+[[CASE_OFFICER_NAME]]
+"""
+
+BEIS_EMAIL_BODY = """Dear colleagues
+
+[[CASE_REFERENCE]
+
+We have received a [[APPLICATION_TYPE]] application from:
+
+Exporter details:
+[[EXPORTER_NAME]]
+[[EXPORTER_ADDRESS]]
+
+Please review and advise whether Import Licencing Branch can issue a GMP certificate for this request.
+
+Manufacturer:
+[[MANUFACTURER_NAME]]
+[[MANUFACTURER_ADDRESS]]
+[[MANUFACTURER_POSTCODE]]
+
+Responsible person:
+[[RESPONSIBLE_PERSON_NAME]]
+[[RESPONSIBLE_PERSON_ADDRESS]]
+[[RESPONSIBLE_PERSON_POSTCODE]]
+
+Name of brands:
+[[BRAND_NAMES]]
+
+Yours sincerely
+
+[[CASE_OFFICER_NAME]]
+[[CASE_OFFICER_EMAIL]]
+[[CASE_OFFICER_PHONE]]
+"""
+
+FIREARMS_CONSTABULARY_BODY = """Dear colleagues
+
+We have received an import licence application from:
+[[IMPORTER_NAME]]
+[[IMPORTER_ADDRESS]]
+
+The application is for:
+[[GOODS_DESCRIPTION]]
+
+[DELETE BELOW AS APPLICABLE]
+
+Grateful if the Police can advise on the validity of the RFD/Firearms/Shotgun Certificate, and whether
+ there are any objections to the issuing of the import licence.
+
+Grateful if the Police can validate the RFD / and Section 1 and 2 authority/authorities on the applicants apply for an import licence.
+
+Grateful if the Home Office can validate the Section 5 authority on the applicants apply for an import licence.
+
+The Home Office have validated the Section 5 authority on the applicants apply for an import licence. (Delete if not Section 5)
+
+Grateful if you can check the attached deactivation certificate and advise as to whether or not it is valid and matches your records.
+(DELETE IF NOT DEACTIVATED)
+
+The import licence will not be issued until your response to this e-mail has been received.
+
+Yours sincerely
+
+[[CASE_OFFICER_NAME]]
+[[CASE_OFFICER_EMAIL]]
+[[CASE_OFFICER_PHONE]]
+"""
+
+IMA_RFI_BODY = f"""Dear [[IMPORTER_NAME]],
+
+You need to provide some more information for Import Licencing Branch (ILB) to process your application.
+[DESCRIBE WHAT INFORMATION OR CLARIFICATION IS NEEDED. INCLUDE SUGGESTIONS IF RELEVANT]
+ regarding [DESCRIBE WHAT FURTHER INFORMATION IS NEEDED / WHAT IS UNCLEAR, MAKE SUGGESTIONS IF RELEVANT].
+
+Your application will not be processed further until you respond to this request.
+
+The application will be closed if the requested response is not received within 1 working day of this email.
+
+Contact {settings.ILB_GSI_CONTACT_EMAIL} if you have any questions about your application.
+
+Include case reference number [[CASE_REFERENCE]] in your email, so we know which application you are contacting us about.
+
+Yours sincerely,
+
+[[CASE_OFFICER_NAME]]
+"""
+
+CA_RFI_BODY = f"""Dear [[EXPORTER_NAME]],
+
+Some more information is needed for the Import Licencing Branch (ILB) to process your application.
+[DESCRIBE WHAT INFORMATION OR CLARIFICATION IS NEEDED. INCLUDE SUGGESTIONS IF RELEVANT].
+
+Your application will not be processed further until you respond to this request.
+
+The application will be closed if the requested response is not received 1 working day of this email.
+
+Contact {settings.ILB_GSI_CONTACT_EMAIL} if you have any questions about your application.
+
+Include case reference number [[CASE_REFERENCE]] in your email, so we know which application you are contacting us about.
+
+Yours sincerely,
+
+[[CASE_OFFICER_NAME]]
+"""
+
+HSE_BODY = """Dear colleagues
+
+[[CASE_REFERENCE]]
+
+We have received a [[APPLICATION_TYPE]] application from:
+[[EXPORTER_NAME]]
+[[EXPORTER_ADDRESS]]
+[[CONTACT_EMAIL]]
+
+The application is for countries:
+
+[[CERT_COUNTRIES]]
+
+The application is for biocidal products:
+
+[[SELECTED_PRODUCTS]]
+
+We would be grateful for your guidance on the items listed.
+
+Yours sincerely,
+
+[[CASE_OFFICER_NAME]]
+[[CASE_OFFICER_EMAIL]]
+[[CASE_OFFICER_PHONE]]
+"""
+
+IAR_RFI_BODY = f"""Dear [[REQUESTER_NAME]],
+
+Some more information is needed for the Import Licencing Branch (ILB) to process your request to access apply for an import licence or export certificate.
+[DESCRIBE WHAT INFORMATION OR CLARIFICATION IS NEEDED. INCLUDE SUGGESTIONS IF RELEVANT].
+
+Use this link [Link to case in apply for an import licence or export certificate] to your access request in apply for an import licence or export certificate.
+
+Contact {settings.ILB_GSI_CONTACT_EMAIL} if you have any questions.
+Include the case reference number [[REQUEST_REFERENCE]] in your email
+
+Yours sincerely,
+
+[[CURRENT_USER_NAME]]
+"""
+
+PUBLISH_MAILSHOT_BODY = """Dear [[FIRST_NAME]],
+
+A new mailshot has been published.
+
+Yours sincerely,
+
+Import Licencing Branch
+"""
+
+RETRACT_MAILSHOT_BODY = """Dear [[FIRST_NAME]],
+
+A published mailshot has been retracted.
+
+Yours sincerely,
+
+Import Licencing Branch
+"""
+
+SANCTIONS_BODY = """Dear colleagues
+
+We have received an import licence application from:
+[[IMPORTER_NAME]]
+[[IMPORTER_ADDRESS]]
+
+The application is for:
+
+[[GOODS_DESCRIPTION]]
+
+Yours sincerely,
+
+[[CASE_OFFICER_NAME]]
+[[CASE_OFFICER_EMAIL]]
+[[CASE_OFFICER_PHONE]]
+"""
+
+
+EMAIL_CONTENT = [
+    (
+        "IMA_APP_UPDATE",
+        "Request for updates to your application [[CASE_REFERENCE]]",
+        APPLICATION_UPDATE_IMPORTER_BODY,
+    ),
+    (
+        "CA_APPLICATION_UPDATE_EMAIL",
+        "Request for updates to your application [[CASE_REFERENCE]]",
+        APPLICATION_UPDATE_EXPORTER_BODY,
+    ),
+    (
+        "CA_BEIS_EMAIL",
+        "Good manufacturing practice (GMP) application enquiry [[CASE_REFERENCE]]",
+        BEIS_EMAIL_BODY,
+    ),
+    (
+        "IMA_CONSTAB_EMAIL",
+        "Import licence Registered Firearms Dealer (RFD) enquiry [[CASE_REFERENCE]]",
+        FIREARMS_CONSTABULARY_BODY,
+    ),
+    ("IMA_RFI", "Request for more information [[CASE_REFERENCE]]", IMA_RFI_BODY),
+    ("CA_RFI_EMAIL", "Request for more information [[CASE_REFERENCE]]", CA_RFI_BODY),
+    ("CA_HSE_EMAIL", "Biocidal product enquiry [[CASE_REFERENCE]]", HSE_BODY),
+    ("IAR_RFI_EMAIL", "Request for more information [[REQUEST_REFERENCE]]", IAR_RFI_BODY),
+    ("PUBLISH_MAILSHOT", "New mailshot", PUBLISH_MAILSHOT_BODY),
+    ("RETRACT_MAILSHOT", "Retracted mailshot", RETRACT_MAILSHOT_BODY),
+    (
+        "IMA_SANCTIONS_EMAIL",
+        "Import sanctions and adhoc licence [[CASE_REFERENCE]]",
+        SANCTIONS_BODY,
+    ),
+]
+
+
+class Command(BaseCommand):
+    help = """Upon sign off update email content inline with V2 terminology."""
+
+    def handle(self, *args, **options):
+        update_database_email_templates(self.stdout)
+        archive_database_email_templates()
+        update_gov_notify_template_ids()
+
+
+def update_database_email_templates(stdout):
+    for template_code, subject, body in EMAIL_CONTENT:
+        try:
+            template = Template.objects.get(template_code=template_code)
+        except Template.DoesNotExist:
+            stdout.write(f"Template {template_code} Not found")
+        else:
+            template.template_title = subject
+            template.template_content = body
+            template.start_datetime = dt.datetime.now(tz=pytz.UTC).strftime("%Y-%m-%d %H:%M:%S:%z")
+            template.save(update_fields=["template_title", "template_content", "start_datetime"])
+
+
+def archive_database_email_templates():
+    templates = [
+        "STOP_CASE",
+        "CASE_REOPEN",
+        "LICENCE_REVOKE",
+        "CERTIFICATE_REVOKE",
+    ]
+    Template.objects.filter(template_code__in=templates).update(is_active=False)
+
+
+def update_gov_notify_template_ids():
+    for email_type, gov_notify_template_id in EMAIL_TEMPLATES:
+        email_template = EmailTemplate.objects.get(name=email_type)
+        email_template.gov_notify_template_id = gov_notify_template_id
+        email_template.save(update_fields=["gov_notify_template_id"])

--- a/web/management/commands/utils/add_template_data.py
+++ b/web/management/commands/utils/add_template_data.py
@@ -1368,28 +1368,44 @@ def add_user_management_email_templates():
             dt.datetime.strptime("18-APR-2024 08:50:23", DATETIME_FORMAT), is_dst=None
         ),
         is_active=True,
-        template_name="[[PLATFORM]] account deactivated",
+        template_title="Your [[PLATFORM]] account has been deactivated",
+        template_name="User account deactivated",
         template_code=EmailTypes.DEACTIVATE_USER_EMAIL,
         template_type="EMAIL_TEMPLATE",
         application_domain="UM",
-        template_content="""Your [[PLATFORM]] account has been deactivated.
+        template_content="""Dear [[FIRST_NAME]],
 
-Contact [[CASE_OFFICER_EMAIL]] if you have any questions.""",
+Your [[PLATFORM]] account has been deactivated.
+
+Contact [[CASE_OFFICER_EMAIL]] if you have any questions.
+
+Yours sincerely
+
+Import Licensing Branch
+""",
     )
     Template.objects.get_or_create(
         start_datetime=pytz.timezone("UTC").localize(
             dt.datetime.strptime("18-APR-2024 08:50:23", DATETIME_FORMAT), is_dst=None
         ),
         is_active=True,
-        template_name="[[PLATFORM]] account reactivated",
+        template_title="Your [[PLATFORM]] account has been reactivated",
+        template_name="User account reactivated",
         template_code=EmailTypes.REACTIVATE_USER_EMAIL,
         template_type="EMAIL_TEMPLATE",
         application_domain="UM",
-        template_content="""Welcome back to [[PLATFORM]].
+        template_content="""Dear [[FIRST_NAME]],
+
+Welcome back to [[PLATFORM]].
 
 Your account has been reactivated.
 
 You can now sign in to your account here [[PLATFORM_LINK]]
 
-Contact [[CASE_OFFICER_EMAIL]] if you have any questions.""",
+Contact [[CASE_OFFICER_EMAIL]] if you have any questions.
+
+Yours sincerely,
+
+Import Licencing Branch
+""",
     )

--- a/web/templates/web/domains/template/detail.html
+++ b/web/templates/web/domains/template/detail.html
@@ -52,7 +52,7 @@
             <dt class="bold">Email Subject</dt>
             <dd>{{ object.template_title}}</dd>
             <dt class="bold">Email Body</dt>
-            <dd>{{ object.template_content }}</dd>
+            <dd>{{ object.template_content|nl2br }}</dd>
           </dl>
         {% elif object.template_type == "LETTER_TEMPLATE"%}
           <dl>

--- a/web/tests/domains/case/_import/sanctions/test_views.py
+++ b/web/tests/domains/case/_import/sanctions/test_views.py
@@ -6,7 +6,10 @@ from django.utils import timezone
 from pytest_django.asserts import assertRedirects, assertTemplateUsed
 
 from web.mail.constants import EmailTypes
-from web.mail.url_helpers import get_case_view_url, get_validate_digital_signatures_url
+from web.mail.url_helpers import (
+    get_case_manage_view_url,
+    get_validate_digital_signatures_url,
+)
 from web.models import (
     Commodity,
     Country,
@@ -16,7 +19,7 @@ from web.models import (
     Task,
     UpdateRequest,
 )
-from web.sites import get_importer_site_domain
+from web.sites import get_caseworker_site_domain
 from web.tests.auth import AuthTestCase
 from web.tests.conftest import LOGIN_URL
 from web.tests.domains.case._import.factory import (
@@ -495,7 +498,7 @@ class TestSubmitSanctions:
                 "validate_digital_signatures_url": get_validate_digital_signatures_url(
                     full_url=True
                 ),
-                "application_url": get_case_view_url(self.app, get_importer_site_domain()),
-                "icms_url": get_importer_site_domain(),
+                "application_url": get_case_manage_view_url(self.app),
+                "icms_url": get_caseworker_site_domain(),
             },
         )

--- a/web/tests/domains/case/access/test_views.py
+++ b/web/tests/domains/case/access/test_views.py
@@ -331,6 +331,9 @@ class TestCloseAccessRequest(AuthTestCase):
                 "reason": "",
                 "request_type": "Importer",
                 "icms_url": get_importer_site_domain(),
+                "is_agent": "no",
+                "has_been_refused": "no",
+                "service_name": "apply for an import licence",
             },
         )
 
@@ -358,6 +361,9 @@ class TestCloseAccessRequest(AuthTestCase):
                 "reason": "Reason: test refuse",
                 "request_type": "Importer",
                 "icms_url": get_importer_site_domain(),
+                "is_agent": "no",
+                "has_been_refused": "yes",
+                "service_name": "apply for an import licence",
             },
         )
 
@@ -390,6 +396,9 @@ class TestCloseAccessRequest(AuthTestCase):
                 "reason": "",
                 "request_type": "Exporter",
                 "icms_url": get_exporter_site_domain(),
+                "is_agent": "no",
+                "has_been_refused": "no",
+                "service_name": "apply for an export certificate",
             },
         )
 
@@ -417,6 +426,9 @@ class TestCloseAccessRequest(AuthTestCase):
                 "reason": "Reason: test refuse",
                 "request_type": "Exporter",
                 "icms_url": get_exporter_site_domain(),
+                "is_agent": "no",
+                "has_been_refused": "yes",
+                "service_name": "apply for an export certificate",
             },
         )
 

--- a/web/tests/domains/case/views/test_views_update_request.py
+++ b/web/tests/domains/case/views/test_views_update_request.py
@@ -4,7 +4,11 @@ from pytest_django.asserts import assertContains, assertTemplateUsed
 
 from web.domains.case.types import ImpOrExp
 from web.mail.constants import EmailTypes
-from web.mail.url_helpers import get_case_view_url, get_validate_digital_signatures_url
+from web.mail.url_helpers import (
+    get_case_view_url,
+    get_update_request_view_url,
+    get_validate_digital_signatures_url,
+)
 from web.models import ImportApplication, UpdateRequest, User
 from web.sites import get_importer_site_domain
 from web.tests.application_utils import resubmit_app
@@ -65,6 +69,9 @@ def test_manage_update_requests(ilb_admin_client: Client, wood_app_submitted: Im
             "validate_digital_signatures_url": get_validate_digital_signatures_url(full_url=True),
             "application_url": get_case_view_url(wood_app_submitted, get_importer_site_domain()),
             "icms_url": get_importer_site_domain(),
+            "application_update_url": get_update_request_view_url(
+                wood_app_submitted, update_request, get_importer_site_domain()
+            ),
         },
         exp_subject=post["request_subject"],
         exp_in_body=post["request_detail"],

--- a/web/tests/mail/test_emails.py
+++ b/web/tests/mail/test_emails.py
@@ -15,12 +15,14 @@ from web.mail.types import ImporterDetails
 from web.mail.url_helpers import (
     get_accept_org_invite_url,
     get_account_recovery_url,
+    get_case_manage_view_url,
     get_case_view_url,
     get_dfl_application_otd_url,
     get_exporter_access_request_url,
     get_importer_access_request_url,
     get_mailshot_detail_view_url,
     get_maintain_importers_view_url,
+    get_update_request_view_url,
     get_validate_digital_signatures_url,
 )
 from web.models import (
@@ -102,6 +104,9 @@ class TestEmails(AuthTestCase):
             "reason": "",
             "request_type": "Importer",
             "icms_url": get_importer_site_domain(),
+            "is_agent": "yes",
+            "has_been_refused": "no",
+            "service_name": "apply for an import licence",
         }
         emails.send_access_request_closed_email(importer_access_request)
         assert self.mock_gov_notify_client.send_email_notification.call_count == 1
@@ -122,6 +127,9 @@ class TestEmails(AuthTestCase):
             "reason": "",
             "request_type": "Exporter",
             "icms_url": get_exporter_site_domain(),
+            "is_agent": "no",
+            "has_been_refused": "yes",
+            "service_name": "apply for an export certificate",
         }
         emails.send_access_request_closed_email(exporter_access_request)
         assert self.mock_gov_notify_client.send_email_notification.call_count == 1
@@ -933,8 +941,8 @@ class TestEmails(AuthTestCase):
         expected_personalisation = default_personalisation() | {
             "reference": completed_dfl_app.reference,
             "validate_digital_signatures_url": get_validate_digital_signatures_url(full_url=True),
-            "application_url": get_case_view_url(completed_dfl_app, get_importer_site_domain()),
-            "icms_url": get_importer_site_domain(),
+            "application_url": get_case_manage_view_url(completed_dfl_app),
+            "icms_url": get_caseworker_site_domain(),
         }
         emails.send_application_update_response_email(completed_dfl_app)
         assert self.mock_gov_notify_client.send_email_notification.call_count == 1
@@ -957,6 +965,9 @@ class TestEmails(AuthTestCase):
             "icms_url": get_importer_site_domain(),
             "validate_digital_signatures_url": get_validate_digital_signatures_url(full_url=True),
             "application_url": get_case_view_url(wood_app_submitted, get_importer_site_domain()),
+            "application_update_url": get_update_request_view_url(
+                wood_app_submitted, update_request, get_importer_site_domain()
+            ),
         }
         emails.send_application_update_email(update_request)
         assert self.mock_gov_notify_client.send_email_notification.call_count == 1
@@ -1218,6 +1229,7 @@ Firearms references(s): 423,476,677\r\n"""
             "validate_digital_signatures_url": get_validate_digital_signatures_url(full_url=True),
             "check_code": str(link.check_code),
             "documents_url": get_dfl_application_otd_url(link),
+            "constabulary_name": "Derbyshire",
         }
         assert self.mock_gov_notify_client.send_email_notification.call_count == 1
         self.mock_gov_notify_client.send_email_notification.assert_any_call(


### PR DESCRIPTION
PR includes
 - Command to update all GovNotify template ids
 - Command to update DB email copy
 - Command to archive DB email templates that will no longer be used
 - Update GovNotify lib to latest
 - Fix to User activate / deactivate emails where email subject using incorrect field
 - Added template vars to `AccessRequestClosedEmail` to support optional copy
 - Fixed incorrect urls in `ApplicationUpdateResponseEmail`

To test
 - Set the GOV NOTIFY settings to live
 - Run `python manage.py update_email_data`
 - Send emails and make sure they are using the new templates
 - Run through a process of sending a DB email and check copy has been updated
 - Log in to GOV Notify and view all new templates (in V2 dir)

