### PR TITLE
ICMSLST-2986 Add endpoint to link agents to access requests.

### DIFF
--- a/web/domains/case/access/urls.py
+++ b/web/domains/case/access/urls.py
@@ -17,6 +17,11 @@ urlpatterns = [
         views.link_access_request,
         name="link-request",
     ),
+    path(
+        "case/<int:access_request_pk>/<orgtype:entity>/link-access-request-agent/",
+        views.LinkOrgAgentAccessRequestUpdateView.as_view(),
+        name="link-access-request-agent",
+    ),
     re_path(
         "^case/(?P<access_request_pk>[0-9]+)/(?P<entity>importer|exporter)/close-access-request/$",
         views.close_access_request,

--- a/web/templates/web/domains/case/access/close-access-request.html
+++ b/web/templates/web/domains/case/access/close-access-request.html
@@ -15,6 +15,10 @@
     <div class="info-box info-box-info">
       You cannot close this Access Request because you have already started the Approval Process. To close this Access Request you must first withdraw the Approval Request.
     </div>
+  {% elif agent_missing %}
+    <div class="info-box info-box-info">
+      You cannot close this Access Request because you need to link the agent.
+    </div>
   {% else %}
     <div class="container setOutForm">
       {% call forms.form(action='', method='post', csrf_input=csrf_input) -%}

--- a/web/templates/web/domains/case/access/management.html
+++ b/web/templates/web/domains/case/access/management.html
@@ -66,21 +66,37 @@
         You cannot re-link this Access Request because you have already started the Approval Process. You must first Withdraw / Restart the Approval Request.
       </div>
     {% else %}
+      <p>
+        If the {{ org }} is not found in the below list, click <a href="{{ create_org_url }}" target="_blank" rel="noopener noreferrer">this link</a>
+        to create a new {{ org }} (opens in new tab) before returning here to complete the access request. You may need to reload the browser page to see the new {{ org }}.
+      </p>
       <div class="eight columns">
         {% call forms.form(method='post', csrf_input=csrf_input) -%}
-          {{ fields.field(form.link) }}
-          {% if show_agent_link %}
-            {{ fields.field(form.agent_link, show_optional_indicator=False) }}
-          {% endif %}
-          <p>
-            If the {{ org }} is not found in the above list, click <a href="{{ create_org_url }}" target="_blank" rel="noopener noreferrer">this link</a>
-            to create a new {{ org }} (opens in new tab) before returning here to complete the access request. You may need to reload the browser page to see the new {{ org }}.
-          </p>
-          <button type="submit" class="button primary-button">Link</button>
+          {% for field in form %}
+            {{ fields.field(field) }}
+            {{ forms.submit_button(btn_label="Link") }}
+          {% endfor %}
         {% endcall %}
       </div>
     {% endif %}
 </div>
+{% if show_agent_link %}
+  <div class="row">
+    <h3>Link Agent to Access Request</h3>
+    {% if process.link %}
+      <div class="eight columns">
+        {% call forms.form(action=link_access_request_agent_url, method='post', csrf_input=csrf_input) -%}
+          {% for field in agent_form %}
+            {{ fields.field(field) }}
+            {{ forms.submit_button(btn_label="Link agent") }}
+          {% endfor %}
+        {% endcall %}
+      </div>
+    {% else %}
+      <div class="info-box info-box-info">You need to link the {{ org }} before linking the agent</div>
+    {% endif %}
+  </div>
+{% endif %}
 {% endblock %}
 
 {% block page_js %}


### PR DESCRIPTION
Manage Access Request page with importer and agent foms:
![caseworker_8080_access_case_11_importer_link-access-request_](https://github.com/user-attachments/assets/44315e92-2984-45e5-a236-dc7c7566bf97)

Close access request message when agent hasn't been linked:
![caseworker_8080_access_case_11_importer_close-access-request_](https://github.com/user-attachments/assets/a0add45a-03b6-4ede-b4b7-d7cc1e517239)


Manage Access Request page with complete approval showing agent can still be set after approval:
![caseworker_8080_access_case_11_importer_link-access-request_ (1)](https://github.com/user-attachments/assets/0b31d382-d97f-4c1c-9537-6b33b413d256)
