### PR TITLE
ICMSLST-2734 Fixing page breaks and adding page numbers for CFS pdfs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ module = [
     "fitz.*",
     "endesive.*",
     "PIL.*",
+    "reportlab.*",
 ]
 ignore_missing_imports = true
 

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -38,6 +38,8 @@ tqdm==4.66.3
 whitenoise==6.6.0
 xlsxwriter==3.0.1
 django-csp~=3.7
+pypdf==4.2.0
+reportlab==4.2.2
 PyMuPDF~=1.23.16
 playwright==1.42
 pyOpenSSL==24.0.0

--- a/web/static/web/css/pdfs/certificate-style.css
+++ b/web/static/web/css/pdfs/certificate-style.css
@@ -4,39 +4,18 @@
     margin-right: 65px;
     margin-bottom: 20px;
     margin-left: 65px;
-
-    @top-right {
-        content: "Page " counter(page) " of " counter(pages) " ";
-        font-size: 13px;
-        width: fit-content;
-        height: fit-content;
-        text-align: right;
-        padding-top: 78px;
-        padding-right: 10px;
-        padding-bottom: 14px;
-    }
-
-    @top-left {
-        padding-top: 78px;
-        padding-left: 10px;
-        padding-bottom: 14px;
-        content: element(header);
-    }
-}
-
-header {
-    position: running(header);
 }
 
 .reference {
     font-size: 15px;
 }
 
-#dbt-logo {
-    width: 210px;
-    margin: -30px 0 15px 64px;
+.header-logo {
     display: inline-block;
     vertical-align: top;
+    height: 100px;
+    width: 200px;
+    margin-left: 8px;
 }
 
 hr {

--- a/web/static/web/css/pdfs/cfs-certificate-style.css
+++ b/web/static/web/css/pdfs/cfs-certificate-style.css
@@ -1,8 +1,8 @@
 @page {
     size: A4;
-    margin-top: 40px;
-    margin-right: 75px;
-    margin-bottom: 20px;
+    margin-top: 94px;
+    margin-right: 85px;
+    margin-bottom: 140px;
     margin-left: 90px;
 }
 
@@ -12,61 +12,20 @@
     font-size: 16px;
 }
 
-.header-block {
-    display: inline-block;
-    vertical-align: top;
-    height: 80px;
-    width: 160px;
-}
-
 ul, ol {
     list-style-position: outside;
 }
 
-.schedule-header {
-    margin-top: 80px;
-}
-
-.product-header {
-    margin-bottom: 2px;
-}
-
-.product-name {
-    margin-top: 2px;
-    margin-bottom: 2px;
-}
-
-.schedule-block {
-    height: 99vh;
-    position: relative;
-    page-break-inside: avoid;
-    page-break-before: always;
-}
-
-.schedule-block .schedule_only_valid_block {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-}
-
-.header {
-    display: flex;
-    justify-content: space-between;
-}
-
 header {
-    position: running(header);
+    margin-top: -4px;
 }
 
