### PR TITLE
ECIL-275 Add manage permission when a contact is added to an org.

### DIFF
--- a/web/domains/case/access/views.py
+++ b/web/domains/case/access/views.py
@@ -411,10 +411,12 @@ def close_access_request(
                 if access_request.response == AccessRequest.APPROVED:
                     if access_request.is_agent_request:
                         org = access_request.agent_link
+                        assign_manage = False
                     else:
                         org = access_request.link
+                        assign_manage = True
 
-                    organisation_add_contact(org, access_request.submitted_by)
+                    organisation_add_contact(org, access_request.submitted_by, assign_manage)
 
                 emails.send_access_request_closed_email(access_request)
 

--- a/web/domains/contacts/views.py
+++ b/web/domains/contacts/views.py
@@ -63,7 +63,9 @@ def add(request: AuthenticatedHttpRequest, *, org_type: str, org_pk: int) -> Htt
 
         if form.is_valid():
             contact = form.cleaned_data["contact"]
-            organisation_add_contact(org, contact)
+
+            assign_manage = not org.is_agent()
+            organisation_add_contact(org, contact, assign_manage)
 
         else:
             messages.error(request, "Unable to add contact.")
@@ -219,7 +221,8 @@ class AcceptOrgContactInviteView(LoginRequiredMixin, UserPassesTestMixin, FormVi
         invite = self._get_invite()
 
         if form.cleaned_data["accept_invite"]:
-            organisation_add_contact(invite.organisation, self.request.user)
+            assign_manage = not invite.organisation.is_agent()
+            organisation_add_contact(invite.organisation, self.request.user, assign_manage)
 
         invite.processed = True
         invite.save()

--- a/web/domains/importer/views.py
+++ b/web/domains/importer/views.py
@@ -221,7 +221,8 @@ def create_importer(request: AuthenticatedHttpRequest, *, entity_type: str) -> H
             importer: Importer = form.save()
 
             if entity_type == "individual":
-                organisation_add_contact(importer, importer.user)
+                organisation_add_contact(importer, importer.user, assign_manage=True)
+
             messages.info(request, "Importer created successfully.")
             return redirect(reverse("importer-list") + "?" + urlencode({"name": importer.name}))
     else:
@@ -694,7 +695,7 @@ def create_agent(
             agent = form.save()
 
             if entity_type == "individual":
-                organisation_add_contact(agent, agent.user)
+                organisation_add_contact(agent, agent.user, assign_manage=False)
 
             return redirect(reverse("importer-agent-edit", kwargs={"pk": agent.pk}))
     else:

--- a/web/domains/user/views.py
+++ b/web/domains/user/views.py
@@ -365,7 +365,7 @@ def create_user_alias(user: User, org: Importer | Exporter, alias: str) -> None:
     )
 
     if user_alias not in organisation_get_contacts(org):
-        organisation_add_contact(org, user_alias)
+        organisation_add_contact(org, user_alias, assign_manage=True)
 
 
 class OneLoginTestAccountsDetailView(


### PR DESCRIPTION
A contact can be added to an organisation by the following methods:

1. Directly by an organisation admin in the edit org screen.
2. When an access request is approved.
3. When a user is invited to an organisation by another org contact.
4. When an individual importer is initially created.