### PR TITLE
ECIL-285 Add web-internal to local docker-compose.yml.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,14 +158,21 @@ jobs:
             python manage.py add_dummy_data --password admin
 
       - run:
-          name: starting test server
+          name: starting test server (public)
           command: |
             source .env && export $(cut -d= -f1 < .env)
-            python manage.py runserver 8080
+            ICMS_INCLUDE_PRIVATE_URLS=False python manage.py runserver 8080
           background: true
 
       - run:
-          name: sleep whilst server starts
+          name: starting test server (private)
+          command: |
+            source .env && export $(cut -d= -f1 < .env)
+            ICMS_INCLUDE_PRIVATE_URLS=True python manage.py runserver 8008
+          background: true
+
+      - run:
+          name: sleep whilst servers start
           command: sleep 10
 
       - run:

--- a/.env.circleci
+++ b/.env.circleci
@@ -104,12 +104,12 @@ ICMS_GTM_IMPORTER_CONTAINER_ID=''
 ICMS_GTM_EXPORTER_CONTAINER_ID=''
 
 # Site Urls
-ICMS_CASEWORKER_SITE_URL=http://caseworker:8080/
+ICMS_CASEWORKER_SITE_URL=http://caseworker:8008/
 ICMS_EXPORTER_SITE_URL=http://export-a-certificate:8080/
 ICMS_IMPORTER_SITE_URL=http://import-a-licence:8080/
 
 # To run end-to-end tests.
-E2E_CASEWORKER_URL=http://caseworker:8080/
+E2E_CASEWORKER_URL=http://caseworker:8008/
 E2E_EXPORTER_URL=http://export-a-certificate:8080/
 E2E_IMPORTER_URL=http://import-a-licence:8080/
 E2E_USER_PASSWORD=admin

--- a/.env.local-docker
+++ b/.env.local-docker
@@ -104,12 +104,12 @@ ICMS_GTM_IMPORTER_CONTAINER_ID=''
 ICMS_GTM_EXPORTER_CONTAINER_ID=''
 
 # Site Urls
-ICMS_CASEWORKER_SITE_URL=http://caseworker:8080/
+ICMS_CASEWORKER_SITE_URL=http://caseworker:8008/
 ICMS_EXPORTER_SITE_URL=http://export-a-certificate:8080/
 ICMS_IMPORTER_SITE_URL=http://import-a-licence:8080/
 
 # To run end-to-end tests.
-E2E_CASEWORKER_URL=http://caseworker:8080/
+E2E_CASEWORKER_URL=http://caseworker:8008/
 E2E_EXPORTER_URL=http://export-a-certificate:8080/
 E2E_IMPORTER_URL=http://import-a-licence:8080/
 E2E_USER_PASSWORD=admin

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ end_to_end_test_local: end_to_end_clear_session ## Run end to end tests locally
 	.venv/bin/python -m pytest -c playwright/pytest.ini web/end_to_end/ ${args}
 
 create_end_to_end_caseworker: ## Create an end to end test using codegen for the caseworker site
-	.venv/bin/python -m playwright codegen http://caseworker:8080/ --target python-pytest --viewport-size "1920, 1080" ${args}
+	.venv/bin/python -m playwright codegen http://caseworker:8008/ --target python-pytest --viewport-size "1920, 1080" ${args}
 
 create_end_to_end_export: ## Create an end to end test using codegen for the exporter site
 	.venv/bin/python -m playwright codegen http://export-a-certificate:8080/ --target python-pytest --viewport-size "1920, 1080" ${args}

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ developing, only within Docker.
 - `make add_dummy_data`
   - Create test user(s), add needed permissions to user(s), create dummy importer and exporter, etc
 
-- `make manage args="set_icms_sites http://caseworker:8080 http://export-a-certificate:8080 http://import-a-licence:8080"`
+- `make manage args="set_icms_sites http://caseworker:8008 http://export-a-certificate:8080 http://import-a-licence:8080"`
   - Creates the sites for working on ICMS locally
 
 - Add the following lines to your `/etc/hosts` file:
@@ -76,7 +76,7 @@ developing, only within Docker.
 
 Start everything using docker-compose: `make debug`
 
