### PR TITLE
ECIL-520 Update close access request view to close open FIRs.

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -5251,3 +5251,4 @@ Spottyfish
 export_search_user_2
 Figwee
 Woofham
+this Access Request

--- a/web/templates/web/domains/case/access/close-access-request.html
+++ b/web/templates/web/domains/case/access/close-access-request.html
@@ -8,11 +8,14 @@
     <div class="info-box info-box-info">
       You cannot close this Access Request because you have already started the Approval Process. To close this Access Request you must first withdraw the Approval Request.
     </div>
-  {% elif has_open_firs %}
-    <div class="info-box info-box-info">
-      Further information requests must be closed or deleted before this Access Request can be closed
-    </div>
   {% else %}
+
+    {% if has_open_firs %}
+      <div class="info-box info-box-warning">
+        Open Further information Requests will be closed when this Access Request is closed.
+      </div>
+    {% endif %}
+
     <div class="container setOutForm">
       {% call forms.form(action='', method='post', csrf_input=csrf_input) -%}
         {% for field in form %}


### PR DESCRIPTION
**Example access request with several FIRs (open and draft):**
![caseworker_8008_case_access_19_firs_manage_](https://github.com/user-attachments/assets/24016bee-18c3-4555-b37c-97626afacabb)

**Message shown on Close Access Request view:**
![caseworker_8008_access_case_19_exporter_close-access-request_](https://github.com/user-attachments/assets/503a00bf-5ab6-41fa-abeb-0413eb4a0b53)

**When viewing historical access request (everything apart from draft FIR is shown):**
![caseworker_8008_access_access_request_19_history_](https://github.com/user-attachments/assets/33caf3f1-5048-4645-9883-06bff998fc68)
