### PR TITLE
ECIL-587 Add missing ECIL form validation and error messages.

### DIFF
--- a/web/ecil/forms/forms_access_requests.py
+++ b/web/ecil/forms/forms_access_requests.py
@@ -112,20 +112,31 @@ class ExporterAccessRequestCompanyProductsForm(gds_forms.GDSModelForm):
 
 class ExporterAccessRequestExportCountriesForm(gds_forms.GDSModelForm):
     export_countries = gds_forms.GovUKSelectField(
-        label="What countries do you want to export to?",
+        label="Where do you want to export products to?",
         help_text=(
-            "Start typing a country to add it. You can add up to 40 countries."
-            " You are not limited to these countries and you can change them later if you need to."
+            "Enter a country or territory and select from the results."
+            " You can add up to 40 countries or territories."
+            " You can change these later if you need to."
         ),
         choices=[],
         gds_field_kwargs={"label": {"isPageHeading": True, "classes": "govuk-label--l"}},
+        error_messages={"required": "Select a country or territory you want to export to"},
     )
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, *args: Any, selected_countries: list[str], **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
+        self.selected_countries = selected_countries
 
         countries = [(None, "")] + list(Country.util.get_all_countries().values_list("id", "name"))
         self.fields["export_countries"].choices = countries
+
+    def clean(self) -> None:
+        cleaned_data = super().clean()
+
+        if cleaned_data.get("export_countries") and len(self.selected_countries) >= 40:
+            self.add_error("export_countries", "You can only add up to 40 countries or territories")
+
+        return cleaned_data
 
     class Meta(gds_forms.GDSModelForm.Meta):
         model = ExporterAccessRequest
@@ -172,5 +183,5 @@ class ExporterAccessRequestSummaryForm(gds_forms.GDSModelForm):
             "organisation_registered_number": "Company number",
             "organisation_address": "Address",
             "organisation_products": "What type of products do you want to export?",
-            "export_countries": "What countries do you want to export to?",
+            "export_countries": "Where do you want to export products to?",
         }

--- a/web/ecil/forms/forms_new_user.py
+++ b/web/ecil/forms/forms_new_user.py
@@ -10,6 +10,10 @@ class OneLoginNewUserUpdateForm(gds_forms.GDSModelForm):
             "first_name": "First name",  # /PS-IGNORE
             "last_name": "Last name",  # /PS-IGNORE
         }
+        error_messages = {
+            "first_name": {"required": "Enter your first name"},  # /PS-IGNORE
+            "last_name": {"required": "Enter your last name"},  # /PS-IGNORE
+        }
 
         formfield_callback = gds_forms.GDSFormfieldCallback(
             gds_field_kwargs={
@@ -29,6 +33,9 @@ class ExporterTriageForm(gds_forms.GDSForm):
     applications = gds_forms.GovUKCheckboxesField(
         label="What are you applying for?",
         help_text="Select all that apply",
+        error_messages={
+            "required": "Select if you are applying for an export certificate or something else",
+        },
         choices=[
             ("cfs", "Certificate of Free Sale (CFS)"),
             ("gmp", "Certificate of Good Manufacture Practice (CGMP)"),

--- a/web/ecil/views/views_access_requests.py
+++ b/web/ecil/views/views_access_requests.py
@@ -63,6 +63,14 @@ class ExporterAccessRequestMultiStepFormView(
 
         return initial
 
+    def get_form_kwargs(self) -> dict[str, Any]:
+        kwargs = super().get_form_kwargs()
+
+        if self.current_step == "export-countries":
+            kwargs["selected_countries"] = self._get_saved_countries()
+
+        return kwargs
+
     def form_valid(self, form: django_forms.Form | django_forms.ModelForm) -> HttpResponseRedirect:
         if self.current_step == "export-countries":
             return self.export_countries_form_valid(form)
@@ -83,9 +91,7 @@ class ExporterAccessRequestMultiStepFormView(
         cleaned_data = form.cleaned_data
         new_country = cleaned_data["export_countries"]
 
-        saved_countries = get_session_form_data(
-            self.request, self.cache_prefix(), self.current_step, "export_countries"
-        )
+        saved_countries = self._get_saved_countries()
 
         if saved_countries:
             saved_countries.append(new_country)
@@ -111,6 +117,11 @@ class ExporterAccessRequestMultiStepFormView(
                     "ecil:access_request:exporter_step_form", kwargs={"step": self.current_step}
                 )
             )
+
+    def _get_saved_countries(self) -> list[str]:
+        return get_session_form_data(
+            self.request, self.cache_prefix(), self.current_step, "export_countries"
+        )
 
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)

--- a/web/templates/ecil/access_request/exporter_countries-step.html
+++ b/web/templates/ecil/access_request/exporter_countries-step.html
@@ -7,19 +7,25 @@
 
     {# TODO: Use preventDoubleClick on all submit buttons #}
     {{ gds.govukButton({
-      "text": "Add country",
+      "text": "Add country or territory ",
       "name": "action",
       "value": "add-country",
       "classes": "govuk-button--secondary govuk-!-display-block",
       "type": "submit"
       })
     }}
+    {% if not export_countries %}
+      {# If there are no export countries show a fake continue button to submit the main form #}
+      {# This ensures the error message is shown to populate the form #}
+      {{ gds.govukButton({"text": "Continue"})}}
+    {% endif %}
   </form>
 
+  {# When export countries have been selected show a real button to the summary page. #}
   {% if export_countries %}
     {{ gds.govukTable(govuk_table_kwargs) }}
+    {{ gds.govukButton({"text": "Continue", "href": summary_url})}}
   {% endif %}
-  {{ gds.govukButton({"text": "Continue", "href": summary_url})}}
 {% endblock %}
 
 {% block bodyEnd %}


### PR DESCRIPTION
Changes:
  - Limit list of export countries to 40.
  - Change ExporterAccessRequestExportCountriesForm export_countries label and required error message.
  - Add OneLoginNewUserUpdateForm first_name & last_name required error message.
  - Add ExporterTriageForm applications required error message.
  - Add Fake Continue button when no export countries are chosen to trigger correct error message.