-Go to http://caseworker:8080, login with the one of the test accounts:
+Go to http://caseworker:8008, login with the one of the test accounts:
   - admin (Superuser that doesn't reflect a real user of the system)
   - dev_admin (currently used to create GOV.UK One Login test accounts)
   - ilb_admin
@@ -197,7 +197,7 @@ docker volume rm icms_pgdata
 make migrate
 make manage args="create_icms_groups"
 make add_dummy_data
-make manage args="set_icms_sites http://caseworker:8080 http://export-a-certificate:8080 http://import-a-licence:8080"
+make manage args="set_icms_sites http://caseworker:8008 http://export-a-certificate:8080 http://import-a-licence:8080"
 ```
 
 Alternatively you can run the script found here: `./scripts/reset-local-docker-db`

--- a/config/cf_env.py
+++ b/config/cf_env.py
@@ -61,6 +61,10 @@ class CloudFoundryEnvironment(BaseSettings):
     allowed_hosts: list[str] = Field(alias="icms_allowed_hosts")
     debug: bool = Field(alias="icms_debug", default=False)
 
+    # TODO: Revisit in ECIL-269.
+    #       Remove default value when we have two running versions of ICMS.
+    include_private_urls: bool = True
+
     # Staff SSO
     staff_sso_enabled: bool
     staff_sso_authbroker_url: str

--- a/config/env.py
+++ b/config/env.py
@@ -31,6 +31,10 @@ class DBTPlatformEnvironment(BaseSettings):
     allowed_hosts: list[str]
     debug: bool = False
 
+    # TODO: Revisit in ECIL-269.
+    #       Remove default value when we have two running versions of ICMS.
+    include_private_urls: bool = True
+
     # S3 env vars
     aws_region: str = Field(alias="aws_region", default="")
     aws_storage_bucket_name: str = Field(alias="aws_storage_bucket_name", default="")

--- a/config/settings.py
+++ b/config/settings.py
@@ -478,7 +478,7 @@ EXPORTER_SITE_URL = env.exporter_site_url
 
 # TODO: Revisit in ECIL-269: Remove hardcoded value when we have two running versions of ICMS.
 # The codebase is deployed as both a public and private application
-IS_PRIVATE_APP = True
+INCLUDE_PRIVATE_URLS = env.include_private_urls
 
 # CSP Settings
 

--- a/config/settings_test.py
+++ b/config/settings_test.py
@@ -16,6 +16,9 @@ RATELIMIT_ENABLE = False
 FILE_UPLOAD_HANDLERS = ("web.tests.file_upload_handler.DummyFileUploadHandler",)  # type: ignore[assignment]
 APP_ENV = "test"
 
+# Ensure all endpoints are available when testing.
+INCLUDE_PRIVATE_URLS = True
+
 # Add so we can test the bypass chief views.
 ALLOW_BYPASS_CHIEF_NEVER_ENABLE_IN_PROD = True
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -30,7 +30,7 @@ urlpatterns = [
 ]
 
 
-if settings.IS_PRIVATE_APP:
+if settings.INCLUDE_PRIVATE_URLS:
     urlpatterns += [
         #
         # Django Admin Site (superuser admin site)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,9 @@ services:
             - DJANGO_SETTINGS_MODULE
             - PYTHONUNBUFFERED=1
             - ICMS_WEB_PORT
-            - ICMS_DEBUG=True # Used in entry.sh
+            - ICMS_DEBUG=True
+            - ICMS_INCLUDE_PRIVATE_URLS=False
+            - ICMS_WEB_PORT=8080
         env_file:
             - .env
         ports:
@@ -52,12 +54,39 @@ services:
         networks:
           backend:
             aliases:
-              - caseworker
               - export-a-certificate
               - import-a-licence
-          public:
-            aliases:
-              - caseworker  # Required for ICMS-HMRC to communicate with ICMS.
+    web-internal:
+        build:
+            context: .
+            dockerfile: local_deployment/Dockerfile
+        command: local_deployment/entry.sh
+        environment:
+            - DJANGO_SETTINGS_MODULE
+            - PYTHONUNBUFFERED=1
+            - ICMS_WEB_PORT
+            - ICMS_DEBUG=True
+            - ICMS_INCLUDE_PRIVATE_URLS=True
+            - ICMS_WEB_PORT=8008
+        env_file:
+            - .env
+        ports:
+            - "8008:8008"
+        depends_on:
+            db:
+                condition: service_healthy
+            redis:
+                condition: service_started
+        volumes:
+            - ./test-reports:/code/test-reports # needed for ci
+            - .:/code
+        networks:
+            backend:
+                aliases:
+                    - caseworker
+            public:
+                aliases:
+                    - caseworker  # Required for ICMS-HMRC to communicate with ICMS.
     redis:
         # The version we will run when migrating to DBT Platform
         image: redis:7.0.15

--- a/local_deployment/entry.sh
+++ b/local_deployment/entry.sh
@@ -3,5 +3,5 @@
 echo "Check missing migrations"
 python manage.py makemigrations --check --dry-run
 
-echo "Starting server"
-python manage.py runserver 0.0.0.0:8080
+echo "Starting server on port: ${ICMS_WEB_PORT}"
+python manage.py runserver 0.0.0.0:$ICMS_WEB_PORT

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -4295,7 +4295,7 @@ View Importer
 {{ page_title }
 rm icms_pgdata icms_redis_data
 Setting ICMS Sites
-http://caseworker:8080 http://export-a-certificate:8080
+http://caseworker:8008 http://export-a-certificate:8080
 Test Chemical
 Select Constabulary
 Enter the Case Reference
@@ -5103,3 +5103,4 @@ GP
 {fixture!r
 Certificate - Certificate Reference Value
 01-Jan-2024
+INCLUDE_PRIVATE_URLS

--- a/web/end_to_end/conftest.py
+++ b/web/end_to_end/conftest.py
@@ -20,7 +20,7 @@ def browser_context_args(browser_context_args: Dict[str, Any]) -> Dict[str, Any]
 
 class EnvironmentConfig(BaseSettings):
     model_config = SettingsConfigDict(extra="ignore", validate_default=False, env_prefix="e2e_")
-    caseworker_url: str = "http://caseworker:8080/"
+    caseworker_url: str = "http://caseworker:8008/"
     exporter_url: str = "http://export-a-certificate:8080/"
     importer_url: str = "http://import-a-licence:8080/"
     user_password: str = "admin"

--- a/web/end_to_end/test_utils.py
+++ b/web/end_to_end/test_utils.py
@@ -2,7 +2,7 @@ from . import utils
 
 
 def test_get_application_id() -> None:
-    url = "http://caseworker:8080/import/firearms/dfl/1234/edit/"
+    url = "http://caseworker:8008/import/firearms/dfl/1234/edit/"
     pattern = r"import/firearms/dfl/(?P<app_pk>\d+)/edit/"
 
     app_pk = utils.get_application_id(url, pattern)

--- a/web/tests/domains/case/views/test_views_search.py
+++ b/web/tests/domains/case/views/test_views_search.py
@@ -522,14 +522,14 @@ class TestRequestVariationUpdateView:
         url = SearchURLS.request_variation(self.wood_app.pk)
 
         # Test referrer query params are remembered
-        referrer = "http://caseworker:8080/case/import/search/standard/results/?status=COMPLETED&decision=APPROVE"
+        referrer = "http://caseworker:8008/case/import/search/standard/results/?status=COMPLETED&decision=APPROVE"
         resp = self.client.get(url, HTTP_REFERER=referrer)
 
         expected = "/case/import/search/standard/results/?status=COMPLETED&decision=APPROVE"
         assert resp.context["search_results_url"] == expected
 
         # Test referrer set without query params
-        referrer = "http://caseworker:8080/case/import/search/standard/results/"
+        referrer = "http://caseworker:8008/case/import/search/standard/results/"
         resp = self.client.get(url, HTTP_REFERER=referrer)
 
         expected = "/case/import/search/standard/results/"

--- a/web/tests/test_urls.py
+++ b/web/tests/test_urls.py
@@ -1,0 +1,32 @@
+import importlib as il
+from http import HTTPStatus
+
+import pytest
+from django.conf import settings
+from django.test import override_settings
+from django.urls import NoReverseMatch, clear_url_caches, reverse
+
+
+def reload_urlconf(url_module=settings.ROOT_URLCONF):
+    module = il.import_module(url_module)
+    il.reload(module)
+
+
+def test_ilb_admin_client_can_access_private_urls(ilb_admin_client):
+    # By default, INCLUDE_PRIVATE_URLS is set to True in settings_test.py
+    response = ilb_admin_client.get(reverse("signature-list"))
+    assert response.status_code == HTTPStatus.OK
+
+
+@override_settings(INCLUDE_PRIVATE_URLS=False)
+def test_ilb_admin_client_cant_access_private_urls(ilb_admin_client):
+    reload_urlconf()
+    reload_urlconf("web.urls")
+    clear_url_caches()
+
+    # Check we can't use reverse.
+    with pytest.raises(NoReverseMatch):
+        reverse("signature-list")
+
+    response = ilb_admin_client.get("/signature/")
+    assert response.status_code == HTTPStatus.NOT_FOUND

--- a/web/urls.py
+++ b/web/urls.py
@@ -115,7 +115,7 @@ private_urls = [
     path("reports/", include("web.reports.urls")),
 ]
 
-if settings.IS_PRIVATE_APP:
+if settings.INCLUDE_PRIVATE_URLS:
     urlpatterns = public_urls + private_urls
 else:
     urlpatterns = public_urls


### PR DESCRIPTION
Run two versions of ICMS to better reflect the future production infrastructure.
Added so that our end to end tests will run on different servers and test the dynamic urls.