### PR TITLE
Data Migration - Fix constabulary emails query

### DIFF
--- a/data_migration/queries/import_application/fa/emails.py
+++ b/data_migration/queries/import_application/fa/emails.py
@@ -1,27 +1,30 @@
-# The xview_ima_constabulary_emails view truncates the body and response over 4000 characters so extract those fields from the xml
 constabulary_emails = """
 SELECT
-  ce.ima_id
-  , ce.email_status status
+  iad.id imad_id
+  , iad.ima_id
+  , x.status email_status
   , cd.email_address "to"
-  , ce.email_cc_address_list cc_address_list_str
-  , ce.email_subject subject
-  , x.body
-  , x.response
-  , ce.email_sent_datetime sent_datetime
-  , ce.email_closed_datetime closed_datetime
-  , firearms_certificate_list constabulary_attachments_xml
-  , 'IMA_CONSTAB_EMAIL' template_code
-  , 'CONSTABULARY' email_type
-FROM impmgr.xview_ima_constabulary_emails ce
-INNER JOIN impmgr.import_application_details iad ON iad.ima_id = ce.ima_id AND iad.status_control = 'C'
+  , x.email_cc_address_list cc_address_list_str
+  , x.email_subject subject
+  , x.firearms_certificate_list constabulary_attachments_xml
+  , email_body body
+  , x.email_response response
+  , dt.to_date_safe(x.sent_datetime, 'YYYY-MM-DD"T"HH24:MI:SS') sent_datetime
+  , dt.to_date_safe(x.closed_datetime, 'YYYY-MM-DD"T"HH24:MI:SS') closed_datetime
+FROM impmgr.import_application_details iad
 CROSS JOIN XMLTABLE('/*/APP_PROCESSING/CONSTABULARY_EMAIL_MASTER/CONSTABULARY_EMAIL_LIST/CONSTABULARY_EMAIL'
   PASSING iad.xml_data
   COLUMNS
-  body CLOB PATH '/*/EMAIL_BODY/text()'
-  , response CLOB PATH '/*/EMAIL_RESPONSE/text()'
+    status VARCHAR2(4000) PATH '/*/STATUS/text()'
+  , constabulary VARCHAR2(4000) PATH '/*/CONSTABULARY/text()'
+  , email_cc_address_list VARCHAR2(4000) PATH '/*/EMAIL_CC_ADDRESS_LIST/text()'
+  , email_subject VARCHAR2(4000) PATH '/*/EMAIL_SUBJECT/text()'
+  , firearms_certificate_list XMLTYPE PATH '/*/FIREARMS_CERTIFICATE_LIST'
+  , email_body CLOB PATH '/*/EMAIL_BODY/text()'
+  , email_response CLOB PATH '/*/EMAIL_RESPONSE/text()'
+  , sent_datetime VARCHAR2(4000) PATH '/*/SENT_DATETIME/text()'
+  , closed_datetime VARCHAR2(4000) PATH '/*/CLOSED_DATETIME/text()'
 ) x
-LEFT JOIN impmgr.xview_constabulary_details cd ON cd.con_id = ce.email_constabulary AND cd.status_control = 'C'
+LEFT JOIN impmgr.xview_constabulary_details cd ON cd.con_id = x.constabulary AND cd.status_control = 'C'
 WHERE iad.status_control = 'C'
-ORDER BY ima_id
 """

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -4829,3 +4829,6 @@ Approval Complete
 Access Request\nFurther Information Requested
 len(expected_row.keys
 x.closed_by_id
+SELECT iad.id imad_id
+iad.ima_id
+CLOB PATH


### PR DESCRIPTION
Changing the query as the previous caused multiple joins to the same row if an application had multiple constabulary emails