### PR TITLE
ECIL-713 Add CFS Schedule statement fields.

### DIFF
--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -5488,3 +5488,5 @@ Valid APP PK
 body">Import Licensing Branch
 {{ gds.uktradeListWithActions(list_with_actions_kwargs
 static("css
+{{ legislation_link_text }
+schedule_statements_is_responsible_person

--- a/web/ecil/forms/forms_cfs.py
+++ b/web/ecil/forms/forms_cfs.py
@@ -363,6 +363,33 @@ class CFSScheduleStatementIsResponsiblePersonForm(gds_forms.GDSModelForm):
         )
 
 
+class CFSScheduleStatementAccordanceWithStandardsForm(gds_forms.GDSModelForm):
+    class Meta(gds_forms.GDSModelForm.Meta):
+        model = CFSSchedule
+        fields = ["schedule_statements_accordance_with_standards"]
+        error_messages = {
+            "schedule_statements_accordance_with_standards": {"required": "Select yes or no"}
+        }
+        formfield_callback = gds_forms.GDSFormfieldCallback(
+            gds_field_kwargs={
+                "schedule_statements_accordance_with_standards": gds_forms.FIELDSET_LEGEND_HEADER
+            },
+        )
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+        self.fields["schedule_statements_accordance_with_standards"].label = get_schedule_label(
+            self.instance,
+            "Are these products manufactured in accordance with the Good Manufacturing Practice standards set out in UK law?",
+        )
+        self.fields["schedule_statements_accordance_with_standards"].help_text = Markup(
+            render_to_string(
+                template_name="ecil/cfs/help_text/schedule_statements_accordance_with_standards.html",
+            ),
+        )
+
+
 def get_schedule_label(schedule: CFSSchedule, label: str) -> Markup:
     schedule_num = get_schedule_number(schedule)
 

--- a/web/ecil/forms/forms_cfs.py
+++ b/web/ecil/forms/forms_cfs.py
@@ -324,6 +324,45 @@ class CFSScheduleProductStandardForm(gds_forms.GDSModelForm):
             self.instance.goods_export_only = YesNoChoices.yes
 
 
+class CFSScheduleStatementIsResponsiblePersonForm(gds_forms.GDSModelForm):
+    schedule_statements_is_responsible_person = gds_forms.GovUKRadioInputField(
+        choices=[
+            (
+                "True",
+                "Yes, I am is the responsible person for the product",
+            ),
+            (
+                "False",
+                "No, I am a third party exporter and not the responsible person for the product",
+            ),
+        ],
+        error_messages={"required": "Select yes or no"},
+        gds_field_kwargs=gds_forms.FIELDSET_LEGEND_HEADER,
+    )
+
+    class Meta(gds_forms.GDSModelForm.Meta):
+        model = CFSSchedule
+        fields = ["schedule_statements_is_responsible_person"]
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+        self.fields["schedule_statements_is_responsible_person"].label = get_schedule_label(
+            self.instance, "Are you the responsible person for the product?"
+        )
+
+        is_ni_eu_cosmetics_regulation = self.instance.legislations.filter(
+            is_active=True, is_eu_cosmetics_regulation=True, ni_legislation=True
+        ).exists()
+
+        self.fields["schedule_statements_is_responsible_person"].help_text = Markup(
+            render_to_string(
+                template_name="ecil/cfs/help_text/schedule_statements_is_responsible_person.html",
+                context={"is_ni_eu_cosmetics_regulation": is_ni_eu_cosmetics_regulation},
+            ),
+        )
+
+
 def get_schedule_label(schedule: CFSSchedule, label: str) -> Markup:
     schedule_num = get_schedule_number(schedule)
 

--- a/web/ecil/urls/urls_cfs.py
+++ b/web/ecil/urls/urls_cfs.py
@@ -68,6 +68,11 @@ urlpatterns = [
                                 views.CFSScheduleStatementIsResponsiblePersonUpdateView.as_view(),
                                 name="schedule-is-responsible-person",
                             ),
+                            path(
+                                "accordance-with-standards/",
+                                views.CFSScheduleStatementAccordanceWithStandardsUpdateView.as_view(),
+                                name="schedule-accordance-with-standards",
+                            ),
                         ],
                     ),
                 ),

--- a/web/ecil/urls/urls_cfs.py
+++ b/web/ecil/urls/urls_cfs.py
@@ -63,6 +63,11 @@ urlpatterns = [
                                 views.CFSScheduleProductStandardUpdateView.as_view(),
                                 name="schedule-product-standard",
                             ),
+                            path(
+                                "responsible-person/",
+                                views.CFSScheduleStatementIsResponsiblePersonUpdateView.as_view(),
+                                name="schedule-is-responsible-person",
+                            ),
                         ],
                     ),
                 ),

--- a/web/ecil/views/views_cfs.py
+++ b/web/ecil/views/views_cfs.py
@@ -470,8 +470,7 @@ class CFSScheduleProductStandardUpdateView(CFSScheduleBaseUpdateView):
         if has_eu_cosmetic_regulation(self.object):
             view_name = "ecil:export-cfs:schedule-is-responsible-person"
         else:
