### PR TITLE
ECIL-343 Prevent access requests being closed with open FIRs.

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -5245,3 +5245,4 @@ showFindServiceDetail = UTILS.getShowElementFunc("div.row_id_find_service_detail
 Django 5.1.5
 otherTextArea = document.querySelector("#id_issue_details
 document.querySelector("#id_find_service_details
+Access

--- a/web/domains/case/app_checks.py
+++ b/web/domains/case/app_checks.py
@@ -365,12 +365,13 @@ def _get_update_request_errors(application: ImpOrExp, case_type: str) -> PageErr
 def _get_fir_errors(application: ImpOrExp, case_type: str) -> list[PageErrors]:
     errors = []
 
-    active_firs = application.further_information_requests.filter(is_active=True).filter(
+    active_firs = application.further_information_requests.filter(
+        is_active=True,
         status__in=[
             FurtherInformationRequest.DRAFT,
             FurtherInformationRequest.OPEN,
             FurtherInformationRequest.RESPONDED,
-        ]
+        ],
     )
 
     sent_firs = active_firs.filter(

--- a/web/templates/web/domains/case/access/close-access-request.html
+++ b/web/templates/web/domains/case/access/close-access-request.html
@@ -8,6 +8,10 @@
     <div class="info-box info-box-info">
       You cannot close this Access Request because you have already started the Approval Process. To close this Access Request you must first withdraw the Approval Request.
     </div>
+  {% elif has_open_firs %}
+    <div class="info-box info-box-info">
+      Further information requests must be closed or deleted before this Access Request can be closed
+    </div>
   {% else %}
     <div class="container setOutForm">
       {% call forms.form(action='', method='post', csrf_input=csrf_input) -%}


### PR DESCRIPTION
Message shown to ILB if they try to close an AR with open FIRs
![caseworker_8008_access_case_6_exporter_close-access-request_](https://github.com/user-attachments/assets/5df1b45d-eecf-4a27-a089-39352e9f962a)

Post example after another fir is created (edge case)
![caseworker_8008_access_case_6_exporter_close-access-request_ (1)](https://github.com/user-attachments/assets/e8b1dafc-eeee-489a-b6dd-96fe3c3604a7)
