### PR TITLE
ICMSLST-3013 Update close access request logic.

### DIFF
--- a/web/domains/case/access/forms.py
+++ b/web/domains/case/access/forms.py
@@ -182,6 +182,11 @@ class CloseAccessRequestForm(ModelForm):
             )
 
         if response == AccessRequest.APPROVED:
+            if not self.instance.link:
+                self.add_error(
+                    "response", "You must link an organisation before approving the access request."
+                )
+
             if self.instance.is_agent_request and not self.instance.agent_link:
                 self.add_error(
                     "response", "You must link an agent before approving the agent access request."

--- a/web/domains/case/access/views.py
+++ b/web/domains/case/access/views.py
@@ -391,19 +391,6 @@ def close_access_request(
                     )
                 )
 
-            if agent_missing:
-                messages.error(
-                    request,
-                    "You cannot close this Access Request because you need to link the agent.",
-                )
-
-                return redirect(
-                    reverse(
-                        "access:close-request",
-                        kwargs={"access_request_pk": access_request.pk, "entity": entity},
-                    )
-                )
-
             task = case_progress.get_expected_task(access_request, Task.TaskType.PROCESS)
             form = forms.CloseAccessRequestForm(request.POST, instance=access_request)
 
@@ -417,9 +404,7 @@ def close_access_request(
                 task.finished = timezone.now()
                 task.save()
 
-                # If approving with a link add the user to the org.
-                # An access request can still be approved without linking (Preserving old behaviour)
-                if access_request.response == AccessRequest.APPROVED and access_request.link:
+                if access_request.response == AccessRequest.APPROVED:
                     if access_request.is_agent_request:
                         org = access_request.agent_link
                     else:

--- a/web/templates/web/domains/case/access/close-access-request.html
+++ b/web/templates/web/domains/case/access/close-access-request.html
@@ -4,20 +4,9 @@
 
 {% block main_content %}
   <h3>Close Access Request</h3>
-  {% if not process.link %}
-    <div class="info-box info-box-warning">
-    NOTE: If approving an access request without linking to an Importer/Exporter, you will have to manually
-    add the user to the relevant Importer/Exporter.
-    </div>
-  {% endif %}
-
   {% if has_open_approval_request %}
     <div class="info-box info-box-info">
       You cannot close this Access Request because you have already started the Approval Process. To close this Access Request you must first withdraw the Approval Request.
-    </div>
-  {% elif agent_missing %}
-    <div class="info-box info-box-info">
-      You cannot close this Access Request because you need to link the agent.
     </div>
   {% else %}
     <div class="container setOutForm">


### PR DESCRIPTION
If approving an access request then the org / agent must be set. If refusing an access request then both org and agent are optional.

Form error handling:
![caseworker_8080_access_case_4_exporter_close-access-request_](https://github.com/user-attachments/assets/57f9ea7e-f352-48df-921d-5aee3e89e1ae)
![caseworker_8080_access_case_3_exporter_close-access-request_](https://github.com/user-attachments/assets/8586f1e5-0ad4-4d23-90b0-d449a80f9d8a)
