### PR TITLE
ICMSLST-2901 Add view to review a case with errors back to processing.

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -4864,3 +4864,5 @@ class="paper-header"><strong
 div class="mb-0-5
 Chapter 93</p
 Department for Business and Trade,<br/
+utils.application_history("IMA/2024/00001
+Document Packs

--- a/web/domains/case/_import/models.py
+++ b/web/domains/case/_import/models.py
@@ -414,7 +414,7 @@ class ImportApplicationLicence(DocumentPackBase):
         ia_pk = self.import_application_id
         st = self.status
         cr = self.case_reference
-        ca = self.created_at
+        ca = self.created_at.strftime("%Y/%m/%d %H:%M:%S")
 
         return (
             f"ImportApplicationLicence("

--- a/web/domains/case/utils.py
+++ b/web/domains/case/utils.py
@@ -165,10 +165,10 @@ def redirect_after_submit(app: ImpOrExp, request: AuthenticatedHttpRequest) -> H
 
 
 def application_history(app_reference: str, is_import: bool = True) -> None:
-    """Debug method to print the history of the application
+    """Debug method to print the history of the application.
 
-    >>> import importlib as im; from web.domains.case import utils
-    >>> im.reload(utils); utils.application_history("IMA/2023/00001")
+    >>> import os; import importlib as im; from web.domains.case import utils
+    >>> os.system("clear"); im.reload(utils); utils.application_history("IMA/2024/00001")
     """
 
     if is_import:
@@ -186,16 +186,26 @@ def application_history(app_reference: str, is_import: bool = True) -> None:
 
     print("\nActive Tasks in order:")
     for t in active:
-        print(f"Task: {t.get_task_type_display()}, created={t.created}, finished={t.finished}")
+        _print_task(t)
 
     print("\nAll tasks in order:")
     for t in all_tasks:
-        print(f"Task: {t.get_task_type_display()}, created={t.created}, finished={t.finished}")
+        _print_task(t)
 
     print("*-" * 40)
-
+    print("Document Packs:")
     for p in document_pack._get_qm(app).order_by("created_at"):
-        print(f"DocumentPack: {p}")
+        print(f"\t- {p}")
+        for df in p.document_references.all():
+            print(f"\t\t- {df}")
+
+
+def _print_task(t: Task) -> None:
+    task_type = t.get_task_type_display()
+    created = t.created.strftime("%Y/%m/%d %H:%M:%S")
+    finished = t.finished.strftime("%Y-%m-%d %H:%M:%S") if t.finished else ""
+
+    print(f"\tTask: {task_type}, created={created}, finished={finished}")
 
 
 def case_documents_metadata(application: ApplicationsWithCaseEmail) -> CaseDocumentsMetadata:

--- a/web/domains/chief/urls.py
+++ b/web/domains/chief/urls.py
@@ -17,6 +17,11 @@ urlpatterns = [
         name="resend-licence",
     ),
     path(
+        "revert-licence-to-processing/<int:application_pk>",
+        views.RevertLicenceToProcessingView.as_view(),
+        name="revert-licence-to-processing",
+    ),
+    path(
         "check-progress/<int:application_pk>",
         views.CheckChiefProgressView.as_view(),
         name="check-progress",

--- a/web/templates/web/domains/chief/failed_licences.html
+++ b/web/templates/web/domains/chief/failed_licences.html
@@ -76,6 +76,19 @@
                   Update importer details
                 </a>
               </li>
+              {% if app.status in ["PROCESSING", "VARIATION_REQUESTED"] %}
+                <li>
+                  <form method="post" action="{{ icms_url("chief:revert-licence-to-processing", kwargs={"application_pk": app.pk}) }}">
+                    {{ csrf_input }}
+                    <button
+                        type="submit" class="button link-button icon-redo2"
+                        data-confirm="Are you sure you want to revert this application to the processing state?"
+                    >
+                      Revert to Processing
+                    </button>
+                  </form>
+                </li>
+              {% endif %}
             </ul>
           </td>
         </tr>


### PR DESCRIPTION
Add the ability to recover from ICMS-HMRC serialization errors using the front end.

![caseworker_8080_chief_failed-licences_](https://github.com/user-attachments/assets/831c02c4-7457-4a79-9cb5-f1688f662fa9)
![caseworker_8080_chief_failed-licences_ (1)](https://github.com/user-attachments/assets/4641de85-31fe-4b7e-a241-8a54839d2587)
![caseworker_8080_chief_failed-licences_ (2)](https://github.com/user-attachments/assets/f7920909-faa5-4a33-bb09-63e172b854aa)
