### PR TITLE
ICMSLST-2876 - FA-DFL -> Authorise Documents -> Response Documents -> Incorrect labels

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -4873,3 +4873,4 @@ Start Now”
 SEARCH
 Approve Application
 Refuse Application
+Firearms Cover Letter

--- a/web/domains/case/views/views_misc.py
+++ b/web/domains/case/views/views_misc.py
@@ -688,7 +688,6 @@ def get_document_context(
 
         context = {
             "cover_letter_flag": at.cover_letter_flag,
-            "type_label": at.Types(at.type).label,
             "customs_copy": at.type == at.Types.OPT,
             "is_cfs": False,
             "document_reference": licence_doc.reference,
@@ -702,6 +701,9 @@ def get_document_context(
             ProcessTypes.FA_SIL,
         ]:
             cover_letter = document_pack.doc_ref_cover_letter_get(licence)
+
+            # Firearms application label
+            type_label = "Firearms"
 
             if application.status == ImpExpStatus.COMPLETED or issued_document:
                 cover_letter_url = reverse(
@@ -721,6 +723,11 @@ def get_document_context(
 
             context["cover_letter_url"] = cover_letter_url
 
+        else:
+            # if not a firearms application, default to the application type label
+            type_label = at.Types(at.type).label
+
+        context["type_label"] = type_label
     else:
         # A supplied document pack or the current draft pack
         certificate = issued_document or document_pack.pack_draft_get(application)

--- a/web/tests/domains/case/views/test_views_misc.py
+++ b/web/tests/domains/case/views/test_views_misc.py
@@ -776,8 +776,8 @@ class TestViewIssuedCaseDocumentsView:
             "Firearms and Ammunition (Specific Individual Import Licence) - Issued Documents",
         )
         assertContains(response, "<h3>Issued documents (15-Jun-2020 11:44)</h3>")
-        assertContains(response, "Firearms and Ammunition Cover Letter")
-        assertContains(response, "Firearms and Ammunition Licence")
+        assertContains(response, "Firearms Cover Letter")
+        assertContains(response, "Firearms Licence")
 
 
 def _test_reassign_ownership_view(ilb_admin_client, ilb_admin_user, ilb_admin_two, app, case_type):


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/1ce09ef9-59d7-4652-af6e-fe5314a0204f)


After:
![image](https://github.com/user-attachments/assets/51fc5ac2-6234-44ee-ac64-49522190752c)
