### PR TITLE
ECIL-421 - Change colour of banner for lower environments

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -111,6 +111,7 @@ TEMPLATES = [
                 "web.auth.context_processors.auth",
                 "web.sites.context_processors.sites",
                 "web.ecil.context_processors.govuk_frontend_jinja_template",
+                "web.misc.context_processors.header_colour",
             ],
         },
     },

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -5232,3 +5232,6 @@ Jose Joao Caminhao
 Cachacaria Pessego
 CDS
 GOV.OK One Login Client
+Dear Test
+"Add the required
+CHANGE_HEADER_COLOUR

--- a/web/misc/context_processors.py
+++ b/web/misc/context_processors.py
@@ -1,0 +1,18 @@
+from django.conf import settings
+from django.http import HttpRequest
+
+from web.sites import SiteName
+
+
+def header_colour(request: HttpRequest) -> dict[str, str]:
+    """Add the required header colour to the context."""
+    header_colours = {
+        SiteName.IMPORTER: "green",
+        SiteName.EXPORTER: "grey",
+        SiteName.CASEWORKER: "red",
+    }
+
+    return {
+        "CHANGE_HEADER_COLOUR": settings.APP_ENV != "production",
+        "HEADER_COLOUR": header_colours[request.site.name],
+    }

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -36,6 +36,16 @@
     {% endcompress %}
 
     {% block css %}{% endblock %}
+    {% if CHANGE_HEADER_COLOUR %}
+      {#
+      changing the colour of the header if we're not on production and depending on the site. 
+      #}
+      <style>
+        #menu-bar {
+          background: {{ HEADER_COLOUR }} !important;
+        }
+      </style>
+    {% endif %}
   </head>
 
   <body>

--- a/web/tests/misc/test_context_processors.py
+++ b/web/tests/misc/test_context_processors.py
@@ -1,0 +1,42 @@
+from django.contrib.sites.models import Site
+from django.test import RequestFactory, override_settings
+
+from web.misc.context_processors import header_colour
+from web.sites import SiteName
+
+
+@override_settings(
+    APP_ENV="test",
+)
+def test_environment_information(rf: RequestFactory, db):
+    request = rf.request()
+    request.site = Site.objects.get(name=SiteName.IMPORTER)
+    assert header_colour(request) == {
+        "CHANGE_HEADER_COLOUR": True,
+        "HEADER_COLOUR": "green",
+    }
+
+    request.site = Site.objects.get(name=SiteName.EXPORTER)
+    assert header_colour(request) == {
+        "CHANGE_HEADER_COLOUR": True,
+        "HEADER_COLOUR": "grey",
+    }
+
+    request.site = Site.objects.get(name=SiteName.CASEWORKER)
+    assert header_colour(request) == {
+        "CHANGE_HEADER_COLOUR": True,
+        "HEADER_COLOUR": "red",
+    }
+
+
+@override_settings(
+    APP_ENV="production",
+)
+def test_environment_information_show_environment_banner(rf: RequestFactory, db):
+    request = rf.request()
+    request.site = Site.objects.get(name=SiteName.IMPORTER)
+
+    assert header_colour(request) == {
+        "CHANGE_HEADER_COLOUR": False,
+        "HEADER_COLOUR": "green",
+    }

--- a/web/tests/views/test_views.py
+++ b/web/tests/views/test_views.py
@@ -325,3 +325,25 @@ class TestLoginRequiredSelect2AutoResponseView(AuthTestCase):
             "more": False,
             "results": [],
         }
+
+
+@override_settings(
+    APP_ENV="local",
+)
+def test_banner_colour_change(ilb_admin_client, exporter_client, importer_client):
+    response = ilb_admin_client.get(reverse("workbasket"))
+    assert "#menu-bar { background: red !important; }" in response.content.decode()
+
+    response = exporter_client.get(reverse("workbasket"))
+    assert "#menu-bar { background: grey !important; }" in response.content.decode()
+
+    response = importer_client.get(reverse("workbasket"))
+    assert "#menu-bar { background: green !important; }" in response.content.decode()
+
+
+@override_settings(
+    APP_ENV="production",
+)
+def test_banner_colour_doesnt_change(ilb_admin_client):
+    response = ilb_admin_client.get(reverse("workbasket"))
+    assert "#menu-bar { background:" not in response.content.decode()


### PR DESCRIPTION
Turns the header a different colour on lower environments depending on site.


Caseworker:
![image](https://github.com/user-attachments/assets/fef702e3-b0e5-41d5-adda-7f1a794be69a)

Exporter:
![image](https://github.com/user-attachments/assets/4b70a5ad-477c-43b2-b21b-7f84dc438c57)

Importer:
![image](https://github.com/user-attachments/assets/c00494e1-8978-40b4-8f1d-f6712196f14c)

