### PR TITLE
ECIL-217 Clean whitespace in goods descriptions for import applications

### DIFF
--- a/web/domains/case/_import/fa_dfl/forms.py
+++ b/web/domains/case/_import/fa_dfl/forms.py
@@ -1,3 +1,4 @@
+import re
 from typing import Any
 
 from django import forms
@@ -68,7 +69,7 @@ class SubmitFaDFLForm(FirearmDFLFormBase):
     """
 
 
-class AddDLFGoodsCertificateForm(forms.ModelForm):
+class AddDFLGoodsCertificateForm(forms.ModelForm):
     document = ICMSFileField(required=True)
 
     class Meta:
@@ -92,8 +93,12 @@ class AddDLFGoodsCertificateForm(forms.ModelForm):
         countries = Country.app.get_fa_dfl_issuing_countries()
         self.fields["issuing_country"].queryset = countries
 
+    def clean_goods_description(self):
+        description = self.cleaned_data["goods_description"]
+        return re.sub(r"\s+", " ", description.strip())
 
-class EditDLFGoodsCertificateForm(forms.ModelForm):
+
+class EditDFLGoodsCertificateForm(forms.ModelForm):
     class Meta:
         model = models.DFLGoodsCertificate
         fields = ("goods_description", "deactivated_certificate_reference", "issuing_country")
@@ -111,6 +116,10 @@ class EditDLFGoodsCertificateForm(forms.ModelForm):
         countries = Country.app.get_fa_dfl_issuing_countries()
         self.fields["issuing_country"].queryset = countries
 
+    def clean_goods_description(self):
+        description = self.cleaned_data["goods_description"]
+        return re.sub(r"\s+", " ", description.strip())
+
 
 class EditDFLGoodsCertificateDescriptionForm(forms.ModelForm):
     class Meta:
@@ -123,6 +132,10 @@ class EditDFLGoodsCertificateDescriptionForm(forms.ModelForm):
                 " You must list only one deactivated firearm per goods line."
             )
         }
+
+    def clean_goods_description(self):
+        description = self.cleaned_data["goods_description"]
+        return re.sub(r"\s+", " ", description.strip())
 
 
 class DFLChecklistForm(ChecklistBaseForm):

--- a/web/domains/case/_import/fa_dfl/forms.py
+++ b/web/domains/case/_import/fa_dfl/forms.py
@@ -95,7 +95,7 @@ class AddDFLGoodsCertificateForm(forms.ModelForm):
 
     def clean_goods_description(self):
         description = self.cleaned_data["goods_description"]
-        return re.sub(r"\s+", " ", description.strip())
+        return re.sub(r"\s+", " ", description)
 
 
 class EditDFLGoodsCertificateForm(forms.ModelForm):
@@ -118,7 +118,7 @@ class EditDFLGoodsCertificateForm(forms.ModelForm):
 
     def clean_goods_description(self):
         description = self.cleaned_data["goods_description"]
-        return re.sub(r"\s+", " ", description.strip())
+        return re.sub(r"\s+", " ", description)
 
 
 class EditDFLGoodsCertificateDescriptionForm(forms.ModelForm):
@@ -135,7 +135,7 @@ class EditDFLGoodsCertificateDescriptionForm(forms.ModelForm):
 
     def clean_goods_description(self):
         description = self.cleaned_data["goods_description"]
-        return re.sub(r"\s+", " ", description.strip())
+        return re.sub(r"\s+", " ", description)
 
 
 class DFLChecklistForm(ChecklistBaseForm):

--- a/web/domains/case/_import/fa_dfl/views.py
+++ b/web/domains/case/_import/fa_dfl/views.py
@@ -37,13 +37,13 @@ from web.utils.validation import (
 )
 
 from .forms import (
-    AddDLFGoodsCertificateForm,
+    AddDFLGoodsCertificateForm,
     DFLChecklistForm,
     DFLChecklistOptionalForm,
     DFLSupplementaryReportFirearmForm,
     DFLSupplementaryReportUploadFirearmForm,
     EditDFLGoodsCertificateDescriptionForm,
-    EditDLFGoodsCertificateForm,
+    EditDFLGoodsCertificateForm,
     EditFaDFLForm,
     SubmitFaDFLForm,
 )
@@ -143,7 +143,7 @@ def add_goods_certificate(
         case_progress.application_in_progress(application)
 
         if request.method == "POST":
-            form = AddDLFGoodsCertificateForm(data=request.POST, files=request.FILES)
+            form = AddDFLGoodsCertificateForm(data=request.POST, files=request.FILES)
 
             if form.is_valid():
                 document: S3Boto3StorageFile = form.cleaned_data.get("document")
@@ -165,7 +165,7 @@ def add_goods_certificate(
                     reverse("import:fa-dfl:list-goods", kwargs={"application_pk": application_pk})
                 )
         else:
-            form = AddDLFGoodsCertificateForm()
+            form = AddDFLGoodsCertificateForm()
 
         context = {
             "process": application,
@@ -192,7 +192,7 @@ def edit_goods_certificate(
         document = application.goods_certificates.filter(is_active=True).get(pk=document_pk)
 
         if request.method == "POST":
-            form = EditDLFGoodsCertificateForm(data=request.POST, instance=document)
+            form = EditDFLGoodsCertificateForm(data=request.POST, instance=document)
 
             if form.is_valid():
                 goods_cert = form.save(commit=False)
@@ -204,7 +204,7 @@ def edit_goods_certificate(
                 )
 
         else:
-            form = EditDLFGoodsCertificateForm(instance=document)
+            form = EditDFLGoodsCertificateForm(instance=document)
 
         context = {
             "process": application,

--- a/web/domains/case/_import/fa_sil/forms.py
+++ b/web/domains/case/_import/fa_sil/forms.py
@@ -431,9 +431,6 @@ class SILChecklistOptionalForm(SILChecklistForm):
 class ResponsePrepBaseForm(forms.ModelForm):
     """Base class form for editing description and quantity in the response preparation screen"""
 
-    class Meta:
-        fields = ("description", "quantity")
-
     quantity = forms.IntegerField(max_value=settings.CHIEF_MAX_QUANTITY)
 
     def clean_description(self):
@@ -464,31 +461,31 @@ class ResponsePrepUnlimitedBaseForm(ResponsePrepBaseForm):
 class ResponsePrepSILGoodsSection1Form(ResponsePrepUnlimitedBaseForm):
     class Meta:
         model = models.SILGoodsSection1
-        fields = ResponsePrepUnlimitedBaseForm.Meta.fields
+        fields = ("description", "quantity")
 
 
 class ResponsePrepSILGoodsSection2Form(ResponsePrepUnlimitedBaseForm):
     class Meta:
         model = models.SILGoodsSection2
-        fields = ResponsePrepUnlimitedBaseForm.Meta.fields
+        fields = ("description", "quantity")
 
 
 class ResponsePrepSILGoodsSection5Form(ResponsePrepUnlimitedBaseForm):
     class Meta:
         model = models.SILGoodsSection5
-        fields = ResponsePrepUnlimitedBaseForm.Meta.fields
+        fields = ("description", "quantity")
 
 
 class ResponsePrepSILGoodsSection582ObsoleteForm(ResponsePrepBaseForm):  # /PS-IGNORE
     class Meta:
         model = models.SILGoodsSection582Obsolete  # /PS-IGNORE
-        fields = ResponsePrepBaseForm.Meta.fields
+        fields = ("description", "quantity")
 
 
 class ResponsePrepSILGoodsSection582OtherForm(ResponsePrepBaseForm):  # /PS-IGNORE
     class Meta:
         model = models.SILGoodsSection582Other  # /PS-IGNORE
-        fields = ResponsePrepBaseForm.Meta.fields
+        fields = ("description", "quantity")
 
 
 class SILCoverLetterTemplateForm(forms.Form):

--- a/web/domains/case/_import/fa_sil/forms.py
+++ b/web/domains/case/_import/fa_sil/forms.py
@@ -135,7 +135,7 @@ class SILGoodsSectionBase(forms.ModelForm):
 
     def clean_description(self):
         description = self.cleaned_data["description"]
-        return re.sub(r"\s+", " ", description.strip())
+        return re.sub(r"\s+", " ", description)
 
     def clean(self):
         cleaned_data = super().clean()
@@ -232,7 +232,7 @@ class SILGoodsSection582ObsoleteForm(forms.ModelForm):  # /PS-IGNORE
 
     def clean_description(self):
         description = self.cleaned_data["description"]
-        return re.sub(r"\s+", " ", description.strip())
+        return re.sub(r"\s+", " ", description)
 
     def clean_curiosity_ornament(self):
         curiosity_ornament = self.cleaned_data["curiosity_ornament"]
@@ -330,7 +330,7 @@ class SILGoodsSection582OtherForm(forms.ModelForm):  # /PS-IGNORE
 
     def clean_description(self):
         description = self.cleaned_data["description"]
-        return re.sub(r"\s+", " ", description.strip())
+        return re.sub(r"\s+", " ", description)
 
     def clean_curiosity_ornament(self):
         curiosity_ornament = self.cleaned_data["curiosity_ornament"]
@@ -435,7 +435,7 @@ class ResponsePrepBaseForm(forms.ModelForm):
 
     def clean_description(self):
         description = self.cleaned_data["description"]
-        return re.sub(r"\s+", " ", description.strip())
+        return re.sub(r"\s+", " ", description)
 
 
 class ResponsePrepUnlimitedBaseForm(ResponsePrepBaseForm):

--- a/web/domains/case/_import/sanctions/forms.py
+++ b/web/domains/case/_import/sanctions/forms.py
@@ -1,3 +1,4 @@
+import re
 from typing import Any
 
 from django import forms
@@ -117,6 +118,10 @@ class GoodsForm(forms.ModelForm):
 
         self.fields["commodity"].queryset = get_usage_commodities(usage_records)
 
+    def clean_goods_description(self):
+        description = self.cleaned_data["goods_description"]
+        return re.sub(r"\s+", " ", description.strip())
+
 
 class GoodsSanctionsLicenceForm(forms.ModelForm):
     class Meta:
@@ -128,3 +133,7 @@ class GoodsSanctionsLicenceForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["commodity"].disabled = True
+
+    def clean_goods_description(self):
+        description = self.cleaned_data["goods_description"]
+        return re.sub(r"\s+", " ", description.strip())

--- a/web/domains/case/_import/sanctions/forms.py
+++ b/web/domains/case/_import/sanctions/forms.py
@@ -120,7 +120,7 @@ class GoodsForm(forms.ModelForm):
 
     def clean_goods_description(self):
         description = self.cleaned_data["goods_description"]
-        return re.sub(r"\s+", " ", description.strip())
+        return re.sub(r"\s+", " ", description)
 
 
 class GoodsSanctionsLicenceForm(forms.ModelForm):
@@ -136,4 +136,4 @@ class GoodsSanctionsLicenceForm(forms.ModelForm):
 
     def clean_goods_description(self):
         description = self.cleaned_data["goods_description"]
-        return re.sub(r"\s+", " ", description.strip())
+        return re.sub(r"\s+", " ", description)

--- a/web/tests/domains/case/_import/fa_dfl/test_forms.py
+++ b/web/tests/domains/case/_import/fa_dfl/test_forms.py
@@ -1,0 +1,81 @@
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from web.domains.case._import.fa_dfl.forms import (
+    AddDFLGoodsCertificateForm,
+    EditDFLGoodsCertificateDescriptionForm,
+    EditDFLGoodsCertificateForm,
+)
+from web.models import Country
+
+
+def test_add_goods_form(db):
+    country = Country.app.get_fa_dfl_issuing_countries().first()
+    document = SimpleUploadedFile("myimage.png", b"file_content")
+    data = {
+        "goods_description": "some goods description",
+        "deactivated_certificate_reference": "1234",
+        "issuing_country": country,
+    }
+    form = AddDFLGoodsCertificateForm(data=data, files={"document": document})
+    assert form.is_valid()
+    assert form.cleaned_data["goods_description"] == "some goods description"
+    assert form.cleaned_data["deactivated_certificate_reference"] == "1234"
+
+
+def test_add_goods_form_clean_goods_description(db):
+    country = Country.app.get_fa_dfl_issuing_countries().first()
+    document = SimpleUploadedFile("myimage.png", b"file_content")
+    data = {
+        "goods_description": " some\r\n goods \t description\n  ",
+        "deactivated_certificate_reference": "1234",
+        "issuing_country": country,
+        "document": document,
+    }
+    form = AddDFLGoodsCertificateForm(data=data, files={"document": document})
+    assert form.is_valid()
+    assert form.cleaned_data["goods_description"] == "some goods description"
+    assert form.cleaned_data["deactivated_certificate_reference"] == "1234"
+
+
+def test_edit_dfl_goods_form(fa_dfl_agent_app_in_progress):
+    goods = fa_dfl_agent_app_in_progress.goods_certificates.first()
+    country = Country.app.get_fa_dfl_issuing_countries().first()
+    data = {
+        "goods_description": "some goods description",
+        "deactivated_certificate_reference": "1234",
+        "issuing_country": country,
+    }
+    form = EditDFLGoodsCertificateForm(instance=goods, data=data)
+    assert form.is_valid()
+    assert form.cleaned_data["goods_description"] == "some goods description"
+    assert form.cleaned_data["deactivated_certificate_reference"] == "1234"
+
+
+def test_edit_dfl_goods_form_clean_goods_description(fa_dfl_agent_app_in_progress):
+    goods = fa_dfl_agent_app_in_progress.goods_certificates.first()
+    country = Country.app.get_fa_dfl_issuing_countries().first()
+    data = {
+        "goods_description": " some\r\n goods \t description\n  ",
+        "deactivated_certificate_reference": "1234",
+        "issuing_country": country,
+    }
+    form = EditDFLGoodsCertificateForm(instance=goods, data=data)
+    assert form.is_valid()
+    assert form.cleaned_data["goods_description"] == "some goods description"
+    assert form.cleaned_data["deactivated_certificate_reference"] == "1234"
+
+
+def test_edit_dfl_goods_description_form(fa_dfl_agent_app_submitted):
+    goods = fa_dfl_agent_app_submitted.goods_certificates.first()
+    data = {"goods_description": "some goods description"}
+    form = EditDFLGoodsCertificateDescriptionForm(instance=goods, data=data)
+    assert form.is_valid()
+    assert form.cleaned_data["goods_description"] == "some goods description"
+
+
+def test_edit_dfl_goods_description_form_clean_description(fa_dfl_agent_app_submitted):
+    goods = fa_dfl_agent_app_submitted.goods_certificates.first()
+    data = {"goods_description": " some\r\n goods \t description\n  "}
+    form = EditDFLGoodsCertificateDescriptionForm(instance=goods, data=data)
+    assert form.is_valid()
+    assert form.cleaned_data["goods_description"] == "some goods description"

--- a/web/tests/domains/case/_import/fa_sil/test_forms.py
+++ b/web/tests/domains/case/_import/fa_sil/test_forms.py
@@ -1,0 +1,468 @@
+from web.domains.case._import.fa_sil.forms import (
+    ResponsePrepSILGoodsSection582ObsoleteForm,  # /PS-IGNORE
+)
+from web.domains.case._import.fa_sil.forms import (
+    ResponsePrepSILGoodsSection582OtherForm,  # /PS-IGNORE
+)
+from web.domains.case._import.fa_sil.forms import (
+    SILGoodsSection582ObsoleteForm,  # /PS-IGNORE
+)
+from web.domains.case._import.fa_sil.forms import (
+    SILGoodsSection582OtherForm,  # /PS-IGNORE
+)
+from web.domains.case._import.fa_sil.forms import (
+    ResponsePrepSILGoodsSection1Form,
+    ResponsePrepSILGoodsSection2Form,
+    ResponsePrepSILGoodsSection5Form,
+    SILGoodsSection1Form,
+    SILGoodsSection2Form,
+    SILGoodsSection5Form,
+)
+from web.models import ObsoleteCalibre, Section5Clause
+
+
+def test_add_section1_goods_form(db):
+    data = {
+        "manufacture": False,
+        "description": "some goods description",
+        "quantity": 100,
+        "unlimited_quantity": None,
+    }
+    form = SILGoodsSection1Form(data=data)
+    assert form.is_valid()
+    assert form.cleaned_data["description"] == "some goods description"
+    assert form.cleaned_data["quantity"] == 100
+    assert form.cleaned_data["unlimited_quantity"] is False
+
+
+def test_add_section1_goods_form_unlimited_quantity(db):
+    data = {
+        "manufacture": False,
+        "description": " some\r\n goods \t description\n  ",
+        "quantity": None,
+        "unlimited_quantity": True,
+    }
+    form = SILGoodsSection1Form(data=data)
+    assert form.is_valid()
+    assert form.cleaned_data["description"] == "some goods description"
+    assert form.cleaned_data["quantity"] is None
+    assert form.cleaned_data["unlimited_quantity"] is True
+
+
+def test_add_section1_goods_form_manufactured_before_1900(db):
+    data = {
+        "manufacture": False,
+        "description": "some goods description",
+        "quantity": None,
+        "unlimited_quantity": None,
+    }
+    form = SILGoodsSection1Form(data=data)
+    assert form.is_valid() is False
+    assert (
+        form.errors["quantity"][0]
+        == "You must enter either a quantity or select unlimited quantity"
+    )
+
+
+def test_add_section1_goods_form_unknown_quantity(db):
+    data = {
+        "manufacture": True,
+        "description": "some goods description",
+        "quantity": 100,
+        "unlimited_quantity": None,
+    }
+    form = SILGoodsSection1Form(data=data)
+    assert form.is_valid() is False
+
+
+def test_add_section2_goods_form(db):
+    data = {
+        "manufacture": False,
+        "description": "some goods description",
+        "quantity": 200,
+        "unlimited_quantity": None,
+    }
+    form = SILGoodsSection2Form(data=data)
+    assert form.is_valid()
+    assert form.cleaned_data["description"] == "some goods description"
+    assert form.cleaned_data["quantity"] == 200
+    assert form.cleaned_data["unlimited_quantity"] is False
+
+
+def test_add_section2_goods_form_unlimited_quantity(db):
+    data = {
+        "manufacture": False,
+        "description": " some\r\n goods \t description\n  ",
+        "quantity": None,
+        "unlimited_quantity": True,
+    }
+    form = SILGoodsSection2Form(data=data)
+    assert form.is_valid()
+    assert form.cleaned_data["description"] == "some goods description"
+    assert form.cleaned_data["quantity"] is None
+    assert form.cleaned_data["unlimited_quantity"] is True
+
+
+def test_add_section2_goods_form_manufactured_before_1900(db):
+    data = {
+        "manufacture": False,
+        "description": "some goods description",
+        "quantity": None,
+        "unlimited_quantity": None,
+    }
+    form = SILGoodsSection2Form(data=data)
+    assert form.is_valid() is False
+    assert (
+        form.errors["quantity"][0]
+        == "You must enter either a quantity or select unlimited quantity"
+    )
+
+
+def test_add_section5_goods_form(db):
+    clause = Section5Clause.objects.filter(is_active=True).first()
+    data = {
+        "section_5_clause": clause,
+        "manufacture": False,
+        "description": "some goods description",
+        "quantity": 500,
+        "unlimited_quantity": None,
+    }
+    form = SILGoodsSection5Form(data=data)
+    assert form.is_valid()
+    assert form.cleaned_data["description"] == "some goods description"
+    assert form.cleaned_data["quantity"] == 500
+    assert form.cleaned_data["unlimited_quantity"] is False
+
+
+def test_add_section5_goods_form_unlimited_quantity(db):
+    clause = Section5Clause.objects.filter(is_active=True).first()
+    data = {
+        "section_5_clause": clause,
+        "manufacture": False,
+        "description": " some\r\n goods \t description\n  ",
+        "quantity": None,
+        "unlimited_quantity": True,
+    }
+    form = SILGoodsSection5Form(data=data)
+    assert form.is_valid()
+    assert form.cleaned_data["description"] == "some goods description"
+    assert form.cleaned_data["quantity"] is None
+    assert form.cleaned_data["unlimited_quantity"] is True
+
+
+def test_add_section5_goods_form_manufactured_before_1900(db):
+    clause = Section5Clause.objects.filter(is_active=True).first()
+    data = {
+        "section_5_clause": clause,
+        "manufacture": False,
+        "description": "some goods description",
+        "quantity": None,
+        "unlimited_quantity": None,
+    }
+    form = SILGoodsSection5Form(data=data)
+    assert form.is_valid() is False
+    assert (
+        form.errors["quantity"][0]
+        == "You must enter either a quantity or select unlimited quantity"
+    )
+
+
+def test_add_obsolete_calibre_goods_form(db):
+    calibre = ObsoleteCalibre.objects.filter(is_active=True).first()
+    data = {
+        "curiosity_ornament": True,
+        "acknowledgement": True,
+        "centrefire": True,
+        "manufacture": True,
+        "original_chambering": True,
+        "obsolete_calibre": calibre.name,
+        "description": "some goods description",
+        "quantity": 100,
+    }
+
+    form = SILGoodsSection582ObsoleteForm(data=data)  # /PS-IGNORE
+    assert form.is_valid()
+    assert form.cleaned_data["description"] == "some goods description"
+
+
+def test_add_obsolete_calibre_goods_form_clean_description(db):
+    calibre = ObsoleteCalibre.objects.filter(is_active=True).first()
+    data = {
+        "curiosity_ornament": True,
+        "acknowledgement": True,
+        "centrefire": True,
+        "manufacture": True,
+        "original_chambering": True,
+        "obsolete_calibre": calibre.name,
+        "description": " some\r\n goods \t description\n  ",
+        "quantity": 100,
+    }
+
+    form = SILGoodsSection582ObsoleteForm(data=data)  # /PS-IGNORE
+    assert form.is_valid()
+    assert form.cleaned_data["description"] == "some goods description"
+
+
+def test_add_obsolete_calibre_goods_form_errors(db):
+    calibre = ObsoleteCalibre.objects.filter(is_active=True).first()
+    data = {
+        "curiosity_ornament": False,
+        "acknowledgement": False,
+        "centrefire": False,
+        "manufacture": False,
+        "original_chambering": False,
+        "obsolete_calibre": calibre.name,
+        "description": "some goods description",
+        "quantity": 100,
+    }
+
+    form = SILGoodsSection582ObsoleteForm(data=data)  # /PS-IGNORE
+    assert form.is_valid() is False
+    assert form.errors["curiosity_ornament"][0] == (
+        'If you do not intend to possess the firearm as a "curiosity or ornament" you'
+        " cannot choose Section 58(2). You must change your selection to either"
+        " Section 1, Section 2 or Section 5."
+    )
+    assert form.errors["acknowledgement"][0] == "You must acknowledge the above statement"
+    assert form.errors["manufacture"][0] == (
+        "If your firearm was manufactured after 1939 then you cannot choose Section 58(2)"
+        " and must change your selection to either Section 1, Section 2 or Section 5."
+        "<br/>If your firearm was manufactured before 1900 then an import licence is not"
+        " required."
+    )
+    assert form.errors["centrefire"][0] == (
+        "If your firearm is not a breech loading centrefire firearm, you cannot choose"
+        " Section 58(2) - Obsolete Calibre. You must change your selection to either"
+        " Section 1, Section 2 or Section 5."
+    )
+    assert form.errors["original_chambering"][0] == (
+        "If your item does not retain its original chambering you cannot choose Obsolete Calibre."
+    )
+
+
+def test_add_section_5_other_goods_form(db):
+    data = {
+        "curiosity_ornament": True,
+        "acknowledgement": True,
+        "centrefire": True,
+        "manufacture": True,
+        "original_chambering": True,
+        "description": "some goods description",
+        "quantity": 100,
+        "muzzle_loading": True,
+        "rimfire": False,
+        "rimfire_details": None,
+        "ignition": False,
+        "ignition_details": None,
+        "ignition_other": None,
+        "chamber": False,
+        "bore": False,
+        "bore_details": None,
+    }
+
+    form = SILGoodsSection582OtherForm(data=data)  # /PS-IGNORE
+    assert form.is_valid()
+    assert form.cleaned_data["description"] == "some goods description"
+
+
+def test_add_section_5_other_goods_form_clean_description(db):
+    data = {
+        "curiosity_ornament": True,
+        "acknowledgement": True,
+        "centrefire": True,
+        "manufacture": True,
+        "original_chambering": True,
+        "description": " some\r\n goods \t description\n  ",
+        "quantity": 100,
+        "muzzle_loading": True,
+        "rimfire": False,
+        "rimfire_details": None,
+        "ignition": False,
+        "ignition_details": None,
+        "ignition_other": None,
+        "chamber": False,
+        "bore": False,
+        "bore_details": None,
+    }
+
+    form = SILGoodsSection582OtherForm(data=data)  # /PS-IGNORE
+    assert form.is_valid()
+    assert form.cleaned_data["description"] == "some goods description"
+
+
+def test_add_section_5_other_goods_form_errors(db):
+    data = {
+        "curiosity_ornament": False,
+        "acknowledgement": False,
+        "centrefire": False,
+        "manufacture": False,
+        "original_chambering": False,
+        "description": "some goods description",
+        "quantity": 100,
+        "muzzle_loading": True,
+        "rimfire": True,
+        "rimfire_details": None,
+        "ignition": True,
+        "ignition_details": None,
+        "ignition_other": None,
+        "chamber": False,
+        "bore": True,
+        "bore_details": None,
+    }
+
+    form = SILGoodsSection582OtherForm(data=data)  # /PS-IGNORE
+    assert form.is_valid() is False
+    assert form.errors["curiosity_ornament"][0] == (
+        'If you do not intend to possess the firearm as a "curiosity or ornament" you'
+        " cannot choose Section 58(2). You must change your selection to either"
+        " Section 1, Section 2 or Section 5."
+    )
+    assert form.errors["acknowledgement"][0] == "You must acknowledge the above statement"
+    assert form.errors["manufacture"][0] == (
+        "If your firearm was manufactured after 1939 then you cannot choose Section 58(2)"
+        " and must change your selection to either Section 1, Section 2 or Section 5."
+        "<br/>If your firearm was manufactured before 1900 then an import licence is not"
+        " required."
+    )
+    assert (
+        form.errors["bore"][0] == "Only one of the above five questions can be answered with 'Yes'"
+    )
+    assert form.errors["bore_details"][0] == "You must enter this item"
+    assert form.errors["rimfire_details"][0] == "You must enter this item"
+    assert form.errors["ignition_details"][0] == "You must enter this item"
+
+
+def test_section_1_response_prep_form(db, fa_sil_app_processing):
+    obj = fa_sil_app_processing.goods_section1.first()
+    obj.unlimited_quantity = False
+    data = {
+        "description": "some goods description",
+        "quantity": 100,
+    }
+
+    form = ResponsePrepSILGoodsSection1Form(instance=obj, data=data)
+    assert form.is_valid()
+    assert form.cleaned_data["description"] == "some goods description"
+    assert form.cleaned_data["quantity"] == 100
+
+
+def test_section_1_response_prep_form_clean_description(db, fa_sil_app_processing):
+    obj = fa_sil_app_processing.goods_section1.first()
+    obj.unlimited_quantity = True
+    data = {
+        "description": " some\r\n goods \t description\n  ",
+        "quantity": 100,
+    }
+
+    form = ResponsePrepSILGoodsSection1Form(instance=obj, data=data)
+    assert form.is_valid()
+    assert form.cleaned_data["description"] == "some goods description"
+    assert form.cleaned_data["quantity"] is None
+
+
+def test_section_2_response_prep_form(db, fa_sil_app_processing):
+    obj = fa_sil_app_processing.goods_section2.first()
+    obj.unlimited_quantity = False
+    data = {
+        "description": "some goods description",
+        "quantity": 200,
+    }
+
+    form = ResponsePrepSILGoodsSection2Form(instance=obj, data=data)
+    assert form.is_valid()
+    assert form.cleaned_data["description"] == "some goods description"
+    assert form.cleaned_data["quantity"] == 200
+
+
+def test_section_2_response_prep_form_clean_description(db, fa_sil_app_processing):
+    obj = fa_sil_app_processing.goods_section2.first()
+    obj.unlimited_quantity = True
+    data = {
+        "description": " some\r\n goods \t description\n  ",
+        "quantity": 200,
+    }
+
+    form = ResponsePrepSILGoodsSection2Form(instance=obj, data=data)
+    assert form.is_valid()
+    assert form.cleaned_data["description"] == "some goods description"
+    assert form.cleaned_data["quantity"] is None
+
+
+def test_section_5_response_prep_form(db, fa_sil_app_processing):
+    obj = fa_sil_app_processing.goods_section5.first()
+    obj.unlimited_quantity = False
+    data = {
+        "description": "some goods description",
+        "quantity": 500,
+    }
+
+    form = ResponsePrepSILGoodsSection5Form(instance=obj, data=data)
+    assert form.is_valid()
+    assert form.cleaned_data["description"] == "some goods description"
+    assert form.cleaned_data["quantity"] == 500
+
+
+def test_section_5_response_prep_form_clean_description(db, fa_sil_app_processing):
+    obj = fa_sil_app_processing.goods_section5.first()
+    obj.unlimited_quantity = True
+    data = {
+        "description": " some\r\n goods \t description\n  ",
+        "quantity": 500,
+    }
+
+    form = ResponsePrepSILGoodsSection5Form(instance=obj, data=data)
+    assert form.is_valid()
+    assert form.cleaned_data["description"] == "some goods description"
+    assert form.cleaned_data["quantity"] is None
+
+
+def test_section_5_obsolete_response_prep_form(db, fa_sil_app_processing):
+    obj = fa_sil_app_processing.goods_section582_obsoletes.first()  # /PS-IGNORE
+    data = {
+        "description": "some goods description",
+        "quantity": 500,
+    }
+
+    form = ResponsePrepSILGoodsSection582ObsoleteForm(instance=obj, data=data)  # /PS-IGNORE
+    assert form.is_valid()
+    assert form.cleaned_data["description"] == "some goods description"
+    assert form.cleaned_data["quantity"] == 500
+
+
+def test_section_5_obsolete_response_prep_form_clean_description(db, fa_sil_app_processing):
+    obj = fa_sil_app_processing.goods_section582_obsoletes.first()  # /PS-IGNORE
+    data = {
+        "description": " some\r\n goods \t description\n  ",
+        "quantity": 500,
+    }
+
+    form = ResponsePrepSILGoodsSection582ObsoleteForm(instance=obj, data=data)  # /PS-IGNORE
+    assert form.is_valid()
+    assert form.cleaned_data["description"] == "some goods description"
+    assert form.cleaned_data["quantity"] == 500
+
+
+def test_section_5_other_response_prep_form(db, fa_sil_app_processing):
+    obj = fa_sil_app_processing.goods_section582_others.first()  # /PS-IGNORE
+    data = {
+        "description": "some goods description",
+        "quantity": 500,
+    }
+
+    form = ResponsePrepSILGoodsSection582OtherForm(instance=obj, data=data)  # /PS-IGNORE
+    assert form.is_valid()
+    assert form.cleaned_data["description"] == "some goods description"
+    assert form.cleaned_data["quantity"] == 500
+
+
+def test_section_5_other_response_prep_form_clean_description(db, fa_sil_app_processing):
+    obj = fa_sil_app_processing.goods_section582_others.first()  # /PS-IGNORE
+    data = {
+        "description": " some\r\n goods \t description\n  ",
+        "quantity": 500,
+    }
+
+    form = ResponsePrepSILGoodsSection582OtherForm(instance=obj, data=data)  # /PS-IGNORE
+    assert form.is_valid()
+    assert form.cleaned_data["description"] == "some goods description"
+    assert form.cleaned_data["quantity"] == 500


### PR DESCRIPTION
Replace all whitespace characters in freetext import goods descriptions with a blank space. The whitespace characters are not visible in the frontend and cause issues when sent to icms-hmrc

Added tests for the import application forms that clean the whitespace characters