### PR TITLE
ECIL-509 Add a rolling session for ILB users.

### DIFF
--- a/config/cf_env.py
+++ b/config/cf_env.py
@@ -115,6 +115,7 @@ class CloudFoundryEnvironment(BaseSettings):
 
     # Age in seconds
     django_session_cookie_age: int = 60 * 30
+    django_session_save_every_request: bool = False
 
     # Bypass chief
     allow_bypass_chief_never_enable_in_prod: bool = False

--- a/config/env.py
+++ b/config/env.py
@@ -95,6 +95,7 @@ class DBTPlatformEnvironment(BaseSettings):
 
     # Age in seconds
     django_session_cookie_age: int = 60 * 60
+    django_session_save_every_request: bool = False
 
     # Bypass chief
     allow_bypass_chief_never_enable_in_prod: bool = False

--- a/config/settings.py
+++ b/config/settings.py
@@ -321,6 +321,11 @@ SESSION_CACHE_ALIAS = "default"
 
 # Age in seconds
 SESSION_COOKIE_AGE = env.django_session_cookie_age
+# Set to true to enable a "rolling session" where the expiry updates every time a request is made.
+# This is not suitable for public users as we need the same expiry as GOV.UK One Login
+# https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/managing-your-users-sessions/
+# Having a rolling session is desirable for ILB users.
+SESSION_SAVE_EVERY_REQUEST = env.django_session_save_every_request
 
 # Secure cookies only
 SESSION_COOKIE_SECURE = True


### PR DESCRIPTION
Prior to this change a users session would always expire 30 minutes after creation.
Updating the session on every request updates the session end date creating a rolling session.
Internal users will now only be logged out after 30 minutes of inactivity.