### PR TITLE
ICMSLST-2770 Add view to set new user details when first visiting site.

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -4820,3 +4820,5 @@ Business and Trade" src=
 "Save the current timestamp
 Patches the get_signature_file_base64
 get_signature_file_base64
+label_cols='one'
+{{ forms.submit_button(padding_cols="one

--- a/web/domains/user/forms.py
+++ b/web/domains/user/forms.py
@@ -8,6 +8,34 @@ from django_filters import CharFilter, ChoiceFilter, FilterSet
 from web.forms.fields import JqueryDateField, PhoneNumberField
 from web.forms.widgets import ICMSModelSelect2Widget, YesNoRadioSelectInline
 from web.models import Email, Exporter, Importer, PhoneNumber, User
+from web.one_login.constants import ONE_LOGIN_UNSET_NAME
+
+
+class OneLoginNewUserUpdateForm(forms.ModelForm):
+    class Meta:
+        model = User
+        fields = ["first_name", "last_name"]
+
+    def __init__(self, *args: Any, initial: dict[str, Any], instance: User, **kwargs: Any) -> None:
+        """Form used to get new users to provide their name.
+
+        The first_name and last_name of users coming from GOV.UK One Login will be set to
+        "one_login_unset".
+        For that scenario that form sets the initial value to "".
+        """
+
+        one_login_default_name = ONE_LOGIN_UNSET_NAME.casefold()
+
+        if instance.first_name.casefold() == one_login_default_name:
+            initial |= {"first_name": ""}
+
+        if instance.last_name.casefold() == one_login_default_name:
+            initial |= {"last_name": ""}
+
+        super().__init__(*args, initial=initial, instance=instance, **kwargs)
+
+        self.fields["first_name"].required = True
+        self.fields["last_name"].required = True
 
 
 class UserDetailsUpdateForm(forms.ModelForm):

--- a/web/domains/user/models.py
+++ b/web/domains/user/models.py
@@ -4,6 +4,8 @@ from django.db import models
 from guardian.core import ObjectPermissionChecker
 from guardian.mixins import GuardianUserMixin
 
+from web.one_login.constants import ONE_LOGIN_UNSET_NAME
+
 
 class User(GuardianUserMixin, AbstractUser):
     def __init__(self, *args, **kwargs):
@@ -44,8 +46,14 @@ class User(GuardianUserMixin, AbstractUser):
         return self.full_name
 
     @property
-    def full_name(self):
-        return " ".join(filter(None, (self.title, self.first_name, self.last_name)))
+    def full_name(self) -> str:
+        """Returns full name of user."""
+
+        return " ".join(
+            name
+            for name in (self.title, self.first_name, self.last_name)
+            if name and name != ONE_LOGIN_UNSET_NAME
+        )
 
     @property
     def account_last_login_date(self):

--- a/web/domains/user/urls.py
+++ b/web/domains/user/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
         include(
             [
                 path("", views.UserUpdateView.as_view(), name="user-edit"),
+                path("new-user/", views.NewUserUpdateView.as_view(), name="new-user-edit"),
                 path(
                     "number/",
                     include(

--- a/web/domains/user/views.py
+++ b/web/domains/user/views.py
@@ -36,6 +36,7 @@ from web.views import ModelFilterView
 
 from .actions import ActivateUser, DeactivateUser
 from .forms import (
+    OneLoginNewUserUpdateForm,
     OneLoginTestAccountsCreateForm,
     UserDetailsUpdateForm,
     UserEmailForm,
@@ -102,6 +103,26 @@ class UserUpdateView(UserBaseMixin, UpdateView):
                     return reverse("access:importer-request")
 
         return super().get_success_url()
+
+
+class NewUserUpdateView(LoginRequiredMixin, UpdateView):
+    """View shown after a new user is redirected back to ICMS from GOV.UK One Login."""
+
+    # UpdateView config
+    model = User
+    pk_url_kwarg = "user_pk"
+    form_class = OneLoginNewUserUpdateForm
+    template_name = "web/domains/user/one_login/user_edit.html"
+
+    def get_success_url(self) -> str:
+        site = self.request.site
+
+        if is_exporter_site(site):
+            return reverse("access:exporter-request")
+        elif is_importer_site(site):
+            return reverse("access:importer-request")
+        else:
+            return reverse("workbasket")
 
 
 class UserCreateTelephoneView(UserBaseMixin, CreateView):

--- a/web/one_login/backends.py
+++ b/web/one_login/backends.py
@@ -4,13 +4,13 @@ from django.contrib.auth import get_user_model
 from django.http import HttpRequest
 
 from . import types
+from .constants import ONE_LOGIN_UNSET_NAME
 from .utils import get_client, get_userinfo, has_valid_token
 
 if TYPE_CHECKING:
     from django.contrib.auth.models import User
 
 UserModel = get_user_model()
-ONE_LOGIN_UNSET_NAME = "one_login_unset"
 
 
 class OneLoginBackend:

--- a/web/one_login/constants.py
+++ b/web/one_login/constants.py
@@ -1,0 +1,3 @@
+# Default name used when saving a user record for a new GOV.UK One Login user.
+# We need this because GOV.UK One Login will not provide name data without identity verification.
+ONE_LOGIN_UNSET_NAME = "one_login_unset"

--- a/web/templates/web/domains/user/one_login/user_edit.html
+++ b/web/templates/web/domains/user/one_login/user_edit.html
@@ -1,0 +1,19 @@
+{% extends "layout/no-sidebar.html" %}
+{% import "forms/forms.html" as forms %}
+{% import "forms/fields.html" as form_fields %}
+
+{% block main_content %}
+  <h4>Welcome to {{ request.site.name }}.</h4>
+  <br>
+  <p>Before continuing please enter your contact details below.</p>
+  <br>
+  <div class="row">
+    {% call forms.form(action='', method='post', csrf_input=csrf_input) -%}
+      {% for field in form %}
+        {{ form_fields.field(field, label_cols='one', padding='zero', input_cols='six') }}
+      {% endfor %}
+      {{ forms.form_errors(form) }}
+      {{ forms.submit_button(padding_cols="one", btn_label="Submit") }}
+    {% endcall %}
+  </div>
+{% endblock %}

--- a/web/tests/domains/user/test_forms.py
+++ b/web/tests/domains/user/test_forms.py
@@ -3,11 +3,13 @@ import random
 from django.test import TestCase
 
 from web.domains.user.forms import (
+    OneLoginNewUserUpdateForm,
     UserDetailsUpdateForm,
     UserListFilter,
     UserPhoneNumberForm,
 )
 from web.models import PhoneNumber
+from web.one_login.constants import ONE_LOGIN_UNSET_NAME
 
 TOTAL_TEST_USERS = 19
 
@@ -138,3 +140,23 @@ class TestUserPhoneNumberForm(TestCase):
         assert form.is_valid() is True
         form = UserPhoneNumberForm(data=self.phone_number("+90 216 123 45 67"))
         assert form.is_valid() is True
+
+
+class TestOneLoginNewUserUpdateForm:
+    def test_form_errors_when_first_name_is_unset(self, importer_one_contact):
+        importer_one_contact.first_name = ONE_LOGIN_UNSET_NAME
+        importer_one_contact.save()
+
+        form = OneLoginNewUserUpdateForm(initial={}, instance=importer_one_contact)
+
+        assert form["first_name"].initial == ""
+        assert form["last_name"].initial == importer_one_contact.last_name
+
+    def test_form_sets_correct_initial_data_for_last_name(self, importer_one_contact):
+        importer_one_contact.last_name = ONE_LOGIN_UNSET_NAME
+        importer_one_contact.save()
+
+        form = OneLoginNewUserUpdateForm(initial={}, instance=importer_one_contact)
+
+        assert form["first_name"].initial == importer_one_contact.first_name
+        assert form["last_name"].initial == ""

--- a/web/tests/middleware/test_one_login.py
+++ b/web/tests/middleware/test_one_login.py
@@ -1,0 +1,63 @@
+from unittest import mock
+
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+
+from web.middleware.one_login import UserFullyRegisteredMiddleware
+from web.one_login.constants import ONE_LOGIN_UNSET_NAME
+
+
+class TestUserFullyRegisteredMiddleware:
+    def test_middleware_redirects_to_edit_new_user_first_name(self, rf, importer_one_contact):
+        request = rf.request()
+
+        importer_one_contact.first_name = ONE_LOGIN_UNSET_NAME
+        importer_one_contact.save()
+
+        request.path = reverse("workbasket")
+        request.user = importer_one_contact
+
+        with mock.patch("web.middleware.one_login.messages") as mock_messages:
+            middleware = UserFullyRegisteredMiddleware(mock.Mock())
+            response: HttpResponseRedirect = middleware(request)
+
+            assert mock_messages.info.call_count == 1
+            assert mock_messages.info.call_args == mock.call(
+                request, "Please set your first and last name."  # /PS-IGNORE
+            )
+
+        assert response.status_code == 302
+        assert response.url == reverse("new-user-edit", kwargs={"user_pk": importer_one_contact.pk})
+
+    def test_middleware_redirects_to_edit_new_user_last_name(self, rf, importer_one_contact):
+        request = rf.request()
+
+        importer_one_contact.last_name = ONE_LOGIN_UNSET_NAME
+        importer_one_contact.save()
+
+        request.path = reverse("workbasket")
+        request.user = importer_one_contact
+
+        with mock.patch("web.middleware.one_login.messages") as mock_messages:
+            middleware = UserFullyRegisteredMiddleware(mock.Mock())
+            response: HttpResponseRedirect = middleware(request)
+
+            assert mock_messages.info.call_count == 1
+            assert mock_messages.info.call_args == mock.call(
+                request, "Please set your first and last name."  # /PS-IGNORE
+            )
+
+        assert response.status_code == 302
+        assert response.url == reverse("new-user-edit", kwargs={"user_pk": importer_one_contact.pk})
+
+    def test_middleware_does_not_redirect_to_edit_user(self, rf, importer_one_contact):
+        request = rf.request()
+
+        request.path = reverse("workbasket")
+        request.user = importer_one_contact
+
+        mock_get_response = mock.Mock()
+        middleware = UserFullyRegisteredMiddleware(mock_get_response)
+        middleware(request)
+
+        assert mock_get_response.call_args == mock.call(request)


### PR DESCRIPTION
Changes:
  - Add NewUserUpdateView view.
  - Update UserFullyRegisteredMiddleware to redirect to new view.
  - Remove "one_login_unset" from User.full_name property.
  - Move ONE_LOGIN_UNSET_NAME to constants.py file.
  
New view:
![import-a-licence_8080_user_40_new-user_](https://github.com/uktrade/icms/assets/8921101/d617af8b-e974-42f9-8e8e-bb8c5d67b024)
