### PR TITLE
ECIL-651 Send NMIL data to ICMS-HMRC.

### DIFF
--- a/web/domains/chief/client.py
+++ b/web/domains/chief/client.py
@@ -114,6 +114,8 @@ def get_serializer(
             return serializers.fa_sil_serializer
         case ProcessTypes.SANCTIONS:
             return serializers.sanction_serializer
+        case ProcessTypes.NUCLEAR:
+            return serializers.nuclear_material_serializer
         case _:
             raise NotImplementedError(f"Unsupported process_type: {process_type}")
 

--- a/web/domains/chief/types.py
+++ b/web/domains/chief/types.py
@@ -190,7 +190,7 @@ class OrganisationData(BaseModel):
 class LicenceDataPayloadBase(BaseModel):
     """Base class for all licence data payload records."""
 
-    type: Literal["OIL", "DFL", "SIL", "SAN"]
+    type: Literal["OIL", "DFL", "SIL", "SAN", "NUCLEAR"]
     action: Literal["insert", "cancel", "replace"]
 
     id: str  # UUID for this licence payload
@@ -244,10 +244,29 @@ class SanctionsLicenceData(InsertAndReplaceBase):
     goods: list[SanctionGoodsData]
 
 
+class NuclearMaterialGoodsData(BaseModel):
+    commodity: str
+    description: str
+    quantity: float
+    # This is hardcoded to Q rather than having to specify it for each record.
+    controlled_by: Literal[ControlledByEnum.QUANTITY] = ControlledByEnum.QUANTITY
+    unit: QuantityCodeEnum
+
+
+class NuclearMaterialLicenceData(InsertAndReplaceBase):
+    type: Literal["NUCLEAR"]
+    goods: list[NuclearMaterialGoodsData]
+
+
 class LicenceDataPayload(BaseModel):
     """Payload that gets sent to ICMS-HRMC."""
 
-    licence: FirearmLicenceData | SanctionsLicenceData | CancelLicencePayload
+    licence: (
+        FirearmLicenceData
+        | SanctionsLicenceData
+        | CancelLicencePayload
+        | NuclearMaterialLicenceData
+    )
 
 
 #

--- a/web/static/web/css/pdfs/import/nuclear-material-licence-style.css
+++ b/web/static/web/css/pdfs/import/nuclear-material-licence-style.css
@@ -1,0 +1,133 @@
+@page {
+    size: A4;
+    margin: 68px 40px 60px 70px;
+}
+
+body {
+    margin: 0 0 0 0;
+    font-size: 14px;
+}
+
+main {
+    box-decoration-break: clone;
+}
+
+p {
+    margin: 1px;
+    font-weight: normal;
+}
+
+.content-block {
+    padding: 10px;
+    min-height: 40px;
+}
+
+.min-height-150 {
+    min-height: 150px;
+}
+
+.min-height-40 {
+    min-height: 40px;
+}
+
+.large-text-box {
+    max-width: 98%;
+    padding-bottom: 10px;
+    overflow-wrap: anywhere;
+}
+
+.header-block {
+    display: inline-block;
+    vertical-align: top;
+    height: 80px;
+    width: 160px;
+
+}
+
+ul, ol {
+    list-style-position: outside;
+}
+
+li {
+    font-weight: 5;
+}
+
+strong {
+    font-weight: bold;
+}
+
+
+.dbt-logo-block {
+    width: 330px;
+    margin: 20px 0 20px 0px;
+}
+
+.signature-block {
+    break-inside: avoid;
+    width: 100%;
+}
+
+div[name="signature-widget"] {
+    display: flex;
+    flex-wrap: wrap;
+    width: 200px;
+}
+
+div[name="signature-widget"] > span {
+    flex: 0 0 100%;
+    display: block;
+    font-size: 11px;
+    margin: 0;
+}
+
+
+#signature-widget-image-container {
+    flex: 0 0 100%;
+    display: block;
+    margin: 0;
+}
+
+#signature-widget-image {
+    width: 165px;
+    max-height: 100px;
+}
+
+#signature > p {
+    color: black;
+}
+
+#signature > img {
+    padding-left: 5px;
+}
+
+#not_signed_image{
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    max-width: 175px;
+}
+
+.b-bottom-extended {
+    left: -42px;
+    padding-left: 42px;
+    position: relative;
+    border-bottom: 1px solid #000;
+}
+
+.title {
+    font-size: 11px;
+}
+
+.default-dbt-logo {
+    width: 250px;
+    height: 125px;
+}
+
+#licence-start-date {
+    align-self: flex-end;
+    margin-right:35px;
+}
+
+.flex-start{
+    align-self: flex-start;
+}

