### PR TITLE
ICMSLST-2830 Fix app withdrawal bugs relating to status refactor.

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -4924,3 +4924,10 @@ template.created_datetime|datetime_format('%d-%b-%Y
 {{ application_field(platform_user.importer_last_login|datetime_format('%d
 {{ application_field(platform_user.exporter_last_login|datetime_format('%d %
 {{ application_field(object.created_datetime|datetime_format('%d %
+{{ btn_label }
+{{ display.application_field(withdrawal.reason
+{{ display.application_field(withdrawal.created_datetime|datetime_format('%d-%b-%Y'
+{{ display.application_field(withdrawal.request_by
+{{ display.application_field(withdrawal.response
+{{ display.application_field(withdrawal.updated_datetime|datetime_format('%d-%b-%Y'
+Responded Date

--- a/web/domains/case/forms.py
+++ b/web/domains/case/forms.py
@@ -94,6 +94,7 @@ class WithdrawForm(forms.ModelForm):
     class Meta:
         model = WithdrawApplication
         fields = ("reason",)
+        labels = {"reason": "Withdraw Reason"}
 
 
 class WithdrawResponseForm(forms.ModelForm):

--- a/web/domains/case/views/views_misc.py
+++ b/web/domains/case/views/views_misc.py
@@ -149,7 +149,7 @@ def withdraw_case(
             "page_title": get_case_page_title(case_type, application, "Withdrawals"),
             "form": form,
             "withdrawals": withdrawals,
-            "previous_withdrawals": withdrawals.exclude(status="open"),
+            "previous_withdrawals": withdrawals.exclude(status=WithdrawApplication.Statuses.OPEN),
             "case_type": case_type,
         }
         return render(request, "web/domains/case/withdraw.html", context)
@@ -259,7 +259,7 @@ def manage_withdrawals(
             "form": form,
             "withdrawals": withdrawals,
             "current_withdrawal": current_withdrawal,
-            "previous_withdrawals": withdrawals.exclude(status="open"),
+            "previous_withdrawals": withdrawals.exclude(status=WithdrawApplication.Statuses.OPEN),
             "case_type": case_type,
             "readonly_view": readonly_view,
         }

--- a/web/templates/forms/forms.html
+++ b/web/templates/forms/forms.html
@@ -43,13 +43,19 @@
   {% endif %}
 {%- endmacro %}
 
-{% macro submit_button(padding_cols="three", field_cols="six", btn_label="Create") %}
+{% macro submit_button(padding_cols="three", field_cols="six", btn_label="Create", data_confirm="") %}
   <div class="row">
     <div class="{{ padding_cols }} columns"></div>
     <div class="{{ field_cols }} columns">
       <ul class="menu-out flow-across">
         <li>
-          <button type="submit" class="primary-button button">{{ btn_label }}</button>
+          <button
+            type="submit"
+            class="primary-button button"
+            {% if data_confirm %} data-confirm="{{ data_confirm }}"{% endif %}
+          >
+            {{ btn_label }}
+          </button>
         </li>
       </ul>
     </div>

--- a/web/templates/partial/case/export/sidebar-management.html
+++ b/web/templates/partial/case/export/sidebar-management.html
@@ -21,7 +21,7 @@
   {% endwith %}
 
   {% with total = process.withdrawals.count(),
-          processed = process.withdrawals.exclude(status="open").count() %}
+          processed = process.withdrawals.exclude(status=process.withdrawals.model.Statuses.OPEN).count() %}
     {{ icms_link(request, icms_url('case:manage-withdrawals', kwargs={'application_pk': process.pk, 'case_type': 'export'}),
                  'Application Withdrawals (' + processed|string + '/' + total|string + ')') }}
   {% endwith %}

--- a/web/templates/partial/case/import/sidebar-management.html
+++ b/web/templates/partial/case/import/sidebar-management.html
@@ -49,7 +49,7 @@
 
   {# Common import application links #}
   {% with total = process.withdrawals.count(),
-          processed = process.withdrawals.exclude(status="open").count() %}
+          processed = process.withdrawals.exclude(status=process.withdrawals.model.Statuses.OPEN).count() %}
     {{ icms_link(request, icms_url('case:manage-withdrawals', kwargs={'application_pk': process.pk, 'case_type': 'import'}),
                   'Application Withdrawals (' + processed|string + '/' + total|string + ')') }}
   {% endwith %}

--- a/web/templates/partial/withdrawal/box.html
+++ b/web/templates/partial/withdrawal/box.html
@@ -1,43 +1,44 @@
+{% import "display/fields.html" as display %}
+{% set WS = withdrawal.Statuses %}
+
 <fieldset>
   <legend class="bold">
     Withdrawal - {{ withdrawal.get_status_display() }}
   </legend>
 
-  <div class="row">
-    <div class="two columns"></div>
-    <div class="eight columns">
-      <dl>
-        <dt class="bold">Status</dt>
+  {% call display.application_section() %}
+    <div class="row">
+      <div class="three columns">
+        <label class="prompt west">
+          Status
+        </label>
+      </div>
+      <div class="six columns">
         <dd class="status {{ withdrawal.status.lower() }}">
           <span class="text-widget">{{ withdrawal.get_status_display() }}</span>
         </dd>
-        <dt class="bold">Withdraw Reason</dt>
-        <dd>{{ withdrawal.reason|default('N/A', true)|nl2br }}</dd>
-        <dt class="bold">Request Date</dt>
-        <dd>{{ withdrawal.created_datetime|datetime_format('%d-%b-%Y') }}</dd>
-        <dt class="bold">Requested By</dt>
-        <dd>{{ withdrawal.request_by }}</dd>
-
-        {% if withdrawal.status == "rejected" %}
-          <dt class="bold">Withdraw Reject Reason</dt>
-          <dd>{{ withdrawal.response|default('N/A', true)|nl2br }}</dd>
-          <dt class="bold">Responded Date</dt>
-          <dd>{{ withdrawal.updated_datetime|datetime_format('%d-%b-%Y') }}</dd>
-          <dt class="bold">Response By</dt>
-          <dd>{{ withdrawal.response_by }}</dd>
-        {% endif %}
-      </dl>
-
-      {% if withdrawal.status == "open" %}
-        <form method="post" action="{{ icms_url("case:archive-withdrawal", kwargs={'application_pk': process.pk, 'withdrawal_pk': withdrawal.pk, 'case_type': case_type }) }}">
-          {{ csrf_input }}
-          <input
-            type="submit" class="button" value="Retract Request"
-            data-confirm="Are you sure you want to retract this withdrawal request?"
-          />
-        </form>
-      {% endif %}
+      </div>
+      <div class="three columns"></div>
     </div>
-    <div class="two columns"></div>
-  </div>
+
+    {{ display.application_field(withdrawal.reason, "Withdraw Reason", "N/A") }}
+    {{ display.application_field(withdrawal.created_datetime|datetime_format('%d-%b-%Y'), "Request Date") }}
+    {{ display.application_field(withdrawal.request_by, "Requested By") }}
+
+    {% if withdrawal.status == WS.REJECTED %}
+      {{ display.application_field(withdrawal.response, "Withdraw Reject Reason", "N/A") }}
+      {{ display.application_field(withdrawal.updated_datetime|datetime_format('%d-%b-%Y'), "Responded Date", "N/A") }}
+      {{ display.application_field(withdrawal.response_by, "Response By") }}
+    {% endif %}
+  {% endcall %}
+
+{% if withdrawal.status == WS.OPEN %}
+  <form method="post" action="{{ icms_url("case:archive-withdrawal", kwargs={'application_pk': process.pk, 'withdrawal_pk': withdrawal.pk, 'case_type': case_type }) }}">
+    {{ csrf_input }}
+    <input
+      type="submit" class="button" value="Retract Request"
+      data-confirm="Are you sure you want to retract this withdrawal request?"
+    />
+  </form>
+{% endif %}
 </fieldset>

--- a/web/templates/web/domains/case/withdraw.html
+++ b/web/templates/web/domains/case/withdraw.html
@@ -7,7 +7,7 @@
 
 {% block main_content %}
   <h3>Application Withdrawals</h3>
-  {% for withdrawal in withdrawals.filter(status="open") %}
+  {% for withdrawal in withdrawals.filter(status=withdrawals.model.Statuses.OPEN) %}
     {% include "partial/withdrawal/box.html" %}
   {% else %}
     <div class="info-box info-box-info">
@@ -36,28 +36,16 @@
       {% for field in form %}
         {{ fields.field(field) }}
       {% endfor %}
-
-      <div class="container">
-        <div class="row">
-          <div class="three columns"></div>
-          <div class="eight columns">
-            <ul class="menu-out flow-across">
-              <li>
-                <input
-                  type="submit" name="action" class="primary-button button" value="Withdraw"
-                  data-confirm="Are you sure you want to send this withdrawal request?"
-                />
-              </li>
-            </ul>
-          </div>
-        </div>
-      </div>
+      {{ forms.submit_button(btn_label="Withdraw", data_confirm="Are you sure you want to send this withdrawal request?") }}
     </fieldset>
     {% endcall %}
   {% endfor %}
 
-  {% for withdrawal in previous_withdrawals %}
-    {% include "partial/withdrawal/box.html" %}
-  {% endfor %}
+  {% if previous_withdrawals.exists() %}
+    <h3>Previous withdrawals</h3>
+    {% for withdrawal in previous_withdrawals %}
+      {% include "partial/withdrawal/box.html" %}
+    {% endfor %}
+  {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
Changes:
  - Update several places WithdrawApplication.Statuses is used.
  - Add a missing form label
  - Refactor how app withdrawals are shown.

You can no longer add multiple open withdrawal requests and can withdraw if needed:
![import-a-licence_8080_case_import_2_applicant_withdraw_](https://github.com/user-attachments/assets/02f02630-1eda-460f-abd5-c843e6426c7e)
