### PR TITLE
ICMSLST-2797 Update Account Recovery page content.

### DIFF
--- a/web/templates/registration/v1_account_recovery.html
+++ b/web/templates/registration/v1_account_recovery.html
@@ -3,15 +3,12 @@
 {% block main_content %}
 
   <div id="header">
-    <h1>Account Recovery</h1>
+    <h1>Link your existing account</h1>
     <p class="subheading">{{ request.site.name }}</p>
   </div>
   <div class="clearBoth"></div>
-  <p>Please enter the email address and password you used in the old version of {{ request.site.name }} (This was previously called ICMS).</p>
-  <p>Doing this will link all your old data to your GOV.UK One Login user.</p>
-  <p>If successful you will be logged out of {{ request.site.name }}, when you log in again you will be linked to all your old data.</p>
-  <div class="info-box info-box-warning">Any data currently linked to your user will be replaced by the old data</div>
-
+  <p>To link all your existing data to your new account, use the email address and password you used for ICMS.</p>
+  <p>You will be automatically signed out. When you sign back in, you will be able to see all your old information.</p>
   {% call forms.form(method='post', csrf_input=csrf_input) %}
     {% for field in form %}
       {{ fields.field(field) }}
@@ -24,8 +21,7 @@
         <div class="eight columns">
           <ul class="menu-out flow-across">
             <li>
-              <button type="submit" value="save" class="primary-button button">Recover Account
-              </button>
+              <button type="submit" value="save" class="primary-button button">Link existing account</button>
             </li>
           </ul>
         </div>

--- a/web/templates/web/domains/user/user_edit.html
+++ b/web/templates/web/domains/user/user_edit.html
@@ -13,7 +13,7 @@
       <li><a href="{{ icms_url('accounts:password_change') }}">Change Password</a></li>
     {% endif %}
     {% if show_account_recovery %}
-      <li><a href="{{ icms_url('account-recovery') }}">Account Recovery</a></li>
+      <li><a href="{{ icms_url('account-recovery') }}">Link your existing account</a></li>
     {% endif %}
   </ul>
 {% endblock %}


### PR DESCRIPTION
Rename "Account Recovery" to "Link your existing account".

Menu item label:
![image](https://github.com/user-attachments/assets/d76b4bd4-aa76-4418-9d8b-502aa52d4075)

Account Recovery content changes:
![image](https://github.com/user-attachments/assets/e4171096-f19a-43f5-a94c-fce2f5e36ae0)