--- a/web/templates/pdf/import/nuclear-material-licence.html
+++ b/web/templates/pdf/import/nuclear-material-licence.html
@@ -1,0 +1,127 @@
+{% from "web/domains/signature/macros.html" import document_signature_placeholder %}
+{% from "web/domains/signature/macros.html" import not_signed_image %}
+{% from "web/domains/signature/macros.html" import dbt_logo %}
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="description" content="{{ importer_site_name }} import licence">
+    <style>
+      {{ get_css_rules_as_string('web/css/pdfs/shared/fonts.css')|safe }}
+      {{ get_css_rules_as_string('web/css/pdfs/shared/constants.css')|safe }}
+      {{ get_css_rules_as_string("web/css/pdfs/import/nuclear-material-licence-style.css")|safe }}
+      {% if preview_licence %}
+        {{ get_css_rules_as_string("web/css/pdfs/shared/preview.css")|safe }}
+      {% endif %}
+    </style>
+  </head>
+  <body>
+    <main class="bordered flex-row wrap">
+      <div class="flex-row row b-bottom">
+        <div class="half content-block b-right">
+          <p class="title"><strong>1. </strong>Consignee (name, full address, country, VAT number)</p>
+          <p class="content">{{ importer_name | upper }}</p>
+          {% for line in importer_address %}
+            <p class="content">{{ line | upper }}</p>
+          {% endfor %}
+          <p class="content">{{ importer_postcode | upper }}</p>
+            <div class="flex-row flex-end">
+              <div class="flex-column">
+                {% for eori in eori_numbers %}
+                  <p class="content text-right">{{ eori }}</p>
+                {% endfor %}
+              </div>
+            </div>
+        </div>
+        <div>
+          <div class="content-block b-bottom row">
+            <p class="title"><strong>2. </strong>Issue number</p>
+            <p class="{{ 'preview-orange' if preview_licence }}">{{ licence_number }}</p>
+          </div>
+          <div class="content-block b-bottom row">
+            <p class="title"><strong>3. </strong>Proposed place and date of import</p>
+
+          <div class="flex-row space-between">
+               <p class="flex-start">Any UK Port</p>
+               <p id="licence-start-date">{{ licence_start_date }}</p>
+          </div>
+          </div>
+          <div class="content-block row flex-row wrap">
+            <p class="row title"><strong>4. </strong>Authority responsible for issue</p>
+            <p class="row min-height-40">Email: {{ nuclear_contact_email }}</p>
+          </div>
+        </div>
+      </div>
+      <div class="flex-row row b-bottom">
+        <div class="half content-block b-right">
+          <p class="title"><strong>5. </strong>Declarant/representative as applicable (name and full address)</p>
+          <p class="content">{{ importer_name | upper }}</p>
+          {% for line in importer_address %}
+            <p class="content">{{ line | upper }}</p>
+          {% endfor %}
+          <p class="content">{{ importer_postcode | upper }}</p>
+            <div class="flex-row flex-end">
+              <div class="flex-column">
+                {% for eori in eori_numbers %}
+                  <p class="content text-right">{{ eori }}</p>
+                {% endfor %}
+              </div>
+            </div>
+        </div>
+        <div class="half">
+          <div class="content-block b-bottom row">
+            <p class="title"><strong>6. </strong>Country of manufacture (and geonomeclature code)</p>
+            <p>{{ country_of_manufacture }}</p>
+          </div>
+          <div class="content-block b-bottom row">
+            <p class="title"><strong>7. </strong>Country of shipment (and geonomenclature code)</p>
+             <p>{{ country_of_shipment }}</p>
+          </div>
+          <div class="content-block row">
+            <p class="title"><strong>8. </strong>Last day of validity</p>
+            <p>{{ licence_end_date }}</p>
+          </div>
+        </div>
+      </div>
+      <div class="flex-row row">
+        <div class="large-text-box content-block row">
+          <p class="title"><strong>9. </strong>Description of goods, commodity code and category, quantity, and value in GBP (cif at UK frontier)</p>
+          {% for goods in goods_list %}
+            {% for goods_line in goods %}
+              <p>{{ goods_line }}</p>
+            {% endfor %}
+          {% endfor %}
+        </div>
+      </div>
+      <div class="flex-row row b-top">
+          <div class="large-text-box min-height-150 content-block row">
+            <p class="title"><strong>10. </strong>Additional remarks</p>
+            {% if endorsements %}
+              {% for endorsement in endorsements %}
+                {% for endorsement_line in endorsement %}
+                  <p>{{ endorsement_line }}</p>
+                {% endfor %}
+              {% endfor %}
+            {% elif preview_licence %}
+              <p class="preview-green">[[ADDITIONAL_REMARKS]]</p>
+            {% endif %}
+          </div>
+        </div>
+      <div class="signature-block content-block flex-row row b-top">
+        <div class="flex-row row wrap">
+          <p class="row title"><strong>11. </strong>Competent authority's endorsement</p>
+          <div class="digital-signature half">
+              {% if preview_licence %}
+                  {{ not_signed_image() }}
+              {% else %}
+                  {{ document_signature_placeholder(signature_file, signature.content_type, signature.signatory)  }}
+              {% endif %}
+          </div>
+          <div class="half">
+              {{ dbt_logo(classes="header-block") }}
+          </div>
+        </div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/web/tests/domains/chief/test_serializers.py
+++ b/web/tests/domains/chief/test_serializers.py
@@ -9,6 +9,7 @@ from web.domains.chief.serializers import (
     fix_licence_reference,
     get_organisation,
     get_restrictions,
+    nuclear_material_serializer,
     sanction_serializer,
 )
 from web.domains.chief.types import (
@@ -17,6 +18,8 @@ from web.domains.chief.types import (
     FirearmGoodsData,
     FirearmLicenceData,
     LicenceDataPayload,
+    NuclearMaterialGoodsData,
+    NuclearMaterialLicenceData,
     OrganisationData,
     QuantityCodeEnum,
     SanctionGoodsData,
@@ -346,3 +349,55 @@ def test_sanction_serializer(sanctions_app_processing):
         )
     )
     assert expected == sanction_serializer(app, "insert", "1234")