-            # TODO: Change to next view when implemented.
-            view_name = "export:cfs-schedule-edit"
+            view_name = "ecil:export-cfs:schedule-accordance-with-standards"
 
         return reverse(
             view_name, kwargs={"application_pk": self.application.pk, "schedule_pk": self.object.pk}
@@ -494,9 +493,8 @@ class CFSScheduleStatementIsResponsiblePersonUpdateView(CFSScheduleBaseUpdateVie
         )
 
     def get_success_url(self) -> str:
-        # TODO: Change to next view when implemented.
         return reverse(
-            "export:cfs-schedule-edit",
+            "ecil:export-cfs:schedule-accordance-with-standards",
             kwargs={"application_pk": self.application.pk, "schedule_pk": self.object.pk},
         )
 
@@ -508,3 +506,26 @@ def has_eu_cosmetic_regulation(schedule: CFSSchedule) -> bool:
     not_export_only = schedule.goods_export_only == YesNoChoices.no
 
     return has_cosmetics and not_export_only
+
+
+class CFSScheduleStatementAccordanceWithStandardsUpdateView(CFSScheduleBaseUpdateView):
+    # UpdateView config
+    form_class = forms.CFSScheduleStatementAccordanceWithStandardsForm
+    template_name = "ecil/gds_form.html"
+
+    def get_back_link_url(self) -> str | None:
+        if has_eu_cosmetic_regulation(self.object):
+            view_name = "ecil:export-cfs:schedule-is-responsible-person"
+        else:
+            view_name = "ecil:export-cfs:schedule-product-standard"
+
+        return reverse(
+            view_name, kwargs={"application_pk": self.application.pk, "schedule_pk": self.object.pk}
+        )
+
+    def get_success_url(self) -> str:
+        # TODO: Change to next view when implemented.
+        return reverse(
+            "export:cfs-schedule-edit",
+            kwargs={"application_pk": self.application.pk, "schedule_pk": self.object.pk},
+        )

--- a/web/templates/ecil/cfs/help_text/schedule_statements_accordance_with_standards.html
+++ b/web/templates/ecil/cfs/help_text/schedule_statements_accordance_with_standards.html
@@ -1,0 +1,11 @@
+<p class="govuk-body govuk-hint">
+  Selecting no will not impact the outcome of your application, however this statement will not show on the certificate.
+</p>
+<p class="govuk-body govuk-hint">
+  Products manufactured in accordance with the Good Manufacturing Practice standards set out in UK law should:
+</p>
+<ul class="govuk-list govuk-list--bullet govuk-hint">
+  <li>be of consistent high quality</li>
+  <li>be appropriate to their intended use</li>
+  <li>meet the requirements of the product specification</li>
+</ul>

--- a/web/templates/ecil/cfs/help_text/schedule_statements_is_responsible_person.html
+++ b/web/templates/ecil/cfs/help_text/schedule_statements_is_responsible_person.html
@@ -1,0 +1,21 @@
+{% if is_ni_eu_cosmetics_regulation %}
+  {% set legislation_link = "https://www.legislation.gov.uk/eur/2009/1223/contents" %}
+  {% set legislation_link_text = "Regulation (EC) No 1223/2009 of the European Parliament and of the Council of 30 November 2009 on cosmetic products as applicable in NI" %}
+{% else %}
+  {% set legislation_link = "https://www.gov.uk/government/publications/cosmetic-products-enforcement-regulations-2013/regulation-20091223-and-the-cosmetic-products-enforcement-regulations-2013-great-britain" %}
+  {% set legislation_link_text = "Cosmetic Regulation No 1223/2009 as applicable in GB" %}
+{% endif %}
+
+<p class="govuk-body govuk-hint">
+  You understand that <strong>your company</strong> is legally responsible for ensuring the products
+  in the schedule meet the safety legislation requirements set out in
+  <a href="{{ legislation_link }}" class="govuk-link" target="_blank" rel="noopener noreferrer">
+    {{ legislation_link_text }}
+  </a>.
+</p>
+<p class="govuk-body govuk-hint">
+  In line with the responsible person definition as set out in this regulation,
+  <strong>
+    the person making the application is not individually responsible for the product
+  </strong>.
+</p>


### PR DESCRIPTION
Changes:
  - Add CFSScheduleStatementIsResponsiblePersonUpdateView.
      - GB:      
![export-a-certificate_8080_ecil_cfs_application_9_schedule_8_responsible-person_](https://github.com/user-attachments/assets/c45db405-eab4-43eb-a1c0-ddb40b71b6a9)
      - NI:      
![export-a-certificate_8080_ecil_cfs_application_16_schedule_9_responsible-person_](https://github.com/user-attachments/assets/df2ee837-5688-4c02-a6ed-245f5cb58685)
  - Add Add CFSScheduleStatementAccordanceWithStandardsUpdateView.    
![export-a-certificate_8080_ecil_cfs_application_9_schedule_8_accordance-with-standards_](https://github.com/user-attachments/assets/d67b6f96-c3f7-43cb-be27-6b7c2209820a)

