### PR TITLE
Fix datetime formatting on case notes view.

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -5007,3 +5007,4 @@ the Approval Process
 the Approval Request
 Approval Process
 Approval
+{{ note.create_datetime|datetime_format("%d %

--- a/web/templates/partial/case/case-note-box.html
+++ b/web/templates/partial/case/case-note-box.html
@@ -1,7 +1,7 @@
 <fieldset>
-  <legend class="bold">Case Note: {{ note.create_datetime.date()|localize }}</legend>
+  <legend class="bold">Case Note: {{ note.create_datetime|datetime_format("%d %b %Y") }}</legend>
   <div class="extra-info case-item-extra-info">
-      Created by {{ note.created_by }} on {{ note.create_datetime|localize }} {% if note.updated_by %}(Last updated by {{ note.updated_by }} on {{ note.updated_at|localize }}){% endif %}
+      Created by {{ note.created_by }} on {{ note.create_datetime|datetime_format|localize }} {% if note.updated_by %}(Last updated by {{ note.updated_by }} on {{ note.updated_at|datetime_format|localize }}){% endif %}
   </div>
   <br>
 

--- a/web/templates/web/domains/case/manage/edit-note.html
+++ b/web/templates/web/domains/case/manage/edit-note.html
@@ -11,9 +11,9 @@
 {% block main_content %}
   <h3>Edit Case Note</h3>
     <fieldset>
-      <legend class="bold">Case Note: {{ note.create_datetime.date()|localize }}</legend>
+      <legend class="bold">Case Note: {{ note.create_datetime|datetime_format("%d %b %Y") }}</legend>
       <div class="extra-info case-item-extra-info">
-          Created by {{ note.created_by }} on {{ note.create_datetime|localize }} {% if note.updated_by %}(Last updated by {{ note.updated_by }} on {{ note.updated_at|localize }}){% endif %}
+          Created by {{ note.created_by }} on {{ note.create_datetime|datetime_format|localize }} {% if note.updated_by %}(Last updated by {{ note.updated_by }} on {{ note.updated_at|datetime_format|localize }}){% endif %}
       </div>
       <br>
 


### PR DESCRIPTION
Before (note an hour behind my local time on my mac - UTC):
![image](https://github.com/user-attachments/assets/4e99da54-68e3-40a4-ad93-9673f2896fd8)

After (correctly displays BST datetime):
![image](https://github.com/user-attachments/assets/51a7417d-c4a5-49c9-88f9-cd82c5c9d8cd)