+
+
+def test_nuclear_serializer(nuclear_app_processing):
+    app = nuclear_app_processing
+
+    expected = LicenceDataPayload(
+        licence=NuclearMaterialLicenceData(
+            type="NUCLEAR",
+            action="insert",
+            id="1234",
+            reference="IMA/2024/00001",
+            licence_reference="GBSIL0000001B",
+            start_date=dt.date(2020, 6, 1),
+            end_date=dt.date(2024, 12, 31),
+            organisation=OrganisationData(
+                eori_number="GB0123456789ABCDE",
+                name="Test Importer 1",
+                address=AddressData(
+                    line_1="I1 address line 1",
+                    line_2="I1 address line 2",
+                    line_3="",
+                    line_4="",
+                    line_5="",
+                    postcode="BT180LZ",  # /PS-IGNORE
+                ),
+                start_date=None,
+                end_date=None,
+            ),
+            country_group=None,
+            country_code="BY",
+            restrictions="",
+            goods=[
+                NuclearMaterialGoodsData(
+                    commodity="2844500000",
+                    description="More Commoditites",
+                    quantity=56.78,
+                    controlled_by=ControlledByEnum.QUANTITY,
+                    unit=QuantityCodeEnum.WEIGHT_GRAMME,
+                ),
+                NuclearMaterialGoodsData(
+                    commodity="2612101000",
+                    description="Test Goods",
+                    quantity=1000.0,
+                    controlled_by=ControlledByEnum.QUANTITY,
+                    unit=QuantityCodeEnum.WEIGHT_KILOGRAMME,
+                ),
+            ],
+        )
+    )
+    actual = nuclear_material_serializer(app, "insert", "1234")
+
+    assert expected == actual

