### PR TITLE
Fix naive datetime instances used for date_joined values.

### DIFF
--- a/web/management/commands/add_dummy_data.py
+++ b/web/management/commands/add_dummy_data.py
@@ -587,7 +587,7 @@ class Command(BaseCommand):
             last_name=last_name,
             date_of_birth=dt.date(2000, 1, 1),
             icms_v1_user=icms_v1_user,
-            date_joined=dt.date(2020, 1, 20),
+            date_joined=dt.datetime(2020, 1, 20, tzinfo=dt.UTC),
         )
 
         Email.objects.create(

--- a/web/management/commands/add_test_data.py
+++ b/web/management/commands/add_test_data.py
@@ -217,7 +217,7 @@ class Command(BaseCommand):
             job_title=f"{username}_job_title",
             organisation=f"{username}_org",
             department=f"{username}_dep",
-            date_joined=dt.date(2024, 1, 20),
+            date_joined=dt.datetime(2024, 1, 20, tzinfo=dt.UTC),
         )
 
     def create_import_access_request(self, user):


### PR DESCRIPTION
Fix warnings shown when running tests:
![image](https://github.com/user-attachments/assets/f9e5ecf2-c233-4b99-8e36-34e487f8eac5)
