### PR TITLE
ICMSLST-2757 Set default django cookie age to one hour.

### DIFF
--- a/config/env.py
+++ b/config/env.py
@@ -87,7 +87,7 @@ class DBTPlatformEnvironment(BaseSettings):
     clam_av_domain: str
 
     # Age in seconds
-    django_session_cookie_age: int = 60 * 30
+    django_session_cookie_age: int = 60 * 60
 
     # Bypass chief
     allow_bypass_chief_never_enable_in_prod: bool = False


### PR DESCRIPTION
Updated **ICMS_DJANGO_SESSION_COOKIE_AGE** ParamStore values in hotfix and prod to 3600 (1h)