### PR TITLE
Add extra path to point to V1ToV2ServiceRenameView view.

### DIFF
--- a/web/domains/checker/views.py
+++ b/web/domains/checker/views.py
@@ -11,7 +11,6 @@ from web.models import (
     ExportApplication,
     ExportApplicationCertificate,
 )
-from web.sites import require_exporter
 from web.utils import datetime_format
 from web.utils.s3 import create_presigned_url
 
@@ -34,7 +33,6 @@ def _get_export_application_goods(app: ExportApplication) -> str:
 
 @method_decorator(ratelimit(key="ip", rate="10/m", method="POST", block=True), name="post")
 @method_decorator(ratelimit(key="ip", rate="20/m", method="GET", block=True), name="get")
-@method_decorator(require_exporter(check_permission=False), name="dispatch")
 class CheckCertificateView(FormView):
     form_class = CertificateCheckForm
     template_name = "web/domains/checker/certificate-checker.html"

--- a/web/tests/domains/checker/test_views.py
+++ b/web/tests/domains/checker/test_views.py
@@ -54,14 +54,16 @@ def test_caseworker_domain_no_access(cw_client):
     url = reverse("checker:certificate-checker")
     response = cw_client.get(url)
 
-    assert response.status_code == HTTPStatus.FORBIDDEN
+    # Allowed for now (as we don't know what site the redirect will point to)
+    assert response.status_code == HTTPStatus.OK
 
 
 def test_importer_domain_no_access(imp_client):
     url = reverse("checker:certificate-checker")
     response = imp_client.get(url)
 
-    assert response.status_code == HTTPStatus.FORBIDDEN
+    # Allowed for now (as we don't know what site the redirect will point to)
+    assert response.status_code == HTTPStatus.OK
 
 
 def test_prepopulate_form(exp_client):

--- a/web/urls.py
+++ b/web/urls.py
@@ -91,6 +91,11 @@ urlpatterns = [
         "icms/fox/icms/",
         V1ToV2ServiceRenameView.as_view(),
     ),
+    # Users who have bookmarked the old V1 url (extra importer login url)
+    path(
+        "icms/fox/live/IMP_LOGIN/login",
+        V1ToV2ServiceRenameView.as_view(),
+    ),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
Also remove require_exporter from CheckCertificateView as we are unsure what domain the V1 DNS will point.
![image](https://github.com/user-attachments/assets/7872ed2b-0945-4824-90f6-b25366487b69)

