### PR TITLE
ICMSLST-2980 Always show Show Details link for section 5 authorities.

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -5015,3 +5015,4 @@ Serach
 {{ application_field(process.agent_office.address
 ON td.id = xtd.td_id
 MAN ADDRESS MAN POSTCODE
+{{ application_field(section5.start_date.strftime('%d-%b-%Y'

--- a/web/domains/case/_import/fa_sil/views.py
+++ b/web/domains/case/_import/fa_sil/views.py
@@ -50,6 +50,13 @@ def check_can_edit_application(user: User, application: models.SILApplication) -
         raise PermissionDenied
 
 
+def check_can_view_application(user: User, application: models.SILApplication) -> None:
+    checker = AppChecker(user, application)
+
+    if not checker.can_view():
+        raise PermissionDenied
+
+
 @login_required
 def edit(request: AuthenticatedHttpRequest, *, application_pk: int) -> HttpResponse:
     with transaction.atomic():
@@ -498,12 +505,11 @@ def view_verified_section5(
         application = get_object_or_404(
             models.SILApplication.objects.select_for_update(), pk=application_pk
         )
-        check_can_edit_application(request.user, application)
+        check_can_view_application(request.user, application)
+
         section5 = get_object_or_404(
             application.importer.section5_authorities.filter(is_active=True), pk=section5_pk
         )
-
-        case_progress.application_in_progress(application)
 
         context = {
             "process": application,

--- a/web/templates/web/domains/case/import/fa-sil/view-verified-section5.html
+++ b/web/templates/web/domains/case/import/fa-sil/view-verified-section5.html
@@ -1,149 +1,88 @@
-{% extends "web/domains/case/applicant-base.html" %}
-
-
-{% block content_actions %}
-<div class="content-actions">
-  <ul class="menu-out flow-across">
-    <li>
-      <a
-        href="{{ icms_url('import:fa:manage-certificates', kwargs={'application_pk': process.pk}) }}"
-        class="prev-link">
-        Certificates
-      </a>
-    </li>
-  </ul>
-</div>
-{% endblock %}
+{% extends 'layout/no-sidebar.html' %}
+{% from "display/fields.html" import application_section, application_field %}
 
 {% block main_content %}
-  <h3>Verified Section5 Authority</h3>
-  <div class="container">
-    <div class="row">
-      <div class="three columns">
-        <label class="prompt west">Reference</label>
-      </div>
-      <div class="six columns">
-        {{ section5.reference or "" }}
-      </div>
-      <div class="three columns"></div>
-    </div>
+  {% call application_section("Verified Section 5 Authority") %}
+    {{ application_field(section5.reference or "", "Reference") }}
+    {{ application_field(section5.address, "Address") }}
+    {{ application_field(section5.postcode, "Postcode") }}
+    {{ application_field(section5.start_date.strftime('%d-%b-%Y'), "Start Date") }}
+    {{ application_field(section5.end_date.strftime('%d-%b-%Y'), "End Date") }}
+  {% endcall %}
 
-    <div class="row">
-      <div class="three columns">
-        <label class="prompt west">Address</label>
-      </div>
-      <div class="six columns">
-        {{ section5.address|nl2br }}
-      </div>
-      <div class="three columns"></div>
-    </div>
-
-    <div class="row">
-      <div class="three columns">
-        <label class="prompt west">Postcode</label>
-      </div>
-      <div class="six columns">
-        {{ section5.postcode }}
-      </div>
-      <div class="three columns"></div>
-    </div>
-
-    <div class="row">
-      <div class="three columns">
-        <label class="prompt west">Start Date</label>
-      </div>
-      <div class="six columns">
-        {{ section5.start_date.strftime('%d-%b-%Y') }}
-      </div>
-      <div class="three columns"></div>
-    </div>
-
-    <div class="row">
-      <div class="three columns">
-        <label class="prompt west">End Date</label>
-      </div>
-      <div class="six columns">
-        {{ section5.end_date.strftime('%d-%b-%Y') }}
-      </div>
-      <div class="three columns"></div>
-    </div>
-
-    <div class="row">
-      <div class="three columns">
-        <label class="prompt west">Authority Details</label>
-      </div>
-      <div class="six columns">
+  {% call application_section("Authority Details") %}
+    {% with clause_quantities = section5.clausequantity_set.all() %}
+      {% if clause_quantities %}
         <table class="setoutList">
           <thead>
-            <tr>
-              <th>Category</th>
-              <th>Quantity</th>
+          <tr>
+            <th>Category</th>
+            <th>Quantity</th>
           </thead>
           <tbody>
-            {% for clause in section5.clausequantity_set.all() %}
-              <tr>
-                <td>{{ clause.section5clause.clause }}</td>
-                <td>
-                  {% if clause.infinity %}
-                    Unlimited
-                  {% else %}
-                    {{ clause.quantity }}
-                  {% endif %}
-                </td>
-              </tr>
-            {% else %}
-              <tr>
-                <td colspan="2">
-                  <div class="info-box info-box-info">
-                    There are no section 5 clause attached
-                  </div>
-                </td>
-              </tr>
-            {% endfor %}
+          {% for clause in clause_quantities %}
+            <tr>
+              <td>{{ clause.section5clause.clause }}</td>
+              <td>
+                {% if clause.infinity %}
+                  Unlimited
+                {% else %}
+                  {{ clause.quantity }}
+                {% endif %}
+              </td>
+            </tr>
+          {% else %}
+            <tr>
+              <td colspan="2">
+                <div class="info-box info-box-info">
+                  There are no section 5 clause attached
+                </div>
+              </td>
+            </tr>
+          {% endfor %}
           </tbody>
         </table>
-      </div>
-      <div class="three columns"></div>
-    </div>
+      {% else %}
+        <div class="info-box info-box-info">There are no section 5 clause attached</div>
+      {% endif %}
+    {% endwith %}
+  {% endcall %}
 
-    <h3>Documents</h3>
-
-    {% if section5.files.active() %}
-      <table class="setoutList">
-        <thead>
+  {% call application_section("Documents") %}
+    {% with documents = section5.files.active() %}
+      {% if documents %}
+        <table class="setoutList">
+          <thead>
           <tr>
             <th scope="col">Document Type</th>
             <th scope="col">Uploaded By</th>
             <th scope="col">File (Size)</th>
           </tr>
-        </thead>
-        <tbody>
-        {% for document in section5.files.active() %}
-          <tr>
-            <td>
-               Verified Section 5 Authority
-            </td>
-            <td>
-              {{ document.created_by }}<br />
-              <span class="extra-info">{{ document.created_datetime|datetime_format }}</span>
-            </td>
-            <td>
-              <a
-                href="{{ icms_url('import:fa-sil:view-verified-section5-document', kwargs={'application_pk': process.pk, 'document_pk': document.pk}) }}">
-                {{ document.filename }}
-              </a>
-              <br />
-              <span class="extra-info">{{ document.human_readable_file_size() }}</span>
-            </td>
-          </tr>
-        {% endfor %}
-        </tbody>
-      </table>
-
-    {% else %}
-      <div class="info-box info-box-info">
-        There are no documents attached
-      </div>
-    {% endif %}
-  </div>
+          </thead>
+          <tbody>
+          {% for document in section5.files.active() %}
+            <tr>
+              <td>
+                Verified Section 5 Authority
+              </td>
+              <td>
+                {{ document.created_by }}<br/>
+                <span class="extra-info">{{ document.created_datetime|datetime_format }}</span>
+              </td>
+              <td>
+                <a href="{{ icms_url('import:fa-sil:view-verified-section5-document', kwargs={'application_pk': process.pk, 'document_pk': document.pk}) }}">
+                  {{ document.filename }}
+                </a>
+                <br/>
+                <span class="extra-info">{{ document.human_readable_file_size() }}</span>
+              </td>
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
+      {% else %}
+        <div class="info-box info-box-info">There are no documents attached</div>
+      {% endif %}
+    {% endwith %}
+  {% endcall %}
 {% endblock %}

--- a/web/templates/web/domains/case/import/partials/fa-sil/verified-section5-authorities.html
+++ b/web/templates/web/domains/case/import/partials/fa-sil/verified-section5-authorities.html
@@ -18,9 +18,7 @@
           <th>Postcode</th>
           <th>Start Date</th>
           <th>End Date</th>
-          {% if not read_only %}
-            <th>Actions</th>
-          {% endif %}
+          <th>Actions</th>
         </tr>
       </thead>
       <tbody>
@@ -41,14 +39,14 @@
             <td>{{ section.postcode }}</td>
             <td>{{ section.start_date.strftime('%d-%b-%Y') }}</td>
             <td>{{ section.end_date.strftime('%d-%b-%Y') }}</td>
-            {% if not read_only %}
-              <td>
-                <a
-                  href="{{ icms_url('import:fa-sil:view-verified-section5', kwargs={'application_pk': process.pk, 'section5_pk': section.pk}) }}">
+            <td>
+              <a
+                href="{{ icms_url('import:fa-sil:view-verified-section5', kwargs={'application_pk': process.pk, 'section5_pk': section.pk}) }}"
+                target="_blank" rel="noopener noreferrer"
+              >
                 View Details
-                </a>
-              </td>
-            {% endif %}
+              </a>
+            </td>
           </tr>
         {% endfor %}
       </tbody>
@@ -68,9 +66,7 @@
           <th>Postcode</th>
           <th>Start Date</th>
           <th>End Date</th>
-          {% if not read_only %}
-            <th>Actions</th>
-          {% endif %}
+          <th>Actions</th>
         </tr>
       </thead>
       <tbody>
@@ -91,14 +87,14 @@
             <td>{{ section.postcode }}</td>
             <td>{{ section.start_date.strftime('%d-%b-%Y') }}</td>
             <td>{{ section.end_date.strftime('%d-%b-%Y') }}</td>
-            {% if not read_only %}
               <td>
-                <a
-                  href="{{ icms_url('import:fa-sil:view-verified-section5', kwargs={'application_pk': process.pk, 'section5_pk': section.pk}) }}">
+              <a
+                href="{{ icms_url('import:fa-sil:view-verified-section5', kwargs={'application_pk': process.pk, 'section5_pk': section.pk}) }}"
+                target="_blank" rel="noopener noreferrer"
+              >
                 View Details
-                </a>
-              </td>
-            {% endif %}
+              </a>
+            </td>
           </tr>
         {% endfor %}
       </tbody>


### PR DESCRIPTION
Changes:
  - Update Show Details link to always show.
  - Refactor details page UI.
  - Fix permission checking when viewing details.

When viewing a case before:
![image](https://github.com/user-attachments/assets/8353a440-121c-4170-b24b-2a4436a27c26)
When viewing a case after:
![image](https://github.com/user-attachments/assets/b764cf05-c23b-4e47-a746-330b30feb537)

Updated view details view:
![caseworker_8080_import_firearms_sil_2_verified-section5_1_view_](https://github.com/user-attachments/assets/81d9a2df-ba93-4ae0-9af4-de37a870be25)

