### PR TITLE
ECIL-491 - Remove back link to “Exporters” within the top task bar on caseworker

### DIFF
--- a/web/domains/exporter/views.py
+++ b/web/domains/exporter/views.py
@@ -393,8 +393,14 @@ def _get_user_context(user: User) -> dict[str, Any]:
     if user.has_perm(Perms.sys.exporter_admin):
         base_template = "layout/sidebar.html"
         parent_url = reverse("exporter-list")
+        show_content_actions = False
     else:
         base_template = "layout/no-sidebar.html"
         parent_url = reverse("user-exporter-list")
+        show_content_actions = True
 
-    return {"base_template": base_template, "parent_url": parent_url}
+    return {
+        "base_template": base_template,
+        "parent_url": parent_url,
+        "show_content_actions": show_content_actions,
+    }

--- a/web/templates/web/domains/exporter/detail.html
+++ b/web/templates/web/domains/exporter/detail.html
@@ -1,11 +1,13 @@
 {% extends base_template %}
 
 {% block content_actions %}
-  <div class="content-actions">
-    <ul class="menu-out flow-across">
-      <li><a href="{{ parent_url }}" class="prev-link">Exporters</a></li>
-    </ul>
-  </div>
+  {% if show_content_actions %}
+    <div class="content-actions">
+      <ul class="menu-out flow-across">
+        <li><a href="{{ parent_url }}" class="prev-link">Exporters</a></li>
+      </ul>
+    </div>
+  {% endif %}
 {% endblock %}
 
 {% block context_header %}

--- a/web/templates/web/domains/exporter/edit.html
+++ b/web/templates/web/domains/exporter/edit.html
@@ -9,11 +9,13 @@
 {% endblock %}
 
 {% block content_actions %}
-  <div class="content-actions">
-    <ul class="menu-out flow-across">
-      <li><a href="{{ parent_url }}" class="prev-link">Exporters</a></li>
-    </ul>
-  </div>
+  {% if show_content_actions %}
+    <div class="content-actions">
+      <ul class="menu-out flow-across">
+        <li><a href="{{ parent_url }}" class="prev-link">Exporters</a></li>
+      </ul>
+    </div>
+  {% endif %}
 {% endblock %}
 
 {% block context_header %}

--- a/web/tests/domains/exporter/test_views.py
+++ b/web/tests/domains/exporter/test_views.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from guardian.shortcuts import remove_perm
 from pytest_django.asserts import assertRedirects
 
+from web.domains.exporter.views import _get_user_context
 from web.models import Exporter
 from web.permissions import Perms
 from web.tests.auth import AuthTestCase
@@ -556,3 +557,16 @@ class TestEditUserExporterPermissionsView(AuthTestCase):
             Perms.obj.exporter.edit.codename,
             Perms.obj.exporter.manage_contacts_and_agents.codename,
         }
+
+
+def test_get_user_context(ilb_admin_user, exporter_one_agent_one_contact):
+    assert _get_user_context(ilb_admin_user) == {
+        "base_template": "layout/sidebar.html",
+        "parent_url": reverse("exporter-list"),
+        "show_content_actions": False,
+    }
+    assert _get_user_context(exporter_one_agent_one_contact) == {
+        "base_template": "layout/no-sidebar.html",
+        "parent_url": reverse("user-exporter-list"),
+        "show_content_actions": True,
+    }


### PR DESCRIPTION
before:
<img width="827" alt="image" src="https://github.com/user-attachments/assets/69ced83f-74ea-40e2-9b94-535b7c0390fe" />


after:
<img width="843" alt="image" src="https://github.com/user-attachments/assets/b7116ec2-98a0-41af-bfa8-0700aea84524" />
