### PR TITLE
ECIL-201 Set is_verified for ICMS V1 users who haven't logged in yet.

### DIFF
--- a/web/auth/utils.py
+++ b/web/auth/utils.py
@@ -80,11 +80,16 @@ def get_or_create_icms_user(
         user.email = provider_email
         user.save()
 
-        UserEmail.objects.get_or_create(
+        email, email_created = UserEmail.objects.get_or_create(
             user=user,
             email=provider_email,
             defaults={"is_primary": True, "portal_notifications": True, "is_verified": True},
         )
+
+        # set is_verified for users logging in via one login if it's not already set.
+        if not email_created and not email.is_verified:
+            email.is_verified = True
+            email.save()
 
     return user, created
 


### PR DESCRIPTION
This is an edge case for the following:
  - User is a V1 user.
  - User has an UserEmail record that they log in with where is_primary is set to False.