### PR TITLE
ICMSLST-2785 Make registered_number optional for all orgs and agents.

### DIFF
--- a/web/domains/exporter/forms.py
+++ b/web/domains/exporter/forms.py
@@ -56,24 +56,28 @@ class ExporterForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["name"].required = True
-        self.fields["registered_number"].required = True
 
-    def clean_registered_number(self):
-        registered_number = self.cleaned_data["registered_number"]
+        # Set in clean_registered_number if a company is found
+        self.company = None
 
-        # this is parsed in save()
-        try:
-            self.company = api_get_company(registered_number)
-        except APIError as e:
-            raise ValidationError(e.error_msg)
-        except CompanyNotFound:
-            self.company = None
+    def clean_registered_number(self) -> str | None:
+        if registered_number := self.cleaned_data.get("registered_number"):
+            # this is parsed in save()
+            try:
+                self.company = api_get_company(registered_number)
+            except APIError as e:
+                raise ValidationError(e.error_msg)
+            except CompanyNotFound:
+                self.company = None
 
-        return registered_number
+            return registered_number
+
+        return None
 
     def save(self, commit=True):
         instance = super().save(commit)
 
+        # Creates an office if registered_number was set and returned a company.
         if commit and self.company:
             office_address = self.company.get("registered_office_address", {})
             address_line_1 = office_address.get("address_line_1")
@@ -123,7 +127,6 @@ class AgentForm(forms.ModelForm):
 
         self.fields["main_exporter"].required = True
         self.fields["name"].required = True
-        self.fields["registered_number"].required = False
 
 
 class AgentNonILBForm(AgentForm):

--- a/web/domains/exporter/views.py
+++ b/web/domains/exporter/views.py
@@ -94,7 +94,9 @@ def create_exporter(request: AuthenticatedHttpRequest) -> HttpResponse:
         if form.is_valid():
             exporter: Exporter = form.save()
             messages.info(request, "Exporter created successfully."),
-            return redirect(reverse("exporter-list") + "?" + urlencode({"name": exporter.name}))
+            return redirect(
+                reverse("exporter-list") + "?" + urlencode({"exporter_name": exporter.name})
+            )
     else:
         form = ExporterForm()
 
@@ -119,7 +121,9 @@ def edit_exporter(request: AuthenticatedHttpRequest, *, pk: int) -> HttpResponse
         exporter = form.save()
         messages.info(request, "Updated exporter details have been saved.")
         if request.user.has_perm(Perms.sys.exporter_admin):
-            return redirect(reverse("exporter-list") + "?" + urlencode({"name": exporter.name}))
+            return redirect(
+                reverse("exporter-list") + "?" + urlencode({"exporter_name": exporter.name})
+            )
         else:
             return redirect(reverse("user-exporter-list"))
 

--- a/web/templates/partial/importer/detail.html
+++ b/web/templates/partial/importer/detail.html
@@ -11,7 +11,7 @@
     <dt class="bold">Organisation Name</dt>
     <dd>{{ importer.name }}</dd>
     <dt class="bold">Registered Number</dt>
-    <dd>{{ importer.registered_number }}</dd>
+    <dd>{{ importer.registered_number|default("", True) }}</dd>
     <dt class="bold">Importer EORI Number</dt>
     <dd>{{ importer.eori_number|default("N/A", True) }}</dd>
     <dt class="bold">Importer Region Origin</dt>

--- a/web/templates/web/domains/exporter/detail.html
+++ b/web/templates/web/domains/exporter/detail.html
@@ -31,7 +31,7 @@
       Registered Number
     </dt>
     <dd>
-      {{ object.registered_number }}
+      {{ object.registered_number|default("", True) }}
     </dd>
     <dt class="bold">
       Comments

--- a/web/tests/domains/exporter/test_views.py
+++ b/web/tests/domains/exporter/test_views.py
@@ -103,7 +103,7 @@ class TestExporterCreateView(AuthTestCase):
             self.url, {"name": "test exporter", "registered_number": "42"}
         )
         exporter = Exporter.objects.first()
-        assertRedirects(response, reverse("exporter-list") + f"?name={exporter.name}")
+        assertRedirects(response, reverse("exporter-list") + f"?exporter_name={exporter.name}")
         assert "Exporter created successfully." in get_messages_from_response(response)
         assert exporter.name == "test exporter"
 
@@ -164,7 +164,7 @@ class TestEditExporterView(AuthTestCase):
             {"name": "test exporter", "registered_number": "42", "exclusive_correspondence": False},
         )
         exporter = Exporter.objects.first()
-        assertRedirects(response, reverse("exporter-list") + f"?name={exporter.name}")
+        assertRedirects(response, reverse("exporter-list") + f"?exporter_name={exporter.name}")
         assert "Updated exporter details have been saved." in get_messages_from_response(response)
         assert exporter.name == "test exporter"
         assert exporter.exclusive_correspondence is False


### PR DESCRIPTION
Changes:
  - Make Registered Number optional when creating a main Importer.
  - Make Registered Number optional when creating an agent Importer.
  - Make Registered Number optional when creating a main Exporter.
  - Fix exporter redirects to use correct query param name.