--- a/web/utils/pdf/generator.py
+++ b/web/utils/pdf/generator.py
@@ -89,6 +89,8 @@ class PdfGenerator(PdfGenBase):
                     return "pdf/import/fa-sil-licence.html"
                 case ProcessTypes.SANCTIONS:
                     return "pdf/import/sanctions-licence.html"
+                case ProcessTypes.NUCLEAR:
+                    return "pdf/import/nuclear-material-licence.html"
                 case ProcessTypes.WOOD:
                     return "pdf/import/wood-licence.html"
                 case ProcessTypes.CFS:
@@ -131,6 +133,10 @@ class PdfGenerator(PdfGenBase):
                 )
             case ProcessTypes.SANCTIONS:
                 context = utils.get_sanctions_licence_context(
+                    self.application, self.doc_pack, self.doc_type
+                )
+            case ProcessTypes.NUCLEAR:
+                context = utils.get_nuclear_material_licence_context(
                     self.application, self.doc_pack, self.doc_type
                 )
             case ProcessTypes.WOOD:
@@ -184,6 +190,8 @@ class PdfGenerator(PdfGenBase):
                 return pages.format_oil_pages(pdf_data, self.get_document_context())
             case ProcessTypes.SANCTIONS:
                 return pages.format_sanctions_pages(pdf_data, self.get_document_context())
+            case ProcessTypes.NUCLEAR:
+                return pages.format_nuclear_material_pages(pdf_data, self.get_document_context())
             case _:
                 return pdf_data
 

--- a/web/utils/pdf/pages.py
+++ b/web/utils/pdf/pages.py
@@ -294,3 +294,93 @@ def format_sanctions_pages(pdf_data: bytes, context: dict[str, Any]) -> bytes:
     with io.BytesIO() as bytes_stream:
         writer.write(bytes_stream)
         return bytes_stream.getvalue()
