### PR TITLE
Removing pdf/pages.py from coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,6 +150,7 @@ jobs:
               --cov=web \
               --cov=config \
               --cov-report=json:test-reports/coverage.json \
+              --cov-config=.coveragerc \
               --circleci-parallelize \
               --maxprocesses=2 \
               -n=auto \

--- a/.coveragerc
+++ b/.coveragerc
@@ -18,6 +18,7 @@ omit =
     web/management/commands/drop_all_tables.py
     web/management/commands/query_task_result.py
     web/harness/*
+    web/utils/pdf/pages.py
 
 [report]
 exclude_lines =


### PR DESCRIPTION
Removing web/utils/pdf/pages.py from coverage as those functions are implicitly tested through the PDF visual regression tests