### PR TITLE
ICMSLST-3005 CFS Spreadsheet Upload less strict for non biocide products

### DIFF
--- a/web/templates/web/domains/case/export/partials/cfs/schedule-products.html
+++ b/web/templates/web/domains/case/export/partials/cfs/schedule-products.html
@@ -10,6 +10,9 @@
     Once uploaded the products list will be filled out automatically.
   </p>
 </div>
+<div class="info-box info-box-warning">
+  Uploaded spreadsheets must be .xlsx files. If using the spreadhseet uploader, please download and use the template provided.
+</div>
 
 
 {% if not read_only %}


### PR DESCRIPTION
Made the spreadsheet uploaded less strict
- Doesn't require a sheet name. Will just take the first sheet if there are no sheets named "CFS Products"
- Will skip blank rows rather than raising a validation error
- As long as the first column is "Product Name" for non biocide, it will upload the first column of data regardless of whats in the other columns

Added a message to the screen to use the .xlsx template provided

<img width="1520" alt="image" src="https://github.com/user-attachments/assets/1cbe68f0-f8ab-483f-b993-8757c0173cfa">