+
+
+def format_nuclear_material_pages(pdf_data: bytes, context: dict[str, Any]) -> bytes:
+    start_date = context["licence_start_date"]
+
+    reader = pypdf.PdfReader(io.BytesIO(pdf_data))
+    writer = pypdf.PdfWriter()
+
+    top_margin = 810
+    left_margin = 53
+    right_margin = 565
+    page_total = len(reader.pages)
+    for page_number, page in enumerate(reader.pages):
+        packet = io.BytesIO()
+        new_page = canvas.Canvas(packet, pagesize=portrait(A4))
+
+        # holders copy box
+        new_page.setLineWidth(0.5)
+
+        # Numbers in holders copy box
+        new_page.setFontSize(14)
+        new_page.drawRightString(left_margin - 8, 770, "1")
+        new_page.drawRightString(left_margin - 8, 489, "1")
+
+        # holders copy text
+        new_page.saveState()
+        new_page.rotate(90)
+        new_page.setFontSize(12)
+        new_page.drawString(610, -45, "Holder's copy")
+        new_page.restoreState()
+
+        # some margins are different on the first page
+        if page_number == 0:
+            y_coordinate = 790.8
+        else:
+            y_coordinate = 794
+
+        # holders copy box - left vertical line.
+        new_page.line(left_margin - 25, y_coordinate, left_margin - 25, 468.6)
+
+        # holders copy box - right vertical line.
+        new_page.line(left_margin, y_coordinate, left_margin, 468.6)
+
+        # holders copy box - top box - top horizontal line
+        new_page.line(left_margin - 25, y_coordinate, left_margin, y_coordinate)
+
+        # holders copy box - top box - bottom horizontal line
+        new_page.line(left_margin - 25, 750, left_margin, 750)
+
+        # holders copy box - bottom box - top horizontal line
+        new_page.line(left_margin - 25, 513.2, left_margin, 513.2)
+
+        # holders copy box - bottom box - bottom horizontal line
+        new_page.line(left_margin - 25, 468.7, left_margin, 468.7)
+
+        if page_number == 0:
+            # Header
+            new_page.setFont("Helvetica-Bold", 10)
+            new_page.drawRightString(165, top_margin, "ELECTRONIC LICENCE")
+            new_page.setFont("Helvetica", 10)
+            new_page.drawString(
+                168,
+                top_margin,
+                f"issued on {start_date} and sent to HM Revenue and Customs",
+            )
+        else:
+            # On secondary pages - Lift top horizontal line a few pixels so the line does not crash into text
+            new_page.setLineWidth(0.7)
+            # Top Horizontal line across the full page
+            new_page.line(left_margin, 794, right_margin, 794)
+            # Small vertical line on left to extend border
+            new_page.line(left_margin, 794, left_margin, 791)
+            # Small vertical line on right to extend border
+            new_page.line(right_margin, 794, right_margin, 791)
+
+        if page_total > 0 and page_number != page_total - 1:
+            # if more than one page add a horizontal line at the end of each page
+            new_page.setLineWidth(0.7)
+            new_page.line(left_margin, 45, right_margin, 45)
+
+        new_page.save()
+
+        packet.seek(0)
+        new_pdf = pypdf.PdfReader(packet)
+        page.merge_page(new_pdf.pages[0])
+        writer.add_page(page)
+
+    with io.BytesIO() as bytes_stream:
+        writer.write(bytes_stream)
+        return bytes_stream.getvalue()

--- a/web/utils/pdf/utils.py
+++ b/web/utils/pdf/utils.py
@@ -152,7 +152,6 @@ def get_country_and_geo_code(country: Country) -> str:
     return f"{country.name} {country.hmrc_code} {country.commission_code}"
 
 
-# TODO: Extend with NuclearMaterialApplicationGoods
 def get_sanctions_goods_line(goods: SanctionsAndAdhocApplicationGoods) -> list[str]:
     goods_line = _split_text_field_newlines(goods.goods_description)
     last_line = goods_line.pop()


### PR DESCRIPTION
Changes:
  - ECIL-651 Send NMIL data to ICMS-HMRC.
  - ECIL-666 Add placeholder NCIL licence generation code.

Example licenceData send to ICMS-HMRC:
```
1\fileHeader\ILBDOTI\CHIEF\licenceData\202503141517\3\N
2\licence\IMA/2025/00003\insert\GBSIL0000003D\SIL\I\20250314\20260331
3\trader\\GB123456789012341\\\Dummy importer 1\1 Whitehall Pl\Westminster\London\\\SW1A1HP
4\country\AF\\O
5\restrictions\The licence is only valid if you also hold authority of the Secretary of State for Defence under the Landmines Act 1988 to possess and meet the conditions set out in that authority. You have a responsibility to comply with any legislation relating to explosives, if relevant, and that this import licence does not replace this responsibility. Please contact the Health and Safety Executive for further advice.||The movement of landmines from the port to their final destination is covered by the provisions of the Landmines Act 1998 and must be carried out by suitably authorised persons.||The Ministry of Defence requested that you include details of your UK mine holdings in due course.
6\line\1\2844105000\\\\1\Q\\023\\1.0\\\\\\
7\end\licence\6
8\fileTrailer\1
```

Complete Nuclear Material Import Licence
![image](https://github.com/user-attachments/assets/5c7a61d1-649c-4727-8d3f-bc825b4bec4e)

