### PR TITLE
Downgrade logging level when logout backend is unknown.

### DIFF
--- a/web/views/views.py
+++ b/web/views/views.py
@@ -152,7 +152,7 @@ def logout_view(request: HttpRequest) -> HttpResponse:
             url = login_start
 
         case _:
-            logger.error(f"Unknown backend: {backend}, defaulting to login_start")
+            logger.warning(f"Unknown backend: {backend}, defaulting to login_start")
             url = login_start
 
     # 3. Clear session and user


### PR DESCRIPTION
Downgraded so sentry doesn't log the message as an event.

Docs:
https://docs.sentry.io/platforms/python/integrations/logging/#options

event_level (default ERROR): The Sentry Python SDK will report log records with a level higher than or equal to event_level as events as long as the logger itself is set to output records of those log levels (see note below). If a value of None occurs, the SDK won't send log records as events.