### PR TITLE
ICMSLST-2744 Fix COM Certificate styling on page breaks

### DIFF
--- a/web/static/web/css/pdfs/com-certificate-style.css
+++ b/web/static/web/css/pdfs/com-certificate-style.css
@@ -1,31 +1,54 @@
 @page {
     size: A4;
-    margin-top: 60px;
-    margin-right: 70px;
-    margin-bottom: 20px;
+    margin-top: 70px;
+    margin-right: 85px;
+    margin-bottom: 220px;
     margin-left: 85px;
+ }
+
+@page:first {
+    margin-bottom: 20px;
 }
 
-.signature-block {
-    display: flex;
-    justify-content: space-evenly;
-    align-items: stretch;
-    flex-wrap: nowrap;
+.preview-orange {
+    color: darkorange;
 }
 
-.signature,
-.qr-code,
-.qr-text {
-    display: block;
-    flex: 33% 0 0;
+.preview-green {
+    color: #0B8433;
 }
 
-.qr-text {
-    font-size: 12px;
+p {
+    line-height: 1.2em;
+}
+
+.blank-page {
+    page-break-after: always;
 }
 
 body {
     counter-reset: li-counter;
+}
+
+.certificate-header {
+    margin-bottom: 40px;
+    justify-content: space-between;
+}
+
+.large-header-logo {
+    height: 125px;
+    width: 250px;
+}
+
+.certificate-reference {
+    align-items: flex-end;
+    margin-right: 0;
+}
+
+.reference {
+    font-size: 14px;
+    margin-top: 20px;
+    margin-right: 0;
 }
 
 .issue-date {
@@ -35,7 +58,6 @@ body {
 .title-line {
     margin-bottom: 12px;
 }
-
 
 ol:first-of-type {
     margin-bottom: 40px;
@@ -49,7 +71,23 @@ ol li:not(:last-child) {
     margin-bottom: 12px;
 }
 
-div.com-item p {
+li {
+    line-height: 1.2em;
+}
+
+ul, ol {
+    list-style-position: outside;
+}
+
+ol li {
+    padding-left: 20px;
+}
+
+ol {
+    padding-left: 20px;
+}
+
+div.com-item > p {
     margin: 0;
 }
 
@@ -62,122 +100,17 @@ div.com-item p {
 }
 
 
-ol li {
-    padding-left: 20px;
-}
-
-ol {
-    padding-left: 20px;
-}
-
-.large-header-logo {
-    height: 125px;
-    width: 250px;
-}
-
-.certificate-reference {
-    align-items: end;
-}
-
-.signature-block {
-    margin-bottom: 40px;
-}
-
-li {
-    line-height: 1.2em;
-}
-
-@page {
-    size: A4;
-}
-
-.flex-column {
-    display: flex;
-    flex-direction: column;
-}
-
-.flex-row {
-    display: flex;
-    flex-direction: row;
-}
-
-.align-centre {
-    align-items: center;
-}
-
-
-.two-third {
-    flex: 67% 0 0;
-}
-
-
-.third {
-    flex: 33% 0 0;
-}
-
-.thirty_width {
-    flex: 30% 0 0;
-}
-
-
-ul, ol {
-    list-style-position: outside;
-}
-
-.preview-orange {
-    color: darkorange;
-}
-
-.preview-green {
-    color: #0B8433;
-}
-
-.align_bottom_footer {
-    position: absolute;
-    bottom: 0;
-}
-
-
-.certificate-header {
-    margin-bottom: 40px;
-}
-
-
-header {
-    position: running(header);
-}
-
-.reference {
-    font-size: 13px;
-}
-
-#dbt-logo {
-    width: 210px;
-    margin: -30px 0 15px 64px;
-    display: inline-block;
-    vertical-align: top;
-}
-
-hr {
-    border-top: 0.15em solid black;
-    border-bottom: none;
-}
-
-
-.title-line {
-    margin-bottom: 25px;
-}
-
-
-p {
-    line-height: 1.3em;
-}
-
 .signature-block {
     display: flex;
     justify-content: space-evenly;
     align-items: stretch;
     flex-wrap: nowrap;
+    margin-bottom: 40px;
+}
+
+footer {
+    position: absolute;
+    bottom: 0;
 }
 
 .signature,
@@ -209,8 +142,8 @@ p {
 }
 
 .qr-text {
-    font-size: 11px;
-    margin: 0;
+    font-size: 12px;
+    margin-top: 20px;
 }
 
 

--- a/web/static/web/css/pdfs/constants.css
+++ b/web/static/web/css/pdfs/constants.css
@@ -8,6 +8,10 @@
     flex-direction: row;
 }
 
+.avoid-break {
+    break-inside: avoid;
+}
+
 .align-centre {
     align-items: center;
 }

--- a/web/templates/pdf/export/com-certificate.html
+++ b/web/templates/pdf/export/com-certificate.html
@@ -17,7 +17,8 @@
   </head>
 
   <body>
-    <div class="page-margin">
+    <div class="main-content">
+      <div class="blank-page"></div>
       <div class="certificate-header flex-row">
         <div class="flex-column two-third">
           {{ dbt_logo(classes="large-header-logo") }}
@@ -62,7 +63,7 @@
           </li>
         </ol>
       </div>
-      <footer class="align_bottom_footer">
+      <footer>
         <div class="signature-block flex-row">
           <div class="flex-column third">
             {% if preview %}
@@ -87,7 +88,7 @@
               <p class="{{ 'preview-orange' if preview }} mb-0 mt-0">
                 <strong>{{ certificate_code }}</strong>
               </p>
-                Alternatively you can go to <strong>{{ qr_check_url }}</strong> and enter the certificate reference and
+                Alternatively you can go to <strong class="avoid-break">{{ qr_check_url }}</strong> and enter the certificate reference and
                 code.
             </span>
           </div>

--- a/web/utils/pdf/generator.py
+++ b/web/utils/pdf/generator.py
@@ -169,6 +169,8 @@ class PdfGenerator(PdfGenBase):
         match self.application.process_type:
             case ProcessTypes.CFS:
                 return pages.format_cfs_pages(pdf_data, self.get_document_context())
+            case ProcessTypes.COM:
+                return pages.format_com_pages(pdf_data)
             case _:
                 return pdf_data
 

--- a/web/utils/pdf/pages.py
+++ b/web/utils/pdf/pages.py
@@ -48,3 +48,21 @@ def format_cfs_pages(pdf_data: bytes, context: dict[str, Any]) -> bytes:
     with io.BytesIO() as bytes_stream:
         writer.write(bytes_stream)
         return bytes_stream.getvalue()
+
+
+def format_com_pages(pdf_data: bytes) -> bytes:
+    """Function to merge the first page containing only the footer with the following pages
+    in CFS PDF documents."""
+
+    reader = pypdf.PdfReader(io.BytesIO(pdf_data))
+    writer = pypdf.PdfWriter()
+
+    footer_page = reader.pages[0]
+
+    for page in reader.pages[1:]:
+        page.merge_page(footer_page)
+        writer.add_page(page)
+
+    with io.BytesIO() as bytes_stream:
+        writer.write(bytes_stream)
+        return bytes_stream.getvalue()


### PR DESCRIPTION
Page breaks fixed by creating a first page with just a footer and merging it with the rest of the pages containing a larger bottom margin.

<img width="877" alt="image" src="https://github.com/uktrade/icms/assets/61604535/ec96da41-cf79-4806-b89b-0ade22df7adc">