-.reference {
-    font-size: 14px;
-}
-
-#dbt-logo {
-    width: 210px;
-    margin: -30px 0 15px 64px;
+.header-logo {
     display: inline-block;
     vertical-align: top;
+    height: 80px;
+    width: 160px;
+    margin-left: 4px;
 }
 
 hr {
@@ -78,7 +37,7 @@ hr {
     padding-top: 8px;
     display: flex;
     flex-wrap: wrap;
-    height: 815px;
+    height: 750px;
     align-content: space-between;
 }
 
@@ -93,7 +52,7 @@ hr {
 .title {
     font-size: 16px;
     color: black;
-    margin-bottom: 60px;
+    margin-bottom: 100px;
 }
 
 .title-line {
@@ -111,21 +70,25 @@ p {
 }
 
 .signature-block {
-    margin-bottom: 60px;
+    margin-bottom: 20px;
     display: flex;
     justify-content: space-evenly;
     align-items: stretch;
     flex-wrap: nowrap;
 }
 
-.signature,
+.signature {
+    display: block;
+    flex: 40% 0 0;
+}
 .qr-text-block {
     display: block;
     flex: 31% 0 0;
+    padding-left: 16px;
 }
 
 .qr-code {
-    flex: 38% 0 0;
+    flex: 31% 0 0;
     flex-direction: column;
 }
 
@@ -152,13 +115,33 @@ p {
     margin: 0;
 }
 
-.date-block {
-    margin-top: 18px;
+.schedule-header {
+    margin-top: 48px;
 }
 
-.date-block > span {
+.product-header {
+    margin-bottom: 2px;
+}
+
+.product-name {
+    margin-top: 2px;
+    margin-bottom: 2px;
+}
+
+.schedule-block {
+    position: relative;
     display: block;
-    font-size: 18px;
+    page-break-before: always;
+}
+
+.schedule-index-block {
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
+}
+
+.schedule-index {
+    font-size: 13px;
 }
 
 .centre {

--- a/web/static/web/css/pdfs/gmp-certificate-style.css
+++ b/web/static/web/css/pdfs/gmp-certificate-style.css
@@ -18,14 +18,6 @@
     flex-direction: row;
 }
 
-.header-block {
-    display: inline-block;
-    vertical-align: top;
-    height: 80px;
-    width: 160px;
-
-}
-
 ul, ol {
     list-style-position: outside;
 }
@@ -48,11 +40,12 @@ header {
     font-size: 14px;
 }
 
-#dbt-logo {
-    width: 210px;
-    margin: -30px 0 15px 64px;
+.header-logo {
     display: inline-block;
     vertical-align: top;
+    height: 80px;
+    width: 160px;
+    margin-left: 4px;
 }
 
 hr {

--- a/web/templates/pdf/export/cfs-certificate.html
+++ b/web/templates/pdf/export/cfs-certificate.html
@@ -7,9 +7,12 @@
 <html lang="en">
   <head>
     <style>
-      {{ get_css_rules_as_string('web/css/pdfs/fonts.css')|safe }}
-      {{ get_css_rules_as_string('web/css/pdfs/constants.css')|safe }}
-      {{ get_css_rules_as_string('web/css/pdfs/cfs-certificate-style.css')|safe }}
+      {{ get_css_rules_as_string('web/css/pdfs/fonts.css') | safe }}
+      {{ get_css_rules_as_string('web/css/pdfs/constants.css') | safe }}
+      {{ get_css_rules_as_string('web/css/pdfs/cfs-certificate-style.css') | safe }}
+      {% if preview %}
+        {{ get_css_rules_as_string('web/css/pdfs/preview.css') | safe }}
+      {% endif %}
       .dbt_logo_watermark {
         background-image: url("data:image/png;base64,{{ get_file_base64('web/img/dbt_logo.png') }}");
       }
@@ -18,13 +21,10 @@
   </head>
 
   <body>
-    <div class="page-margin">
+    <div>
       <header>
-        <div class="flex-row">
-          <p class="mb-0-5"><span class="reference {{ 'preview-orange' if preview }}">{{ reference }}</span></p>
-        </div>
         <div class="flex-row mb-2">
-          {{ dbt_logo(classes="header-block") }}
+          {{ dbt_logo(classes="header-logo") }}
         </div>
         <hr>
       </header>
@@ -76,20 +76,15 @@
               </div>
             {% endif %}
           </div>
-          <div class="date-block">
-            <span>Date issued:</span>
-            <span>{{ issue_date }}</span>
-          </div>
         </footer>
       </div>
 
       {% for schedule in process.schedules.order_by('created_at') %}
         {% set english_paragraphs = schedule_text[schedule.pk].english_paragraphs %}
         {% set translation_paragraphs = schedule_text[schedule.pk].translation_paragraphs %}
-        <div class="schedule-block page-margin">
-          <div class="header">
-            <p class="reference">{{ reference }}</p>
-            <p class="schedule-index reference">Schedule {{ loop.index }} of {{ loop.length }}</p>
+        <div class="schedule-block">
+          <div class="schedule-index-block">
+            <p class="schedule-index mt-0">Schedule {{ loop.index }} of {{ loop.length }}</p>
           </div>
 
           <h4 class="schedule-header bold">{{ english_paragraphs.header | upper }}</h4>
@@ -112,13 +107,6 @@
                 <p class="product-name">{{ product_name }}</p>
               {% endfor %}
             </div>
-            <footer class="schedule_only_valid_block">
-              <p>
-                This schedule is only valid with Certificate
-                <span class="{{ 'preview-orange' if preview }} footer-reference">{{ reference }}</span>
-              </p>
-              <p>Date issued: {{ issue_date }}</p>
-            </footer>
           </div>
         </div>
       {% endfor %}

--- a/web/templates/pdf/export/gmp-certificate.html
+++ b/web/templates/pdf/export/gmp-certificate.html
@@ -22,7 +22,7 @@
           <p class="mb-0-5"><span class="reference {{ 'preview-orange' if preview }}">{{ reference }}</span></p>
         </div>
         <div class="flex-row mb-2 pl-0-5">
-          {{ dbt_logo(classes="header-block") }}
+          {{ dbt_logo(classes="header-logo") }}
         </div>
         <hr>
       </header>

--- a/web/templates/pdf/shared/pdf_header.html
+++ b/web/templates/pdf/shared/pdf_header.html
@@ -1,21 +1,3 @@
-
 <style>
-    .playwright-header {
-        width: 100%;
-    }
-
-    .page_number_count {
-        margin-right: 107px;
-        float: right;
-    }
-
-    .page_number_count, .pageNumber, .totalPages {
-        font-family: Helvetica, sans-serif;
-        font-size: 15px;
-    }
-    {{ get_css_rules_as_string('web/css/pdfs/fonts.css')|safe }}
+    {{ get_css_rules_as_string('web/css/pdfs/fonts.css') | safe }}
 </style>
-
-<div class="playwright-header">
-  <span class="page_number_count">Page <span class="pageNumber"></span> of <span class="totalPages"></span></span>
-</div>

--- a/web/utils/pdf/pages.py
+++ b/web/utils/pdf/pages.py
@@ -1,0 +1,50 @@
+import io
+from typing import Any
+
+import pypdf
+from reportlab.lib.pagesizes import A4, portrait
+from reportlab.pdfgen import canvas
+
+
+def format_cfs_pages(pdf_data: bytes, context: dict[str, Any]) -> bytes:
+    """Function to add page numbers and running headers and footers to CFS documents
+    Creates new blank pages with only the header and footer content and merges with
+    the original document."""
+
+    reader = pypdf.PdfReader(io.BytesIO(pdf_data))
+    writer = pypdf.PdfWriter()
+
+    issue_date = context["issue_date"]
+    reference = context["reference"]
+
+    left_margin = 73
+    top_margin = 780
+    page_total = len(reader.pages)
+    for page_number, page in enumerate(reader.pages):
+        packet = io.BytesIO()
+        new_page = canvas.Canvas(packet, pagesize=portrait(A4))
+        new_page.setFont("Helvetica", 10)
+        new_page.drawRightString(525, top_margin, f"Page {page_number + 1} of {page_total}")
+        new_page.drawString(left_margin, top_margin, reference)
+
+        if page_number == 0:
+            new_page.setFontSize(12)
+            new_page.drawString(left_margin, 90, "Date issued:")
+            new_page.drawString(left_margin, 76, issue_date)
+
+        else:
+            new_page.drawString(
+                left_margin, 52, f"This schedule is only valid with Certificate {reference}"
+            )
+            new_page.drawString(left_margin, 28, f"Date issued: {issue_date}")
+
+        new_page.save()
+
+        packet.seek(0)
+        new_pdf = pypdf.PdfReader(packet)
+        page.merge_page(new_pdf.pages[0])
+        writer.add_page(page)
+
+    with io.BytesIO() as bytes_stream:
+        writer.write(bytes_stream)
+        return bytes_stream.getvalue()


### PR DESCRIPTION
Adding page numbers and fixing running header and footer content for CFS pdfs

Page counts and the reference sit at the top of all pages
<img width="830" alt="image" src="https://github.com/uktrade/icms/assets/61604535/6df31998-3ac9-4b34-85ea-2623d2615fd5">

Bottom of the page has the running footer. Page breaks does not cause text to superimpose
<img width="880" alt="image" src="https://github.com/uktrade/icms/assets/61604535/67fc25be-61ea-4ea4-8eb6-6eda5837ad18">
