### PR TITLE
ECIL-740 Add several views relating to managing CFS schedule products.

### DIFF
--- a/assets/css/uktrade-list-with-actions.css
+++ b/assets/css/uktrade-list-with-actions.css
@@ -2,7 +2,7 @@
     .govuk-summary-list__row {
         .govuk-summary-list__key {
             font-weight: normal;
-            width: 80%;
+            width: 58%;
         }
     }
 }

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -5497,3 +5497,4 @@ LegislationSerializer
 CaseDocumentSerializer
 LegislationSerializer
 CA/2024/00002
+Reuse xxx_add.html

--- a/pii-ner-exclude.txt
+++ b/pii-ner-exclude.txt
@@ -5498,3 +5498,4 @@ CaseDocumentSerializer
 LegislationSerializer
 CA/2024/00002
 Reuse xxx_add.html
+DeleteView

--- a/web/ecil/forms/forms_cfs.py
+++ b/web/ecil/forms/forms_cfs.py
@@ -488,6 +488,29 @@ class CFSScheduleProductEndUseForm(gds_forms.GDSModelForm):
         self.fields["product_end_use"].required = required
 
 
+class CFSScheduleProductAddAnotherForm(gds_forms.GDSForm):
+    add_another = gds_forms.GovUKRadioInputField(
+        label="Do you need to add another product?",
+        choices=YesNoChoices.choices,
+        gds_field_kwargs={"fieldset": {"legend": {"classes": "govuk-fieldset__legend--m"}}},
+        error_messages={"required": "Select yes or no"},
+    )
+
+
+class CFSScheduleProductConfirmRemoveForm(gds_forms.GDSForm):
+    are_you_sure = gds_forms.GovUKRadioInputField(
+        choices=YesNoChoices.choices,
+        gds_field_kwargs=gds_forms.FIELDSET_LEGEND_HEADER,
+        error_messages={"required": "Select yes or no"},
+    )
+
+    def __init__(self, *args: Any, product: CFSProduct, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.fields["are_you_sure"].label = get_schedule_label(
+            product.schedule, f"Are you sure you want to remove {escape(product.product_name)}?"
+        )
+
+
 def get_schedule_label(schedule: CFSSchedule, label: str) -> Markup:
     """Return a schedule label.
 

--- a/web/ecil/gds/component_serializers/list_with_actions.py
+++ b/web/ecil/gds/component_serializers/list_with_actions.py
@@ -1,4 +1,5 @@
-from pydantic import BaseModel
+from markupsafe import Markup
+from pydantic import BaseModel, ConfigDict
 
 
 class ListRowAction(BaseModel):
@@ -7,7 +8,9 @@ class ListRowAction(BaseModel):
 
 
 class ListRow(BaseModel):
-    name: str
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    name: str | Markup
     actions: list[ListRowAction] | None = None
 
 

--- a/web/ecil/urls/urls_cfs.py
+++ b/web/ecil/urls/urls_cfs.py
@@ -91,6 +91,11 @@ urlpatterns = [
                                 views.CFSScheduleProductCreateView.as_view(),
                                 name="schedule-product-add",
                             ),
+                            path(
+                                "products/<product_pk>/end-use/",
+                                views.CFSScheduleProductEndUseUpdateView.as_view(),
+                                name="schedule-product-end-use",
+                            ),
                         ],
                     ),
                 ),

--- a/web/ecil/urls/urls_cfs.py
+++ b/web/ecil/urls/urls_cfs.py
@@ -92,7 +92,12 @@ urlpatterns = [
                                 name="schedule-product-add",
                             ),
                             path(
-                                "products/<product_pk>/end-use/",
+                                "products/<int:product_pk>/edit/",
+                                views.CFSScheduleProductUpdateView.as_view(),
+                                name="schedule-product-edit",
+                            ),
+                            path(
+                                "products/<int:product_pk>/end-use/",
                                 views.CFSScheduleProductEndUseUpdateView.as_view(),
                                 name="schedule-product-end-use",
                             ),

--- a/web/ecil/urls/urls_cfs.py
+++ b/web/ecil/urls/urls_cfs.py
@@ -77,29 +77,39 @@ urlpatterns = [
                             # Schedule product views
                             #
                             path(
-                                "products/",
+                                "product/",
                                 views.CFSScheduleProductStartTemplateView.as_view(),
                                 name="schedule-product-start",
                             ),
                             path(
-                                "products/upload-method/",
-                                views.CFSScheduleAddProductMethodFormView.as_view(),
+                                "product/upload-method/",
+                                views.CFSScheduleProductAddMethodFormView.as_view(),
                                 name="schedule-product-add-method",
                             ),
                             path(
-                                "products/add/",
+                                "product/add/",
                                 views.CFSScheduleProductCreateView.as_view(),
                                 name="schedule-product-add",
                             ),
                             path(
-                                "products/<int:product_pk>/edit/",
+                                "product/add-another/",
+                                views.CFSScheduleProductAddAnotherFormView.as_view(),
+                                name="schedule-product-add-another",
+                            ),
+                            path(
+                                "product/<int:product_pk>/edit/",
                                 views.CFSScheduleProductUpdateView.as_view(),
                                 name="schedule-product-edit",
                             ),
                             path(
-                                "products/<int:product_pk>/end-use/",
+                                "product/<int:product_pk>/end-use/",
                                 views.CFSScheduleProductEndUseUpdateView.as_view(),
                                 name="schedule-product-end-use",
+                            ),
+                            path(
+                                "product/<product_pk>/remove/",
+                                views.CFSScheduleProductConfirmRemoveFormView.as_view(),
+                                name="schedule-product-remove",
                             ),
                         ],
                     ),

--- a/web/ecil/views/views_cfs.py
+++ b/web/ecil/views/views_cfs.py
@@ -620,6 +620,49 @@ class CFSScheduleProductCreateView(
         schedule = self.get_object()
 
         return reverse(
+            "ecil:export-cfs:schedule-product-end-use",
+            kwargs={
+                "application_pk": self.application.pk,
+                "schedule_pk": schedule.pk,
+                "product_pk": self.object.pk,
+            },
+        )
+
+
+#
+# Views relating to editing CFS Schedule product fields.
+#
+@method_decorator(transaction.atomic, name="post")
+class CFSScheduleProductEndUseUpdateView(
+    CFSInProgressRelatedObjectViewBase, BackLinkMixin, UpdateView
+):
+    # UpdateView config
+    pk_url_kwarg = "product_pk"
+    form_class = forms.CFSScheduleProductEndUseForm
+    template_name = "ecil/gds_form.html"
+
+    # Extra typing for clarity
+    object: CFSProduct
+
+    def get_queryset(self) -> QuerySet[CFSProduct]:
+        """Filter the queryset used in SingleObjectMixin that fetches the correct product."""
+        schedule = get_object_or_404(self.application.schedules, pk=self.kwargs["schedule_pk"])
+
+        return schedule.products.all()
+
+    def get_back_link_url(self) -> str | None:
+        schedule = self.object.schedule
+
+        # TODO: The back link will need to go to an edit view (once created)
+        return reverse(
+            "export:cfs-schedule-edit",
+            kwargs={"application_pk": self.application.pk, "schedule_pk": schedule.pk},
+        )
+
+    def get_success_url(self) -> str:
+        schedule = self.object.schedule
+
+        return reverse(
             "export:cfs-schedule-edit",
             kwargs={"application_pk": self.application.pk, "schedule_pk": schedule.pk},
         )

--- a/web/templates/ecil/cfs/help_text/schedule_raw_material_product_end_use.html
+++ b/web/templates/ecil/cfs/help_text/schedule_raw_material_product_end_use.html
@@ -1,0 +1,6 @@
+<p class="govuk-body govuk-hint">
+  A raw material is used in the manufacture of the finished product. For example, as an ingredient in cosmetic formulations.
+</p>
+<p class="govuk-body govuk-hint">
+  Raw materials are different to products included as part of a kit, which need to be listed separately.
+</p>

--- a/web/templates/ecil/cfs/schedule_product_add_another.html
+++ b/web/templates/ecil/cfs/schedule_product_add_another.html
@@ -1,0 +1,7 @@
+{% extends "ecil/gds_form.html" %}
+{% from "ecil/cfs/macros.html" import product_schedule_h1 %}
+
+{% block ecil_content_before_form %}
+  {{ product_schedule_h1(schedule_number, product_heading) }}
+  {{ gds.uktradeListWithActions(list_with_actions_kwargs) }}
+{% endblock %}

--- a/web/templates/gds/components/list-with-actions/macro.html
+++ b/web/templates/gds/components/list-with-actions/macro.html
@@ -9,9 +9,13 @@
           <dt class="govuk-summary-list__key">{{ row.name }}</dt>
           <dd class="govuk-summary-list__actions">
             {% if row.actions %}
-              {% for action in row.actions %}
-                <a class="govuk-link govuk-link--no-visited-state" href="{{ action.url }}">{{ action.label }}<span class="govuk-visually-hidden">{{ action.label }} {{ row.name }}</span></a>
-              {% endfor %}
+              <ul class="govuk-summary-list__actions-list">
+                {% for action in row.actions %}
+                  <li class="govuk-summary-list__actions-list-item">
+                    <a class="govuk-link govuk-link--no-visited-state" href="{{ action.url }}">{{ action.label }}<span class="govuk-visually-hidden">{{ action.label }} {{ row.name }}</span></a>
+                  </li>
+                {% endfor %}
+              </ul>
             {% endif %}
           </dd>
         </div>


### PR DESCRIPTION
Changes:
  - ECIL-742 Add CFSScheduleProductEndUseUpdateView view.
![export-a-certificate_8080_ecil_cfs_application_3_schedule_5_products_16_end-use_](https://github.com/user-attachments/assets/72a42473-2cb6-414a-bb3b-f1eb0c2f48ea)
![export-a-certificate_8080_ecil_cfs_application_3_schedule_5_products_15_end-use_](https://github.com/user-attachments/assets/5818db7b-b588-4e46-97b6-32426f0a8fff)
![export-a-certificate_8080_ecil_cfs_application_3_schedule_5_products_15_end-use_ (1)](https://github.com/user-attachments/assets/6b74da21-6ccc-468b-90bf-48dd02c02029)
  - ECIL-755 Add CFSScheduleProductUpdateView view.
  ![image](https://github.com/user-attachments/assets/e998117c-1e0f-48aa-92b4-e9ca6165f325)
  - ECIL-744 Add CFSScheduleProductAddAnotherFormView view  
![export-a-certificate_8080_ecil_cfs_application_3_schedule_6_product_add-another_](https://github.com/user-attachments/assets/11ec7c8f-4580-419d-bbe2-5998b0df772d)
  - ECIL-744 Add CFSScheduleProductConfirmRemoveFormView view
![export-a-certificate_8080_ecil_cfs_application_3_schedule_6_product_17_remove_](https://github.com/user-attachments/assets/76d4e11d-c323-454d-a1ea-2ee838c8ce59)
