### PR TITLE
ICMSLST-2963 Add ability to test icms / icms-hmrc connections.

### DIFF
--- a/web/domains/chief/urls.py
+++ b/web/domains/chief/urls.py
@@ -31,4 +31,9 @@ urlpatterns = [
         "license-data-callback", views.LicenseDataCallback.as_view(), name="license-data-callback"
     ),
     path("usage-data-callback", views.UsageDataCallbackView.as_view(), name="usage-data-callback"),
+    path(
+        "check-icms-connection/",
+        views.CheckICMSConnectionView.as_view(),
+        name="check_icms_connection",
+    ),
 ]

--- a/web/domains/chief/views.py
+++ b/web/domains/chief/views.py
@@ -1,4 +1,5 @@
 import http
+import json
 from typing import Any
 
 import mohawk
@@ -376,3 +377,19 @@ class CheckChiefProgressView(
             raise Exception("Unknown state for application")
 
         return JsonResponse(data={"msg": msg, "reload_workbasket": reload_workbasket})
+
+
+class CheckICMSConnectionView(HawkViewBase):
+    """View used by ICMS-HMRC to test connection to ICMS"""
+
+    http_method_names = ["post"]
+
+    def post(self, request: HttpRequest, *args: Any, **kwargs: Any) -> JsonResponse:
+        data = json.loads(request.body.decode("utf-8"))
+
+        if data != {"foo": "bar"}:
+            error_msg = f"Invalid request data: {data}"
+
+            return JsonResponse(status=http.HTTPStatus.BAD_REQUEST, data={"errors": error_msg})
+
+        return JsonResponse(status=http.HTTPStatus.OK, data={"bar": "foo"})

--- a/web/management/commands/check_icms_hmrc_connection.py
+++ b/web/management/commands/check_icms_hmrc_connection.py
@@ -1,0 +1,42 @@
+import json
+from urllib.parse import urljoin
+
+import requests
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+from web.domains.chief.client import make_request
+
+
+# To run: make manage args="check_icms_hmrc_connection"
+class Command(BaseCommand):
+    help = """Test ICMS can send a request to ICMS-HMRC server."""
+
+    def handle(self, *args, **options):
+        self.stdout.write("Checking ICMS-HMRC connection.")
+
+        url = urljoin(settings.ICMS_HMRC_DOMAIN, "mail/check-icms-hmrc-connection/")
+
+        data = {"foo": "bar"}
+        hawk_sender, response = make_request(
+            "POST", url, data=json.dumps(data), headers={"Content-Type": "application/json"}
+        )
+
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as e:
+            self.stderr.write(str(response.content))
+            raise e
+
+        # Verify the response signature.
+        server_auth = response.headers["Server-authorization"]
+        hawk_sender.accept_response(
+            server_auth, content=response.content, content_type=response.headers["Content-type"]
+        )
+
+        response_content = json.loads(response.content.decode("utf-8"))
+
+        if response_content != {"bar": "foo"}:
+            raise CommandError(f"Invalid response from ICMS-HMRC: {response_content}")
+
+        self.stdout.write("ICMS can communicate with ICMS-HMRC using mohawk.", self.style.SUCCESS)


### PR DESCRIPTION
Changes:
  - Add endpoint that ICMS-HMRC uses to test it can communicate with ICMS.
  - Add management command to test ICMS can commumicate with ICMS-HMRC.